### PR TITLE
Bugfix for storyInit.tw

### DIFF
--- a/src/init/storyInit.tw
+++ b/src/init/storyInit.tw
@@ -366,7 +366,7 @@
 
 <<else>>
 	<<set $cash to Math.clamp(1000*Math.trunc($cash/100000), 5000, 1000000)>>
-	<<set $PC.career == "arcology owner">>
+	<<set $PC.career to "arcology owner">>
 <</if>>
 
 <<set $ver = "0.9.9">>


### PR DESCRIPTION
Fixes non-working arcology owner career trigger for New Game+.