### PR TITLE
Attempt 3 - Updated weekly Club Report

### DIFF
--- a/src/uncategorized/clubReport.tw
+++ b/src/uncategorized/clubReport.tw
@@ -29,9 +29,20 @@
 <<for $i to 0; $i < $slaves.length; $i++>>
 <<if ($slaves[$i].ID is $DJ.ID)>>
 	<<silently>>
-	<<display "SA long term effects">>
-	<<display "SA relationships">>
-	<<display "SA rivalries">>
+		<<display [[SA serve the public]]>>
+		<<if $slaves[$i].choosesOwnClothes == 1>>
+		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
+		<</if>>
+		<<display "SA diet">>
+		<<display "SA long term effects">>
+		<<display "SA drugs">>
+		<<display "SA relationships">>
+		<<display "SA rivalries">>
 	<</silently>>
 	<<if ($slaves[$i].health < -80)>>
 	<<set $slaves[$i].health += 20>>
@@ -67,7 +78,7 @@
 	<<break>>
 <</if>>
 <</for>>
-$DJ.slaveName is serving as the DJ.<<if $DJ.relationship is -3>>  She tries her best to be your energetic, cheerful wife.<</if>>
+$DJ.slaveName is performing as the DJ.<<if $DJ.relationship is -3>>  She tries her best to be your energetic, cheerful wife.<</if>>
 <<if ($DJFetish == 1)>>
 	She's expected to be the innovative, beautiful DJ spinning beats one minute, and come out of her booth to grind on the floor the next; she enjoys the interplay, and finds greater @@color:lightcoral;pleasure in exhibitionism.@@
 <<elseif ($DJFetish == 2)>>
@@ -145,10 +156,20 @@ $DJ.slaveName is serving as the DJ.<<if $DJ.relationship is -3>>  She tries her 
 	<<set $legendaryEntertainerID to $slaves[$i].ID>>
 	<</if>>
 	<<silently>>
-	<<display [[SA serve the public]]>>
-	<<display "SA long term effects">>
-	<<display "SA relationships">>
-	<<display "SA rivalries">>
+		<<display [[SA serve the public]]>>
+		<<if $slaves[$i].choosesOwnClothes == 1>>
+		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
+		<</if>>
+		<<display "SA diet">>
+		<<display "SA long term effects">>
+		<<display "SA drugs">>
+		<<display "SA relationships">>
+		<<display "SA rivalries">>
 	<</silently>>
 	<<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust > -20)>>
 	<<set $slaves[$i].devotion -= 5>>
@@ -248,5 +269,105 @@ $DJ.slaveName is serving as the DJ.<<if $DJ.relationship is -3>>  She tries her 
 <<else>>
 	''Business in $clubName is normal.''
 	<<set $clubSpots to $club>>
+<</if>>
+
+<<if ($DJ != 0)>>
+	<br><br>
+<<for $i to 0; $i < $slaves.length; $i++>>
+<<if ($slaves[$i].ID is $DJ.ID)>>
+	<<if $showEWD == 0>>
+		<<if ($legendaryEntertainerID == 0) && ($slaves[$i].prestige == 0) && ($slaves[$i].entertainSkill >= 100) && ($slaves[$i].devotion > 50) && ($slaves[$i].prestige == 0)>>
+		<<set $legendaryEntertainerID to $slaves[$i].ID>>
+		<</if>>
+		''__@@color:pink;$slaves[$i].slaveName@@__'' is performing as the DJ in the club.<br>
+		<<silently>>
+		<<display [[SA serve the public]]>>
+		<<if $slaves[$i].choosesOwnClothes == 1>>
+		<<display "SA chooses own clothes">>
+		<</if>>
+		<<display "SA diet">>
+		<<display "SA long term effects">>
+		<<display "SA drugs">>
+		<<display "SA relationships">>
+		<<display "SA rivalries">>
+		<</silently>>
+	<<else>>
+		<<if ($legendaryEntertainerID == 0) && ($slaves[$i].prestige == 0) && ($slaves[$i].entertainSkill >= 100) && ($slaves[$i].devotion > 50) && ($slaves[$i].prestige == 0)>>
+		<<set $legendaryEntertainerID to $slaves[$i].ID>>
+		<</if>>
+		''__@@color:pink;$slaves[$i].slaveName@@__'' is performing as the DJ in the club.
+		<<if $slaves[$i].choosesOwnClothes == 1>>
+		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
+		<</if>>
+		<<display "SA diet">>
+		<<display "SA long term effects">>
+		<<display "SA drugs">>
+		<<display "SA relationships">>
+		<<display "SA rivalries">>
+		<br>&nbsp;&nbsp;&nbsp;&nbsp;
+		<<display "SA devotion">>
+		<br><br>
+	<</if>>
+<</if>>
+<</for>>
+<<else>>
+	<br><br>
+<</if>>
+
+<<if ($clubSlaves > 0)>>
+<<for $i to 0; $i < $slaves.length; $i++>>
+<<if ($slaves[$i].assignment is "serve in the club")>>
+	<<if $showEWD == 0>>
+		<<if ($legendaryEntertainerID == 0) && ($slaves[$i].prestige == 0) && ($slaves[$i].entertainSkill >= 100) && ($slaves[$i].devotion > 50) && ($slaves[$i].prestige == 0)>>
+		<<set $legendaryEntertainerID to $slaves[$i].ID>>
+		<</if>>
+		''__@@color:pink;$slaves[$i].slaveName@@__'' is serving in the club.<br>
+		<<silently>>
+		<<display [[SA serve the public]]>>
+		<<if $slaves[$i].choosesOwnClothes == 1>>
+		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
+		<</if>>
+		<<display "SA diet">>
+		<<display "SA long term effects">>
+		<<display "SA drugs">>
+		<<display "SA relationships">>
+		<<display "SA rivalries">>
+		<</silently>>
+	<<else>>
+		<<if ($legendaryEntertainerID == 0) && ($slaves[$i].prestige == 0) && ($slaves[$i].entertainSkill >= 100) && ($slaves[$i].devotion > 50) && ($slaves[$i].prestige == 0)>>
+		<<set $legendaryEntertainerID to $slaves[$i].ID>>
+		<</if>>
+		''__@@color:pink;$slaves[$i].slaveName@@__''
+		<<display [[SA serve the public]]>>
+		<br>&nbsp;&nbsp;&nbsp;&nbsp;
+		<<if $slaves[$i].choosesOwnClothes == 1>>
+		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
+		<</if>>
+		<<display "SA diet">>
+		<<display "SA long term effects">>
+		<<display "SA drugs">>
+		<<display "SA relationships">>
+		<<display "SA rivalries">>
+		<br>&nbsp;&nbsp;&nbsp;&nbsp;
+		<<display "SA devotion">>
+		<br><br>
+	<</if>>
+<</if>>
+<</for>>
 <</if>>
 <br><br>


### PR DESCRIPTION


Expands the weekly Club Report.  If Options>End week report descriptive
details is enabled (EWD = 1), then it displays a weekly summary report
for each assigned Club slave like the current Penthouse Report does.
Notable exception, the DJ (if assigned) does NOT display her "SA serves
the public" summary as it seemed redundant when compared to current Club
Report summary; a lot of the same info in both.  If Option> EWD is
disabled (EWD = 0) then it simply tacks on a list of all Club slaves at
the bottom of the current report.