### PR TITLE
Bugfix spaReport.tw

### DIFF
--- a/src/uncategorized/spaReport.tw
+++ b/src/uncategorized/spaReport.tw
@@ -13,22 +13,6 @@
 <<if ($slaves[$i].assignment is "rest in the spa")>>
 	<<if $seeImages == 1>><<SlaveArt $slaves[$i] 0 0>><</if>>
 	<<set $spaSlaves += 1>>
-	<<silently>>
-	<<display [[SA rest]]>>
-	<<if $slaves[$i].choosesOwnClothes == 1>>
-	<<display "SA chooses own clothes">>
-	<<if ($slaves[$i].devotion <= 20)>>
-		<<set $slaves[$i].devotion -= 5>>
-	<<else>>
-		<<set $slaves[$i].devotion += 1>>
-	<</if>>
-	<</if>>
-	<<display "SA diet">>
-	<<display "SA long term effects">>
-	<<display "SA drugs">>
-	<<display "SA relationships">>
-	<<display "SA rivalries">>
-	<</silently>>
 	<<if ($slaves[$i].devotion <= 60) && ($slaves[$i].trust < 60)>>
 	<<set $slaves[$i].devotion += 1>>
 	<<set $slaves[$i].trust += 1>>
@@ -143,21 +127,6 @@
 	<</if>>
 
 <<elseif ($Attendant != 0) && ($slaves[$i].ID is $Attendant.ID)>>
-	<<silently>>
-	<<if $slaves[$i].choosesOwnClothes == 1>>
-	<<display "SA chooses own clothes">>
-	<<if ($slaves[$i].devotion <= 20)>>
-		<<set $slaves[$i].devotion -= 5>>
-	<<else>>
-		<<set $slaves[$i].devotion += 1>>
-	<</if>>
-	<</if>>
-	<<display "SA diet">>
-	<<display "SA long term effects">>
-	<<display "SA drugs">>
-	<<display "SA relationships">>
-	<<display "SA rivalries">>
-	<</silently>>
 	<<if ($slaves[$i].health < 100)>>
 	<<set $slaves[$i].health += 20>>
 	<</if>>
@@ -319,10 +288,31 @@
 	<br><br>
 	<<if $showEWD == 0>>
 		''__@@color:pink;$slaves[$i].slaveName@@__'' is serving as the Attendant in the spa.<br>
+		<<silently>>
+		<<if $slaves[$i].choosesOwnClothes == 1>>
+		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
+		<</if>>
+		<<display "SA diet">>
+		<<display "SA long term effects">>
+		<<display "SA drugs">>
+		<<display "SA relationships">>
+		<<display "SA rivalries">>
+		<<display "SA devotion">>
+		<</silently>>
 	<<else>>
 		''__@@color:pink;$slaves[$i].slaveName@@__'' is serving as the Attendant in the spa.
 		<<if $slaves[$i].choosesOwnClothes == 1>>
 		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
 		<</if>>
 		<<display "SA diet">>
 		<<display "SA long term effects">>
@@ -337,12 +327,34 @@
 	<br>
 	<<if $showEWD == 0>>
 		''__@@color:pink;$slaves[$i].slaveName@@__'' is resting in the spa.
+		<<silently>>
+		<<display [[SA rest]]>>
+		<<if $slaves[$i].choosesOwnClothes == 1>>
+		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
+		<</if>>
+		<<display "SA diet">>
+		<<display "SA long term effects">>
+		<<display "SA drugs">>
+		<<display "SA relationships">>
+		<<display "SA rivalries">>
+		<<display "SA devotion">>
+		<</silently>>
 	<<else>>
 		''__@@color:pink;$slaves[$i].slaveName@@__''
 		<<display [[SA rest]]>>
 		<br>&nbsp;&nbsp;&nbsp;&nbsp;
 		<<if $slaves[$i].choosesOwnClothes == 1>>
 		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
 		<</if>>
 		<<display "SA diet">>
 		<<display "SA long term effects">>


### PR DESCRIPTION
Fixes the double running of "SA chooses own clothes", "SA diet", "SA long term effects", "SA drugs", "SA relationships", and "SA rivalries" in the "Spa Report" if $showEWD != 0>. This is just a quick fix to make sure saRelationships and saRivalries are working right.
Stops having slaves bonding with PC then looking elsewhere etc. One would be hidden then the other would not be.