### PR TITLE
Update Windows Compiler

### DIFF
--- a/compile_debug.bat
+++ b/compile_debug.bat
@@ -1,5 +1,6 @@
 @echo off
 :: Free Cities Basic Compiler - Windows x86_64
+:: Will wait for keypress before terminating.
 
 :: Uses embedded Python 3.5.3 x86_64
 :: Will add all *.tw files to StoryIncludes.
@@ -7,3 +8,4 @@
 
 CALL "%~dp0devTools\tweeGo\tweego.exe" -o "%~dp0bin/FC.html" "%~dp0src\config\start.tw"
 ECHO Done
+PAUSE


### PR DESCRIPTION
Compile.bat will terminate automatically.
Compile_debug.bat will terminate only following a key press, allowing you to examine any TweeGo errors.