### PR TITLE
Bugfix-Opt servantsQuartersReport.tw

### DIFF
--- a/src/uncategorized/servantsQuartersReport.tw
+++ b/src/uncategorized/servantsQuartersReport.tw
@@ -2,14 +2,53 @@
 
 ''Servants' Quarters Report''<hr style="margin:0">
 
-<<set $servantsQuartersSlaves to 0>>
-<<set $stewardessFetish to 0>>
-<<set $stewardessBonus to 0>>
-<<set $stewardessImpregnated to 0>>
-<<set $SQMilk = 0>>
-<<set $SQMilkSale = 0>>
+<<set $servantsQuartersSlaves = 0, $stewardessBonus = 0, _SQMilk = 0, _SQMilkSale = 0, _stewardessFetish = 0, _stewardessImpregnated = 0, _SL = $slaves.length, _SWD = -1>>
 
 <<if ($Stewardess != 0)>>
+<<for _SWD = 0; _SWD < _SL; _SWD++>>
+<<if $slaves[_SWD].ID == $Stewardess.ID>>
+	<<break>>
+<</if>>
+<</for>>
+<</if>>
+<<if _SWD != -1>>
+	<<set $i = _SWD>>
+	<<silently>>
+	<<display "SA long term effects">>
+	<<display "SA relationships">>
+	<<display "SA rivalries">>
+	<</silently>>
+	<<if ($slaves[_SWD].health < -80)>>
+	<<set $slaves[_SWD].health += 20>>
+	<<elseif ($slaves[_SWD].health < -40)>>
+	<<set $slaves[_SWD].health += 15>>
+	<<elseif ($slaves[_SWD].health < 0)>>
+	<<set $slaves[_SWD].health += 10>>
+	<<elseif ($slaves[_SWD].health < 90)>>
+	<<set $slaves[_SWD].health += 7>>
+	<</if>>
+	<<if $slaves[_SWD].devotion <= 60>>
+	<<set $slaves[_SWD].devotion += 1>>
+	<</if>>
+	<<if $servantsQuartersDecoration != "standard">>
+	<<set $slaves[_SWD].devotion += 1>>
+	<</if>>
+	<<if $slaves[_SWD].trust < 60>>
+	<<set $slaves[_SWD].trust += 1>>
+	<</if>>
+	<<if $slaves[_SWD].fetishStrength <= 95>>
+	<<if $slaves[_SWD].fetish != "dom">>
+		<<fetishChangeChance $slaves[_SWD]>>
+		<<if $fetishChangeChance > random(0,100)>>
+			<<set _stewardessFetish to 1, $slaves[_SWD].fetishKnown to 1, $slaves[_SWD].fetish to "dom">>
+		<</if>>
+	<<elseif $slaves[_SWD].fetishKnown == 0>>
+		<<set _stewardessFetish to 1, $slaves[_SWD].fetishKnown to 1>>
+	<<else>>
+		<<set _stewardessFetish to 2, $slaves[_SWD].fetishStrength += 4>>
+	<</if>>
+	<</if>>
+	<<set $Stewardess = $slaves[_SWD]>>
 	<<if ($Stewardess.health >= 10) && ($Stewardess.health < 80)>>
 	<<set $stewardessBonus += 50>>
 	<<elseif ($Stewardess.health >= 80)>>
@@ -27,25 +66,20 @@
 <</if>>
 
 <<set $servantMilkersMultiplier = 0.5>>
-<<for $i to 0; $i < $slaves.length; $i++>>
-<<if ($slaves[$i].assignment is "work as a servant")>>
-	<<if $seeImages == 1>><<SlaveArt $slaves[$i] 0 0>><</if>>
-	<<set $servantsQuartersSlaves += 1>>
+<<for _i to 0; _i < _SL; _i++>>
+	<<if ($slaves[_i].assignment != "work as a servant")>><<continue>><</if>>
+	<<if $seeImages == 1>><<SlaveArt $slaves[_i] 0 0>><</if>>
+	<<set $servantsQuartersSlaves++, $i = _i>>
 	<<silently>>
-	<<display [[SA servant]]>>
-	<<if $servantMilkers == 1>>
-	<<if $slaves[$i].lactation > 0>>
+	<<display "SA servant">>
+	<<if ($servantMilkers == 1) && ($slaves[_i].lactation > 0)>>
 		<<display "SA get milked">>
-		<<set $SQMilk += $milk>>
-		<<set $SQMilkSale += $milkSale>>
+		<<set _SQMilk += $milk, _SQMilkSale += $milkSale>>
 	<</if>>
-	<</if>>
-	<<if $stewardessImpregnates == 1>>
-	<<if $Stewardess != 0>>
+	<<if ($stewardessImpregnates == 1) && ($Stewardess != 0)>>
 	<<if $Stewardess.balls > 0>>
-	<<if canGetPregnant($slaves[$i])>>
-		<<set $slaves[$i].preg to 1, $slaves[$i].pregSource to $Stewardess.ID, $stewardessImpregnated += 1, $slaves[$i].vaginalCount += 10, $vaginalTotal += 10>>
-	<</if>>
+	<<if (canGetPregnant($slaves[_i])) && (canPenetrate($Stewardess))>>
+		<<set $slaves[_i].preg to 1, $slaves[_i].pregSource to $Stewardess.ID, _stewardessImpregnated += 1, $slaves[_i].vaginalCount += 10, $vaginalTotal += 10>>
 	<</if>>
 	<</if>>
 	<</if>>
@@ -53,83 +87,36 @@
 	<<display "SA relationships">>
 	<<display "SA rivalries">>
 	<</silently>>
-	<<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust > -20)>>
-	<<set $slaves[$i].devotion -= 5>>
-	<<set $slaves[$i].trust -= 5>>
-	<<elseif ($slaves[$i].devotion < 2)>>
-	<<set $slaves[$i].devotion += 2>>
-	<<elseif ($slaves[$i].devotion > 3)>>
-	<<set $slaves[$i].devotion -= 2>>
+	<<if ($slaves[_i].devotion <= 20) && ($slaves[_i].trust > -20)>>
+	<<set $slaves[_i].devotion -= 5, $slaves[_i].trust -= 5>>
+	<<elseif ($slaves[_i].devotion < 2)>>
+	<<set $slaves[_i].devotion += 2>>
+	<<elseif ($slaves[_i].devotion > 3)>>
+	<<set $slaves[_i].devotion -= 2>>
 	<</if>>
 	<<if $servantsQuartersDecoration != "standard">>
-	<<set $slaves[$i].devotion += 1>>
+	<<set $slaves[_i].devotion += 1>>
 	<</if>>
-	<<if ($slaves[$i].trust < -50)>>
-	<<set $slaves[$i].trust += 2>>
-	<<elseif ($slaves[$i].trust < -6)>>
-	<<set $slaves[$i].trust += 1>>
+	<<if ($slaves[_i].trust < -50)>>
+	<<set $slaves[_i].trust += 2>>
+	<<elseif ($slaves[_i].trust < -6)>>
+	<<set $slaves[_i].trust += 1>>
 	<</if>>
-	<<if ($slaves[$i].health < -80)>>
-	<<set $slaves[$i].health += 20>>
-	<<elseif ($slaves[$i].health < -40)>>
-	<<set $slaves[$i].health += 10>>
-	<<elseif ($slaves[$i].health < 0)>>
-	<<set $slaves[$i].health += 7>>
-	<<elseif ($slaves[$i].health < 90)>>
-	<<set $slaves[$i].health += 3>>
+	<<if ($slaves[_i].health < -80)>>
+	<<set $slaves[_i].health += 20>>
+	<<elseif ($slaves[_i].health < -40)>>
+	<<set $slaves[_i].health += 10>>
+	<<elseif ($slaves[_i].health < 0)>>
+	<<set $slaves[_i].health += 7>>
+	<<elseif ($slaves[_i].health < 90)>>
+	<<set $slaves[_i].health += 3>>
 	<</if>>
 	<<if ($Stewardess != 0)>>
 		<<set $cash += $stewardessBonus>>
 		<<if ($Stewardess.energy > 95) || (($Stewardess.fetishKnown == 1) && ($Stewardess.fetish is "dom"))>>
-			<<if ($slaves[$i].devotion < 45)>><<set $slaves[$i].devotion += 5>><</if>>
+			<<if ($slaves[_i].devotion < 45)>><<set $slaves[_i].devotion += 5>><</if>>
 		<</if>>
 	<</if>>
-
-<<elseif $Stewardess != 0>>
-<<if $slaves[$i].ID is $Stewardess.ID>>
-	<<silently>>
-	<<display "SA long term effects">>
-	<<display "SA relationships">>
-	<<display "SA rivalries">>
-	<</silently>>
-	<<if ($slaves[$i].health < -80)>>
-	<<set $slaves[$i].health += 20>>
-	<<elseif ($slaves[$i].health < -40)>>
-	<<set $slaves[$i].health += 15>>
-	<<elseif ($slaves[$i].health < 0)>>
-	<<set $slaves[$i].health += 10>>
-	<<elseif ($slaves[$i].health < 90)>>
-	<<set $slaves[$i].health += 7>>
-	<</if>>
-	<<if $slaves[$i].devotion <= 60>>
-	<<set $slaves[$i].devotion += 1>>
-	<</if>>
-	<<if $servantsQuartersDecoration != "standard">>
-	<<set $slaves[$i].devotion += 1>>
-	<</if>>
-	<<if $slaves[$i].trust < 60>>
-	<<set $slaves[$i].trust += 1>>
-	<</if>>
-	<<if $slaves[$i].fetishStrength <= 95>>
-	<<if $slaves[$i].fetish != "dom">>
-		<<fetishChangeChance $slaves[$i]>>
-		<<if $fetishChangeChance > random(0,100)>>
-			<<set $stewardessFetish to 1>>
-			<<set $slaves[$i].fetishKnown to 1>>
-			<<set $slaves[$i].fetish to "dom">>
-		<</if>>
-	<<elseif $slaves[$i].fetishKnown == 0>>
-		<<set $stewardessFetish to 1>>
-		<<set $slaves[$i].fetishKnown to 1>>
-	<<else>>
-		<<set $stewardessFetish to 2>>
-		<<set $slaves[$i].fetishStrength += 4>>
-	<</if>>
-	<</if>>
-	<<set $slaves[$i].penetrativeCount += $stewardessImpregnated>>
-	<<set $penetrativeTotal += $stewardessImpregnated>>
-<</if>>
-<</if>>
 <</for>>
 <<set $servantMilkersMultiplier = 1>>
 
@@ -140,23 +127,24 @@
 	<<else>>
 		''There are $servantsQuartersSlaves slaves working out of the servants' quarters.'' They work to @@color:yellowgreen;reduce@@ your household expenses; having a well-staffed house slightly @@color:green;increases@@ your reputation.
 	<</if>>
-	<<if $SQMilk > 0>>
-		Since your lactating servants spend most of their time working in the penthouse, they use the milkers there, giving $SQMilk liters of milk over the week, which is sold for @@color:yellowgreen;¤$SQMilkSale.@@
+	<<if _SQMilk > 0>>
+		Since your lactating servants spend most of their time working in the penthouse, they use the milkers there, giving _SQMilk liters of milk over the week, which is sold for @@color:yellowgreen;¤_SQMilkSale.@@
 	<</if>>
 
 	<<if ($Stewardess != 0)>>
-	$Stewardess.slaveName is serving as your stewardess.<<if $Stewardess.relationship is -3>>  She does her best to be your perfect housewife.<</if>>
-	<<if $stewardessImpregnated > 0>>
+	$Stewardess.slaveName is serving as your stewardess.<<if $Stewardess.relationship is -3>> She does her best to be your perfect housewife.<</if>>
+	<<if _stewardessImpregnated > 0>>
 		It's her responsibility to keep her charges pregnant, and
-		<<if $stewardessImpregnated == 1>>
+		<<if _stewardessImpregnated == 1>>
 			she cums in the fertile one's pussy all week.
 		<<else>>
-			she ensures the $stewardessImpregnated fertile servants are full of her cum at all times.
+			she ensures the _stewardessImpregnated fertile servants are full of her cum at all times.
 		<</if>>
+		<<set Tmult = (_stewardessImpregnated * 10), $slaves[_SWD].penetrativeCount += Tmult, $Stewardess.penetrativeCount += Tmult, $penetrativeTotal += Tmult>>
 	<</if>>
-	<<if $stewardessFetish == 1>>
+	<<if _stewardessFetish == 1>>
 		She's allowed and even expected to use her charges for her own gratification, and sometimes they'll even instigate submissive sex with her just to ingratiate themselves. She becomes comfortable with the role of a @@color:lightcoral;sexual dominant.@@
-	<<elseif $stewardessFetish == 2>>
+	<<elseif _stewardessFetish == 2>>
 		Having a legion of girls jumping to obey her daily commands @@color:lightsalmon;makes her more dominant.@@
 	<</if>>
 	<<if ($Stewardess.health < 10)>>
@@ -175,49 +163,42 @@
 	<<if ($Stewardess.intelligence > 0)>>
 		She's smart enough that she misses very little.
 	<</if>>
-	<<for $i to 0; $i < $slaves.length; $i++>>
-		<<if $slaves[$i].assignment is "work as a servant">>
-		<<if $Stewardess.relationTarget is $slaves[$i].ID>>
-			She pays special attention to her $slaves[$i].relation, $slaves[$i].slaveName, making sure she doesn't slack off just because they are related.
-			<<set $slaves[$i].trust += 1>>
+	<<for _i to 0; _i < _SL; _i++>>
+		<<if $slaves[_i].assignment != "work as a servant">><<continue>><</if>>
+		<<if $Stewardess.relationTarget is $slaves[_i].ID>>
+			She pays special attention to her $slaves[_i].relation, $slaves[_i].slaveName, making sure she doesn't slack off just because they are related.
+			<<set $slaves[_i].trust += 1>>
 		<</if>>
-		<<if $Stewardess.relationshipTarget is $slaves[$i].ID>>
-			She dotes over her <<if $Stewardess.relationship == 1>>friend<<elseif $Stewardess.relationship is 2>>best friend<<elseif $Stewardess.relationship is 3>>friend with benefits<<elseif $Stewardess.relationship is 4>>lover<<elseif $Stewardess.relationship is 5>>slave wife<</if>>, $slaves[$i].slaveName, making sure she is knows how to do a good job and keeps her well stocked with everything she needs.
-			<<set $slaves[$i].devotion += 1>>
+		<<if $Stewardess.relationshipTarget is $slaves[_i].ID>>
+			She dotes over her <<if $Stewardess.relationship == 1>>friend<<elseif $Stewardess.relationship is 2>>best friend<<elseif $Stewardess.relationship is 3>>friend with benefits<<elseif $Stewardess.relationship is 4>>lover<<elseif $Stewardess.relationship is 5>>slave wife<</if>>, $slaves[_i].slaveName, making sure she is knows how to do a good job and keeps her well stocked with everything she needs.
+			<<set $slaves[_i].devotion += 1>>
 		<</if>>
-		<<if $Stewardess.rivalryTarget is $slaves[$i].ID>>
-			She bears down on her <<if $Stewardess.rivalry == 1>>growing rival<<elseif $Stewardess.rivalry is 2>>rival<<elseif $Stewardess.rivalry is 3>>bitter rival<</if>>, $slaves[$i].slaveName, forcing her to work extra hard or suffer punishment.
-			<<set $slaves[$i].devotion -= 1>>
-			<<set $slaves[$i].trust -= 1>>
+		<<if $Stewardess.rivalryTarget is $slaves[_i].ID>>
+			She bears down on her <<if $Stewardess.rivalry == 1>>growing rival<<elseif $Stewardess.rivalry is 2>>rival<<elseif $Stewardess.rivalry is 3>>bitter rival<</if>>, $slaves[_i].slaveName, forcing her to work extra hard or suffer punishment.
+			<<set $slaves[_i].devotion -= 1, $slaves[_i].trust -= 1>>
 			<<if random(1,100) > 65>>
-				<<set $Stewardess.rivalry += 1>>
-			<<set $slaves[$i].rivalry += 1>>
+				<<set $Stewardess.rivalry += 1, $slaves[_SWD].rivalry += 1, $slaves[_i].rivalry += 1>>
 			<</if>>
 		<</if>>
-		<<if $slaves[$i].prestigeDesc is "She is a famed Free Cities whore, and commands top prices.">>
-			She does her best to motivate the famous whore, $slaves[$i].slaveName, though she is uncertain why she is here.
+		<<if $slaves[_i].prestigeDesc is "She is a famed Free Cities whore, and commands top prices.">>
+			She does her best to motivate the famous whore, $slaves[_i].slaveName, though she is uncertain why she is here.
 		<</if>>
-		<<if $slaves[$i].prestigeDesc is "She is a famed Free Cities slut, and can please anyone.">>
-			She ignores her duties in order the fawn over the famous entertainer, $slaves[$i].slaveName.
+		<<if $slaves[_i].prestigeDesc is "She is a famed Free Cities slut, and can please anyone.">>
+			She ignores her duties in order the fawn over the famous entertainer, $slaves[_i].slaveName.
 		<</if>>
-		<<if $slaves[$i].prestigeDesc is "She is remembered for winning best in show as a cockmilker.">>
-			$slaves[$i].slaveName leaves a trail of cum wherever she goes and frequently stops to masturbate greatly annoying $Stewardess.slaveName.
-			<<if random(1,100) > 90 and $Stewardess.rivalry == 0 and $slaves[$i].rivalry == 0>>
-			<<set $Stewardess.rivalryTarget to $slaves[$i].ID>>
-				<<set $Stewardess.rivalry += 1>>
-			<<set $slaves[$i].rivalryTarget to $Stewardess.ID>>
-			<<set $slaves[$i].rivalry += 1>>
+		<<if $slaves[_i].prestigeDesc is "She is remembered for winning best in show as a cockmilker.">>
+			$slaves[_i].slaveName leaves a trail of cum wherever she goes and frequently stops to masturbate greatly annoying $Stewardess.slaveName.
+			<<if random(1,100) > 90 && $Stewardess.rivalry == 0 && $slaves[_i].rivalry == 0>>
+			<<set $Stewardess.rivalryTarget to $slaves[_i].ID, $Stewardess.rivalry += 1, $slaves[_SWD].rivalryTarget to $slaves[_i].ID, $slaves[_SWD].rivalry += 1>>
+			<<set $slaves[_i].rivalryTarget to $Stewardess.ID, $slaves[_i].rivalry += 1>>
 			<</if>>
 		<</if>>
-		<<if $slaves[$i].prestigeDesc is "She is remembered for winning best in show as a dairy cow.">>
-			$slaves[$i].slaveName's huge breasts frequently get in the way of her work and she leaks milk everywhere, greatly annoying $Stewardess.slaveName.
-			<<if random(1,100) > 90 and $Stewardess.rivalry == 0 and $slaves[$i].rivalry == 0>>
-			<<set $Stewardess.rivalryTarget to $slaves[$i].ID>>
-				<<set $Stewardess.rivalry += 1>>
-			<<set $slaves[$i].rivalryTarget to $Stewardess.ID>>
-			<<set $slaves[$i].rivalry += 1>>
+		<<if $slaves[_i].prestigeDesc is "She is remembered for winning best in show as a dairy cow.">>
+			$slaves[_i].slaveName's huge breasts frequently get in the way of her work and she leaks milk everywhere, greatly annoying $Stewardess.slaveName.
+			<<if random(1,100) > 90 and $Stewardess.rivalry == 0 and $slaves[_i].rivalry == 0>>
+			<<set $Stewardess.rivalryTarget to $slaves[_i].ID, $Stewardess.rivalry += 1, $slaves[_SWD].rivalryTarget to $slaves[_i].ID, $slaves[_SWD].rivalry += 1>>
+			<<set $slaves[_i].rivalryTarget to $Stewardess.ID, $slaves[_i].rivalry += 1>>
 			<</if>>
-		<</if>>
 		<</if>>
 	<</for>>
 	<<if ($Stewardess.fetishKnown == 1)>>


### PR DESCRIPTION
Fixes issues with the $Stewardess var and her $slaves[] var being out of sync. Also used canPenetrate() for her. An I fixed her penetration counts to be the same # of times as for a slave (+10 for each). Also separated her code from the other workers, and fixed a possible bug with her impregnating counts not reflecting all possible workers impregnated.

Again var were changed over to _temps; _SQMilk, _SQMilkSale, _stewardessFetish, _stewardessImpregnated.

Not sure if this meant to be this way or is an oversight due to the $universalRulesFacilityWork, but "SA servant" already does  <<set $cash += $stewardessBonus>> for up to a $200 bonus, and then it will also do it again here on **line 115** for another bonus. **I left it in** just in case it's on purpose for SQ workers to get up to $400 bonus.