### PR TITLE
change to rules assistant.tw

### DIFF
--- a/src/uncategorized/rulesAssistant.tw
+++ b/src/uncategorized/rulesAssistant.tw
@@ -224,9 +224,9 @@ __Rule $r Automatic Activation__
 
 <br><br>
 Apply to slaves:<br>
-<<if (ndef $currentRule.selectedSlaves) || ($currentRule.selectedSlaves.length < 1) && (ndef $currentRule.excludedSlaves) || ($currentRule.excludedSlaves.length < 1)>>
+<<if ((ndef $currentRule.selectedSlaves) || ($currentRule.selectedSlaves.length < 1)) && ((ndef $currentRule.excludedSlaves) || ($currentRule.excludedSlaves.length < 1))>>
 ''Currently applied to all slaves'' | [[Choose specific slaves|Rules Slave Select]]
-<<elseif (ndef $currentRule.selectedSlaves) || ($currentRule.selectedSlaves.length < 1) && (def $currentRule.excludedSlaves) && ($currentRule.excludedSlaves.length > 0)>>
+<<elseif ((ndef $currentRule.selectedSlaves) || ($currentRule.selectedSlaves.length < 1)) && (def $currentRule.excludedSlaves) && ($currentRule.excludedSlaves.length > 0)>>
 ''Currently applied to all slaves except excluded slaves'' | [[Choose specific slaves|Rules Slave Select]] | [[Apply to all slaves|Rules Assistant][$currentRule.selectedSlaves to [],$currentRule.excludedSlaves to []]]
 <<else>>
 [[Currently applied to specific slaves|Rules Slave Select]] | [[Apply to all slaves|Rules Assistant][$currentRule.selectedSlaves to [], $currentRule.excludedSlaves to []]]


### PR DESCRIPTION
Now it correctly displays when slaves are excluded or only apply to some slaves.
It didn't work because "and" has an higher priority than "or"