### PR TITLE
Ensure ./bin Is Kept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Builds
-/bin/*
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ A text-only slave management game. (18+)
 
 ## Downloading The Game
 
-There are two methods of acquiring Free Cities:
-1. Download the latest compiled release; either from the [Blog](https://freecitiesblog.blogspot.com/), or from the [Releases](https://github.com/Free-Cities/Free-Cities/releases) page.
-2. Cloning this repository and manually compiling the game (see below).
+There are two methods of acquiring Free Cities:  
+1. Download the latest compiled release; either from the [Blog](https://freecitiesblog.blogspot.com/), or from the [Releases](https://github.com/Free-Cities/Free-Cities/releases) page.  
+2. Cloning this repository and manually compiling the game (see below).  
 
 ### Compiling (Windows x86_64)
 

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
The previous .gitignore prevented an empty directory from being pushed. This commit ensures that ./bin is both empty and present.