### PR TITLE
Changes to Compiler and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ There are two methods of acquiring Free Cities:
 
 ### Compiling (Windows x86_64)
 
-1. Open PowerShell or Command Prompt.
-2. Use cd to change to the Free Cities directory.
-3. Run '.\compile.bat'
+1. Navigate to the Free Cities directory.
+2. Run compile.bat by double clicking the icon.
+3. If no errors are reported, the compilation was a success.
 4. The game will be compiled into a .html file in the Free Cities\bin directory.
 5. Open the .html file with your web browser.
 

--- a/compile.bat
+++ b/compile.bat
@@ -7,3 +7,4 @@
 
 CALL "%~dp0devTools\tweeGo\tweego.exe" -o "%~dp0bin/FC.html" "%~dp0src\config\start.tw"
 ECHO Done
+PAUSE


### PR DESCRIPTION
Developers no longer need to use the command line on Windows to run the compiler. The Readme has been updated to reflect this.