### PR TITLE
Bugfixes-Opt masterSuiteReport.tw, masterSuite.tw

### DIFF
--- a/src/uncategorized/masterSuite.tw
+++ b/src/uncategorized/masterSuite.tw
@@ -1,71 +1,60 @@
-:: Master Suite
+:: Master Suite [nobr]
 
-<<nobr>>
-<<set $nextButton to "Back to Main">>
-<<set $nextLink to "Main">>
-<<set $returnTo to "Master Suite">>
+<<set $nextButton = "Back to Main", $nextLink = "Main", $returnTo = "Master Suite">>
 
 <<if $masterSuiteName != "the Master Suite">>
 	<<set $masterSuiteNameCaps to $masterSuiteName.replace("the ", "The ")>>
 <</if>>
 
-<<set $masterSuiteSlaves to 0>>
-<<set $notMasterSuiteSlaves to 0>>
-<<set $masterSuitePregnantSlaves to 0>>
-<<set $masterSuitePregnantSlavesMultiple to 0>>
-<<set $masterSuitePregnantSlaves to 0>>
-<<set $masterSuiteAverageEnergy to 0>>
-<<set $masterSuiteAverageMilk to 0>>
-<<set $masterSuiteAverageCum to 0>>
-<<set $masterSuiteAverageDick to 0>>
-<<set $masterSuiteAveragePreg to 0>>
-<<set $masterSuiteAverageDom to 0>>
-<<set $masterSuiteAverageSadism to 0>>
+<<set $masterSuiteAverageEnergy = 0, $masterSuiteSlaves = 0, _masterSuiteAverageCum = 0, _masterSuiteAverageDick = 0, _masterSuiteAverageDom = 0, _masterSuiteAverageMilk = 0, _masterSuiteAveragePreg = 0, _masterSuiteAverageSadism = 0, _masterSuitePregnantSlaves = 0, _masterSuitePregnantSlavesMultiple = 0, _notMasterSuiteSlaves = 0, _SL = $slaves.length>>
 
-<<for _i to 0; _i < $slaves.length; _i++>>
+<<for _i to 0; _i < _SL; _i++>>
 <<set _Slave to $slaves[_i]>>
 <<if _Slave.assignment is "serve in the master suite">>
 	<<set $masterSuiteSlaves += 1>>
 	<<if $masterSuiteUpgradeLuxury is 2>>
-	<<if canAchieveErection($slaves[_i])>>
-		<<set $masterSuiteAverageCum += _Slave.balls>>
-		<<set $masterSuiteAverageDick += _Slave.dick>>
+	<<if canAchieveErection(_Slave)>>
+		<<set _masterSuiteAverageCum += _Slave.balls, _masterSuiteAverageDick += _Slave.dick>>
 	<</if>>
-	<<set $masterSuiteAverageMilk += _Slave.lactation*(_Slave.boobs-_Slave.boobsImplant)>>
+	<<set _masterSuiteAverageMilk += _Slave.lactation*(_Slave.boobs-_Slave.boobsImplant)>>
 	<<set $masterSuiteAverageEnergy += _Slave.energy>>
-	<<set $masterSuiteAveragePreg += _Slave.preg>>
+	<<set _masterSuiteAveragePreg += _Slave.preg>>
 	<<if _Slave.fetish is "dom">>
-		<<set $masterSuiteAverageDom += _Slave.fetishStrength>>
+		<<set _masterSuiteAverageDom += _Slave.fetishStrength>>
 	<<elseif _Slave.fetish is "submissive">>
-		<<set $masterSuiteAverageDom -= _Slave.fetishStrength>>
+		<<set _masterSuiteAverageDom -= _Slave.fetishStrength>>
 	<<elseif _Slave.fetish is "sadist">>
-		<<set $masterSuiteAverageSadism += _Slave.fetishStrength>>
+		<<set _masterSuiteAverageSadism += _Slave.fetishStrength>>
 	<<elseif _Slave.fetish is "masochist">>
-		<<set $masterSuiteAverageSadism -= _Slave.fetishStrength>>
+		<<set _masterSuiteAverageSadism -= _Slave.fetishStrength>>
 	<</if>>
 	<</if>>
 	<<if $masterSuiteUpgradeLuxury > 0>>
 	<<set _Slave.livingRules to "luxurious">>
 	<</if>>
+	<<set $slaves[_i] = _Slave>>
+	<<if _Slave.ID == $Concubine.ID>>
+		<<set $Concubine = _Slave>>
+	<</if>>
 <<else>>
-	<<set $notMasterSuiteSlaves += 1>>
+	<<set _notMasterSuiteSlaves += 1>>
 <</if>>
 <<if (_Slave.assignment is "serve in the master suite" or _Slave.ID is $Concubine.ID) && (_Slave.preg >= 4)>>
-	 <<set $masterSuitePregnantSlaves += 1>>
-	 <<if _Slave.pregType > 1>>
-		 <<set $masterSuitePregnantSlavesMultiple += 1>>
-	 <</if>>
+	<<set _masterSuitePregnantSlaves += 1>>
+	<<if _Slave.pregType > 1>>
+		<<set _masterSuitePregnantSlavesMultiple += 1>>
+	<</if>>
 <</if>>
 <</for>>
 
 <<if ($masterSuiteSlaves > 0)>>
 	<<set $masterSuiteAverageEnergy to $masterSuiteAverageEnergy/$masterSuiteSlaves>>
-	<<set $masterSuiteAverageMilk to $masterSuiteAverageMilk/$masterSuiteSlaves>>
-	<<set $masterSuiteAverageCum to $masterSuiteAverageCum/$masterSuiteSlaves>>
-	<<set $masterSuiteAverageDick to $masterSuiteAverageDick/$masterSuiteSlaves>>
-	<<set $masterSuiteAveragePreg to $masterSuiteAveragePreg/$masterSuiteSlaves>>
-	<<set $masterSuiteAverageDom to $masterSuiteAverageDom/$masterSuiteSlaves>>
-	<<set $masterSuiteAverageSadism to $masterSuiteAverageSadism/$masterSuiteSlaves>>
+	<<set _masterSuiteAverageMilk to _masterSuiteAverageMilk/$masterSuiteSlaves>>
+	<<set _masterSuiteAverageCum to _masterSuiteAverageCum/$masterSuiteSlaves>>
+	<<set _masterSuiteAverageDick to _masterSuiteAverageDick/$masterSuiteSlaves>>
+	<<set _masterSuiteAveragePreg to _masterSuiteAveragePreg/$masterSuiteSlaves>>
+	<<set _masterSuiteAverageDom to _masterSuiteAverageDom/$masterSuiteSlaves>>
+	<<set _masterSuiteAverageSadism to _masterSuiteAverageSadism/$masterSuiteSlaves>>
 <</if>>
 
 <<if $masterSuiteUpgradeLuxury == 1>>
@@ -117,9 +106,9 @@ $masterSuiteNameCaps is furnished
 It's is full of luxuries of all kinds. The slaves here live free of want or worry, and have everything except their freedom. Their only duties are to please you and look after the suite and one another.
 <<if $masterSuiteSlaves > 2>>
 	It's busy with slaves, so many that they are able to rotate through keeping themselves perfect and ready for your pleasure. The slaves not on call at the moment are beautifying themselves, cleaning, or serving others.
-	<<if ($masterSuitePregnantSlaves > 2) && ($masterSuitePregnantSlavesMultiple < 2)>>
+	<<if (_masterSuitePregnantSlaves > 2) && (_masterSuitePregnantSlavesMultiple < 2)>>
 	Many of the slaves are pregnant, and they walk around proudly displaying their bellies and the new slaves growing inside them.<br>
-	<<elseif ($masterSuitePregnantSlaves > 2) && ($masterSuitePregnantSlavesMultiple > 2)>>
+	<<elseif (_masterSuitePregnantSlaves > 2) && (_masterSuitePregnantSlavesMultiple > 2)>>
 	Many of the slaves are pregnant with multiple children, and they walk around proudly displaying their distended bellies and the next generation of slaves growing within them.<br>
 	<</if>>
 <<elseif $masterSuiteSlaves > 0>>
@@ -188,19 +177,19 @@ The true focus of the suite is, however, the fuckpit. This stepped depression in
 	<</if>>
 	<<if $masterSuiteAverageEnergy > 90>>
 	The pit features automated cleaning systems, which are quite necessary.
-	<<if $masterSuiteAverageDick > 4>>
+	<<if _masterSuiteAverageDick > 4>>
 		With so many huge cocks in the fuckpit, every hole available is frequently fucked vigorously.
 	<</if>>
-	<<if $masterSuiteAverageCum > 4>>
+	<<if _masterSuiteAverageCum > 4>>
 		The slaves' bodies grow more coated with cum, and more of the white stuff drips from their holes, until they take a break for a shower.
 	<</if>>
-	<<if $masterSuiteAverageMilk > 4000>>
+	<<if _masterSuiteAverageMilk > 4000>>
 		Most of them cannot tear themselves away (or cannot escape) for a normal machine milking, so their tender, overfull breasts squirt milk whenever anyone touches them. The lowest level of the fuckpit is a pool of milk.
 	<</if>>
 	<</if>>
-	<<if ($masterSuitePregnantSlaves > 2) && ($masterSuitePregnantSlavesMultiple < 2)>>
+	<<if (_masterSuitePregnantSlaves > 2) && (_masterSuitePregnantSlavesMultiple < 2)>>
 	Many of the slaves are pregnant, and more than one has her face buried in the cunt directly below a gravid belly while she lovingly massages her own.<br>
-	<<elseif ($masterSuitePregnantSlaves > 2) && ($masterSuitePregnantSlavesMultiple > 2)>>
+	<<elseif (_masterSuitePregnantSlaves > 2) && (_masterSuitePregnantSlavesMultiple > 2)>>
 	Many of the slaves are pregnant with multiple children, and more than one has her face buried in the cunt directly below a grossly swollen belly while she lovingly massages her own distended stomach.<br>
 	<</if>>
 <<elseif $masterSuiteSlaves > 0>>
@@ -259,9 +248,9 @@ $masterSuiteNameCaps is furnished
 
 <<if $masterSuiteSlaves > 2>>
 	It's busy with slaves, so many that they are able to rotate through keeping themselves perfect and ready for your pleasure. The slaves not on call at the moment are beautifying themselves, cleaning, or serving others.
-	<<if ($masterSuitePregnantSlaves > 2) && ($masterSuitePregnantSlavesMultiple < 2)>>
+	<<if (_masterSuitePregnantSlaves > 2) && (_masterSuitePregnantSlavesMultiple < 2)>>
 	Many of the slaves are pregnant, and they walk around proudly displaying their bellies and the new slaves growing inside them.<br>
-	<<elseif ($masterSuitePregnantSlaves > 2) && ($masterSuitePregnantSlavesMultiple > 2)>>
+	<<elseif (_masterSuitePregnantSlaves > 2) && (_masterSuitePregnantSlavesMultiple > 2)>>
 	Many of the slaves are pregnant with multiple children, and they walk around proudly displaying their distended bellies and the next generation of slaves growing within them.<br>
 	<</if>>
 <<elseif $masterSuiteSlaves > 0>>
@@ -316,7 +305,7 @@ $masterSuiteNameCaps is furnished
 	<<display "Slave Summary">>
 <</if>>
 
-<<if $notMasterSuiteSlaves > 0>>
+<<if _notMasterSuiteSlaves > 0>>
 	<br><br>''Send a slave to serve in the master suite:''
 	<<set $Flag to 0>>
 	<<display "Slave Summary">>
@@ -324,4 +313,3 @@ $masterSuiteNameCaps is furnished
 <<unset $Flag>>
 
 <br><br>Rename $masterSuiteName: <<textbox "$masterSuiteName" $masterSuiteName "Master Suite">> //Use a noun or similar short phrase//
-<</nobr>>

--- a/src/uncategorized/masterSuiteReport.tw
+++ b/src/uncategorized/masterSuiteReport.tw
@@ -2,42 +2,31 @@
 
 ''Master Suite Report''<hr style="margin:0">
 
-<<set $legendaryAbolitionistID to 0>>
-<<set $masterSuiteSlaves to 0>>
-<<set $masterSuitePregnantSlaves to 0>>
-<<set $masterSuiteAverageEnergy to 0>>
-<<set $masterSuiteAverageMilk to 0>>
-<<set $masterSuiteAverageCum to 0>>
-<<set $masterSuiteAverageDick to 0>>
-<<set $masterSuiteAveragePreg to 0>>
-<<set $masterSuiteAverageDom to 0>>
-<<set $masterSuiteAverageSadism to 0>>
+<<set $legendaryAbolitionistID = 0, $masterSuiteAverageEnergy = 0, $masterSuiteSlaves = 0, _masterSuiteAverageCum = 0, _masterSuiteAverageDick = 0, _masterSuiteAverageDom = 0, _masterSuiteAverageMilk = 0, _masterSuiteAveragePreg = 0, _masterSuiteAverageSadism = 0, _masterSuitePregnantSlaves = 0, _SL = $slaves.length, _CCB = -1>>
 
-<<for $i to 0; $i < $slaves.length; $i++>>
-<<if ($slaves[$i].assignment is "serve in the master suite") || ($slaves[$i].assignment is "be your Concubine")>>
-	<<if $seeImages == 1>><<SlaveArt $slaves[$i] 0 0>><</if>>
-	<<set $masterSuiteSlaves += 1>>
-	<<set $masterSuiteAverageEnergy += $slaves[$i].energy>>
+<<for _i to 0; _i < _SL; _i++>>
+<<if ($slaves[_i].assignment is "serve in the master suite") || ($slaves[_i].assignment is "be your Concubine")>>
+	<<if $seeImages == 1>><<SlaveArt $slaves[_i] 0 0>><</if>>
+	<<set $masterSuiteSlaves += 1, $masterSuiteAverageEnergy += $slaves[_i].energy>>
 	<<if $masterSuiteUpgradeLuxury == 2>>
-	<<if canAchieveErection($slaves[$i])>>
-		<<set $masterSuiteAverageCum += $slaves[$i].balls>>
-		<<set $masterSuiteAverageDick += $slaves[$i].dick>>
+	<<if canAchieveErection($slaves[_i])>>
+		<<set $masterSuiteAverageCum += $slaves[_i].balls, $masterSuiteAverageDick += $slaves[_i].dick>>
 	<</if>>
-	<<set $masterSuiteAverageMilk += $slaves[$i].lactation*($slaves[$i].boobs-$slaves[$i].boobsImplant)>>
-	<<set $masterSuiteAveragePreg += $slaves[$i].preg>>
-	<<if $slaves[$i].fetish is "dom">>
-		<<set $masterSuiteAverageDom += $slaves[$i].fetishStrength>>
-	<<elseif $slaves[$i].fetish is "submissive">>
-		<<set $masterSuiteAverageDom -= $slaves[$i].fetishStrength>>
-	<<elseif $slaves[$i].fetish is "sadist">>
-		<<set $masterSuiteAverageSadism += $slaves[$i].fetishStrength>>
-	<<elseif $slaves[$i].fetish is "masochist">>
-		<<set $masterSuiteAverageSadism -= $slaves[$i].fetishStrength>>
+	<<set $masterSuiteAverageMilk += $slaves[_i].lactation*($slaves[_i].boobs-$slaves[_i].boobsImplant)>>
+	<<set $masterSuiteAveragePreg += $slaves[_i].preg>>
+	<<if $slaves[_i].fetish is "dom">>
+		<<set $masterSuiteAverageDom += $slaves[_i].fetishStrength>>
+	<<elseif $slaves[_i].fetish is "submissive">>
+		<<set $masterSuiteAverageDom -= $slaves[_i].fetishStrength>>
+	<<elseif $slaves[_i].fetish is "sadist">>
+		<<set $masterSuiteAverageSadism += $slaves[_i].fetishStrength>>
+	<<elseif $slaves[_i].fetish is "masochist">>
+		<<set $masterSuiteAverageSadism -= $slaves[_i].fetishStrength>>
 	<</if>>
 	<</if>>
-	<<if ($legendaryAbolitionistID == 0) && ($slaves[$i].devotion > 95) && ($slaves[$i].prestige == 0)>>
-	<<if ($slaves[$i].origin is "You sentenced her to enslavement as a punishment for attempted theft of a slave.") || ($slaves[$i].origin is "She is an enslaved Daughter of Liberty.")>>
-		<<set $legendaryAbolitionistID to $slaves[$i].ID>>
+	<<if ($legendaryAbolitionistID == 0) && ($slaves[_i].devotion > 95) && ($slaves[_i].prestige == 0)>>
+	<<if ($slaves[_i].origin is "You sentenced her to enslavement as a punishment for attempted theft of a slave.") || ($slaves[_i].origin is "She is an enslaved Daughter of Liberty.")>>
+		<<set $legendaryAbolitionistID to $slaves[_i].ID>>
 	<</if>>
 	<</if>>
 <</if>>
@@ -54,19 +43,22 @@
 <<set $masterSuiteAverageSadism to $masterSuiteAverageSadism/$masterSuiteSlaves>>
 
 <<if $seeImages == 1>><br style="clear:both" /><</if>>
-''There<<if ($masterSuiteSlaves == 1)>>is one slave<<else>>are $masterSuiteSlaves slaves<</if>>
+''There <<if ($masterSuiteSlaves == 1)>>is one slave<<else>>are $masterSuiteSlaves slaves<</if>>
 seeing to your pleasure in the master suite.'' Such sexual opulence @@color:green;improves@@ your reputation.
 <<if ($arcologies[0].FSEgyptianRevivalist > 0) && ($masterSuiteSlaves >= 5)>>
 	Society @@color:green;approves@@ of your keeping a large number of women, which advances the Egyptian revivalist ideal of multiple concubinage.
 	<<set $repGain += 0.2*$masterSuiteSlaves*$FSSingleSlaveRep*($arcologies[0].FSEgyptianRevivalist/$FSLockinLevel)>>
-<<set $arcologies[0].FSEgyptianRevivalist += 0.01*$masterSuiteSlaves*$FSSingleSlaveRep>>
+	<<set $arcologies[0].FSEgyptianRevivalist += 0.01*$masterSuiteSlaves*$FSSingleSlaveRep>>
 <</if>>
 <<if ($masterSuitePregnantSlaves >= 1)>>
 	The suite is supporting the pregnancies of the slaves
-	<<if ($masterSuitePregnancyFertilityDrugs == 1) && ($masterSuitePregnancyFertilitySupplements == 1)>>
-	within, and is providing them with fertility drugs and supplements to encourage impregnation.
-	<<elseif ($masterSuitePregnancyFertilityDrugs == 1) && ($masterSuitePregnancyFertilitySupplements == 1)>>
-	within, and is providing them with fertility drugs to encourage impregnation.
+	<<if ($masterSuitePregnancyFertilityDrugs == 1)>>
+		within, and is providing them with fertility drugs
+		<<if ($masterSuitePregnancyFertilitySupplements == 1)>>
+		and supplements to encourage impregnation.
+		<<else>>
+		to encourage impregnation.
+		<</if>>
 	<<else>>
 	within.
 	<</if>>
@@ -100,53 +92,53 @@ The level of sexual energy in the suite is
 <</if>>
 <</if>>
 
-<<for $i to 0; $i < $slaves.length; $i++>>
-<<if ($slaves[$i].assignment is "serve in the master suite") || ($slaves[$i].assignment is "be your Concubine")>>
-
+<<for _i to 0; _i < _SL; _i++>>
+<<if ($slaves[_i].assignment is "serve in the master suite") || ($slaves[_i].assignment is "be your Concubine")>>
+<<set $i = _i>>
 <<silently>><<display "SA please you">><</silently>>
 
-<<if ($slaves[$i].assignment is "serve in the master suite")>>
-	<<if $verboseDescriptions == 1>><br><br>''__@@color:pink;$slaves[$i].slaveName@@__'' sees to your pleasure in the master suite.<</if>>
+<<if ($slaves[_i].assignment is "serve in the master suite")>>
+	<<if $verboseDescriptions == 1>><br><br>''__@@color:pink;$slaves[_i].slaveName@@__'' sees to your pleasure in the master suite.<</if>>
 	<<if ($masterSuiteUpgradeLuxury == 1)>>
-	<<if ($slaves[$i].devotion <= 95)>>
-		<<set $slaves[$i].devotion += 2>>
+	<<if ($slaves[_i].devotion <= 95)>>
+		<<set $slaves[_i].devotion += 2>>
 	<</if>>
 	<<if $masterSuiteDecoration != "standard">>
-		<<set $slaves[$i].devotion += 1>>
+		<<set $slaves[_i].devotion += 1>>
 	<</if>>
-	<<if ($slaves[$i].trust < 60)>>
-		<<set $slaves[$i].trust += 1>>
+	<<if ($slaves[_i].trust < 60)>>
+		<<set $slaves[_i].trust += 1>>
 	<</if>>
 	<<elseif ($masterSuiteUpgradeLuxury is 2)>>
-	<<if ($slaves[$i].energy > 90)>>
-		<<if ($slaves[$i].devotion <= 95)>>
-		<<set $slaves[$i].devotion += 2>>
+	<<if ($slaves[_i].energy > 90)>>
+		<<if ($slaves[_i].devotion <= 95)>>
+		<<set $slaves[_i].devotion += 2>>
 		<</if>>
-		<<if ($slaves[$i].trust <= 95)>>
-		<<set $slaves[$i].trust += 2>>
+		<<if ($slaves[_i].trust <= 95)>>
+		<<set $slaves[_i].trust += 2>>
 		<</if>>
 	<<else>>
-		<<if ($slaves[$i].devotion <= 60)>>
-		<<set $slaves[$i].devotion += 1>>
+		<<if ($slaves[_i].devotion <= 60)>>
+		<<set $slaves[_i].devotion += 1>>
 		<</if>>
-		<<if ($slaves[$i].trust < 60)>>
-		<<set $slaves[$i].trust += 1>>
+		<<if ($slaves[_i].trust < 60)>>
+		<<set $slaves[_i].trust += 1>>
 		<</if>>
 	<</if>>
 	<<else>>
-	<<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust > -20)>>
-		<<set $slaves[$i].devotion -= 2>>
-		<<set $slaves[$i].trust -= 5>>
-	<<elseif ($slaves[$i].devotion <= 60)>>
-		<<set $slaves[$i].devotion += 2>>
-	<<elseif ($slaves[$i].devotion > 60)>>
-		<<set $slaves[$i].devotion -= 2>>
+	<<if ($slaves[_i].devotion <= 20) && ($slaves[_i].trust > -20)>>
+		<<set $slaves[_i].devotion -= 2, $slaves[_i].trust -= 5>>
+	<<elseif ($slaves[_i].devotion <= 60)>>
+		<<set $slaves[_i].devotion += 2>>
+	<<elseif ($slaves[_i].devotion > 60)>>
+		<<set $slaves[_i].devotion -= 2>>
 	<</if>>
-	<<if ($slaves[$i].trust < 60)>>
-		<<set $slaves[$i].trust += 1>>
+	<<if ($slaves[_i].trust < 60)>>
+		<<set $slaves[_i].trust += 1>>
 	<</if>>
 	<</if>>
 <<else>>
+	<<set $Concubine = $slaves[_i], _CCB = _i>>
 	<<if $verboseDescriptions == 1>><br><br><</if>>''Your concubine $Concubine.slaveName is serving you in $masterSuiteName.'' More than any other slave, her sexual brilliance and physical appeal are @@color:green;critical@@ to your reputation.
 	<<if ($Concubine.career is "an arcology owner")>>
 	She was once your rival, and your relationship is widely thought to be @@color:green;the perfect modern romance.@@
@@ -159,102 +151,99 @@ The level of sexual energy in the suite is
 	<<if $verboseDescriptions == 1>>Many citizens <<if $Concubine.publicCount > 100>>remember having had her themselves, and <</if>>@@color:green;respectfully@@ envy you her exclusive company.<</if>>
 	<<set $repGain += 25>>
 	<</if>>
-	<<if $slaves[$i].devotion <= 20>>
+	<<if $slaves[_i].devotion <= 20>>
 	<<if $masterSuiteUpgradeLuxury > 0>>
-		<<set $slaves[$i].devotion += 4>>
-		<<set $slaves[$i].trust += 4>>
+		<<set $slaves[_i].devotion += 4, $slaves[_i].trust += 4>>
 	<<else>>
-		<<set $slaves[$i].devotion += 2>>
-		<<set $slaves[$i].trust += 2>>
+		<<set $slaves[_i].devotion += 2, $slaves[_i].trust += 2>>
 	<</if>>
 	<</if>>
 	<<if $masterSuiteDecoration != "standard">>
-	<<set $slaves[$i].devotion += 1>>
+	<<set $slaves[_i].devotion += 1>>
 	<</if>>
 <</if>>
 
 <<if $masterSuiteUpgradeLuxury is 2>>
 
-<<fetishChangeChance $slaves[$i]>>
-<<if $slaves[$i].trust > -20>>
-<<if $slaves[$i].devotion > -10>>
-<<if $slaves[$i].fetishStrength <= 95>>
+<<if ($slaves[_i].trust > -20) && ($slaves[_i].devotion > -10) && ($slaves[_i].fetishStrength <= 95)>>
 <<if $masterSuiteAverageEnergy > random(50,90)>>
-	<<if ($masterSuiteAverageMilk > 2000) && ($fetishChangeChance > random(0,50))>>
-	<<if $slaves[$i].fetish is "boobs">>
-		<<if $verboseDescriptions == 1>>Her<<else>>$slaves[$i].slaveName's<</if>> @@color:lightcoral;boob fetish is strengthened@@ by the constant availability of milky nipples for her to play with.
-		<<set $slaves[$i].fetishStrength += 4>>
+	<<if $verboseDescriptions == 1>>
+		<<set _Verb = "She">>
 	<<else>>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;acquires a boob fetish@@ after spending a lot of time in the fuckpit drinking from her fellow fucktoys' tits.
-		<<set $slaves[$i].fetish to "boobs">>
-		<<set $slaves[$i].fetishStrength = 65>>
+		<<set _Verb = $slaves[_i].slaveName>>
 	<</if>>
-	<<elseif ($masterSuiteAverageDick > 3) && ($slaves[$i].anus > 0) && ($fetishChangeChance > random(0,50))>>
-	<<if $slaves[$i].fetish is "buttslut">>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;sinks farther into anal pleasure,@@ since she spends her time in the fuckpit with at least one of the many available cocks up her butt.
-		<<set $slaves[$i].fetishStrength += 4>>
+	<<fetishChangeChance $slaves[_i]>>
+	<<if ($masterSuiteAverageMilk > 2000) && ($fetishChangeChance > random(0,50))>>
+	<<if $slaves[_i].fetish is "boobs">>
+		<<if $verboseDescriptions == 1>>Her<<else>>$slaves[_i].slaveName's<</if>> @@color:lightcoral;boob fetish is strengthened@@ by the constant availability of milky nipples for her to play with.
+		<<set $slaves[_i].fetishStrength += 4>>
 	<<else>>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;acquires an anal fetish@@ after helplessly orgasming at the mercy of your many fucktoys eager to shove their big stiff penises up her ass.
-		<<set $slaves[$i].fetish to "buttslut">>
-		<<set $slaves[$i].fetishStrength = 65>>
+		<<if $verboseDescriptions == 1>>She<<else>>$slaves[_i].slaveName<</if>> @@color:lightcoral;acquires a boob fetish@@ after spending a lot of time in the fuckpit drinking from her fellow fucktoys' tits.
+		<<set $slaves[_i].fetish to "boobs", $slaves[_i].fetishStrength = 65>>
+	<</if>>
+	<<elseif ($masterSuiteAverageDick > 3) && ($slaves[_i].anus > 0) && ($fetishChangeChance > random(0,50))>>
+	_Verb
+	<<if $slaves[_i].fetish is "buttslut">>
+		@@color:lightcoral;sinks farther into anal pleasure,@@ since she spends her time in the fuckpit with at least one of the many available cocks up her butt.
+		<<set $slaves[_i].fetishStrength += 4>>
+	<<else>>
+		@@color:lightcoral;acquires an anal fetish@@ after helplessly orgasming at the mercy of your many fucktoys eager to shove their big stiff penises up her ass.
+		<<set $slaves[_i].fetish to "buttslut", $slaves[_i].fetishStrength = 65>>
 	<</if>>
 	<<elseif ($masterSuiteAverageCum > 3) && ($fetishChangeChance > random(0,50))>>
-	<<if $slaves[$i].fetish is "cumslut">>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;sinks farther into cum addiction,@@ since she spends her time in the fuckpit eagerly sucking down ejaculate, straight from the many sources.
-		<<set $slaves[$i].fetishStrength += 4>>
+	_Verb
+	<<if $slaves[_i].fetish is "cumslut">>
+		@@color:lightcoral;sinks farther into cum addiction,@@ since she spends her time in the fuckpit eagerly sucking down ejaculate, straight from the many sources.
+		<<set $slaves[_i].fetishStrength += 4>>
 	<<else>>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;acquires an oral fixation@@ after orally servicing your many fucktoys eager to blow their loads down her throat.
-		<<set $slaves[$i].fetish to "cumslut">>
-		<<set $slaves[$i].fetishStrength = 65>>
+		@@color:lightcoral;acquires an oral fixation@@ after orally servicing your many fucktoys eager to blow their loads down her throat.
+		<<set $slaves[_i].fetish to "cumslut", $slaves[_i].fetishStrength = 65>>
 	<</if>>
 	<<elseif ($masterSuiteAveragePreg > 10) && ($fetishChangeChance > random(0,50))>>
-	<<if $slaves[$i].fetish is "pregnancy">>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;sinks farther into pregnancy obession,@@ since she never wants for a pregnant girl to make love to.
-		<<set $slaves[$i].fetishStrength += 4>>
+	_Verb
+	<<if $slaves[_i].fetish is "pregnancy">>
+		@@color:lightcoral;sinks farther into pregnancy obession,@@ since she never wants for a pregnant girl to make love to.
+		<<set $slaves[_i].fetishStrength += 4>>
 	<<else>>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;acquires an pregnancy fetish,@@ since many of her sexual partners in the fuckpit are heavily pregnant.
-		<<set $slaves[$i].fetish to "pregnancy">>
-		<<set $slaves[$i].fetishStrength = 65>>
+		@@color:lightcoral;acquires an pregnancy fetish,@@ since many of her sexual partners in the fuckpit are heavily pregnant.
+		<<set $slaves[_i].fetish to "pregnancy", $slaves[_i].fetishStrength = 65>>
 	<</if>>
 	<<elseif ($masterSuiteAverageDom < 50) && ($fetishChangeChance > random(0,50))>>
-	<<if $slaves[$i].fetish is "dom">>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;becomes more dominant,@@ since there are so many subs in the fuckpit who beg her to fuck them hard.
-		<<set $slaves[$i].fetishStrength += 4>>
+	_Verb
+	<<if $slaves[_i].fetish is "dom">>
+		@@color:lightcoral;becomes more dominant,@@ since there are so many subs in the fuckpit who beg her to fuck them hard.
+		<<set $slaves[_i].fetishStrength += 4>>
 	<<else>>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;becomes sexually dominant@@ after having fun satisfying the many submissive fucktoys in the fuckpit who beg her to top them.
-		<<set $slaves[$i].fetish to "dom">>
-		<<set $slaves[$i].fetishStrength = 65>>
+		@@color:lightcoral;becomes sexually dominant@@ after having fun satisfying the many submissive fucktoys in the fuckpit who beg her to top them.
+		<<set $slaves[_i].fetish to "dom", $slaves[_i].fetishStrength = 65>>
 	<</if>>
 	<<elseif ($masterSuiteAverageDom > 50) && ($fetishChangeChance > random(0,50))>>
-	<<if $slaves[$i].fetish is "submissive">>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;becomes even more submissive,@@ since there are so many doms in the fuckpit that she's often used by more than one at once.
-		<<set $slaves[$i].fetishStrength += 4>>
+	_Verb
+	<<if $slaves[_i].fetish is "submissive">>
+		@@color:lightcoral;becomes even more submissive,@@ since there are so many doms in the fuckpit that she's often used by more than one at once.
+		<<set $slaves[_i].fetishStrength += 4>>
 	<<else>>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;becomes sexually submissive@@ after the many dominant slaves in the fuckpit hold her down and use her for their pleasure.
-		<<set $slaves[$i].fetish to "sub">>
-		<<set $slaves[$i].fetishStrength = 65>>
+		@@color:lightcoral;becomes sexually submissive@@ after the many dominant slaves in the fuckpit hold her down and use her for their pleasure.
+		<<set $slaves[_i].fetish to "sub", $slaves[_i].fetishStrength = 65>>
 	<</if>>
 	<<elseif ($masterSuiteAverageSadism < 50) && ($fetishChangeChance > random(0,50))>>
-	<<if $slaves[$i].fetish is "sadist">>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;becomes more sadistic,@@ since there are so many girls in the fuckpit who will do anything for her if she'll only spank them.
-		<<set $slaves[$i].fetishStrength += 4>>
+	_Verb
+	<<if $slaves[_i].fetish is "sadist">>
+		@@color:lightcoral;becomes more sadistic,@@ since there are so many girls in the fuckpit who will do anything for her if she'll only spank them.
+		<<set $slaves[_i].fetishStrength += 4>>
 	<<else>>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;becomes a bit of a sadist@@ after she notices that so many of her fellow fucktoys cum harder if she gives them a good slap.
-		<<set $slaves[$i].fetish to "sadist">>
-		<<set $slaves[$i].fetishStrength = 65>>
+		@@color:lightcoral;becomes a bit of a sadist@@ after she notices that so many of her fellow fucktoys cum harder if she gives them a good slap.
+		<<set $slaves[_i].fetish to "sadist", $slaves[_i].fetishStrength = 65>>
 	<</if>>
 	<<elseif ($masterSuiteAverageSadism > 50) && ($fetishChangeChance > random(0,50))>>
-	<<if $slaves[$i].fetish is "masochist">>
-		<<if $verboseDescriptions == 1>>Her<<else>>$slaves[$i].slaveName's<</if>> @@color:lightcoral;pain addiction deepens,@@ since the fuckpit is full of ladies happy to fuck her while she screams.
-		<<set $slaves[$i].fetishStrength += 4>>
+	<<if $slaves[_i].fetish is "masochist">>
+		<<if $verboseDescriptions == 1>>Her<<else>>$slaves[_i].slaveName's<</if>> @@color:lightcoral;pain addiction deepens,@@ since the fuckpit is full of ladies happy to fuck her while she screams.
+		<<set $slaves[_i].fetishStrength += 4>>
 	<<else>>
-		<<if $verboseDescriptions == 1>>She<<else>>$slaves[$i].slaveName<</if>> @@color:lightcoral;learns masochism@@ after experiencing many orgasms under the exquisite sexual torture of the sadists in the fuckpit.
-		<<set $slaves[$i].fetish to "masochist">>
-		<<set $slaves[$i].fetishStrength = 65>>
+		<<if $verboseDescriptions == 1>>She<<else>>$slaves[_i].slaveName<</if>> @@color:lightcoral;learns masochism@@ after experiencing many orgasms under the exquisite sexual torture of the sadists in the fuckpit.
+		<<set $slaves[_i].fetish to "masochist", $slaves[_i].fetishStrength = 65>>
 	<</if>>
 	<</if>>
-<</if>>
-<</if>>
 <</if>>
 <</if>>
 
@@ -271,50 +260,51 @@ The level of sexual energy in the suite is
 	<<display "SA rivalries">>
 	<</silently>>
 <</if>>
-<<if $slaves[$i].health < 80>>
+<<if $slaves[_i].health < 80>>
 	<<if $masterSuiteUpgradeLuxury == 1>>
-	<<set $slaves[$i].health += 20>>
+	<<set $slaves[_i].health += 20>>
 	<<else>>
-	<<set $slaves[$i].health += 10>>
+	<<set $slaves[_i].health += 10>>
 	<</if>>
 <</if>>
 
 <<if $masterSuiteUpgradePregnancy == 1>>
 	/* If they're not on fertility drugs and the toggle is active, stick them on (if they can take them). Otherwise take them off. */
-	<<if ($masterSuitePregnancyFertilityDrugs == 1) && ($slaves[$i].drugs != "fertility drugs") && (($slaves[$i].preg > -2) && ($slaves[$i].ovaries > 0)) and $slaves[$i].assignment is "serve in the master suite">>
-	<<elseif ($masterSuitePregnancyFertilityDrugs == 0) && ($slaves[$i].drugs is "fertility drugs") and $slaves[$i].assignment is "serve in the master suite">>
-	<<set $slaves[$i].drugs to "no drugs">>
+	<<if ($masterSuitePregnancyFertilityDrugs == 1) && ($slaves[_i].drugs != "fertility drugs") && (($slaves[_i].preg > -2) && ($slaves[_i].ovaries > 0)) and $slaves[_i].assignment is "serve in the master suite">>
+		<<set $slaves[_i].drugs = "fertility drugs">>
+	<<elseif ($masterSuitePregnancyFertilityDrugs == 0) && ($slaves[_i].drugs is "fertility drugs") and $slaves[_i].assignment is "serve in the master suite">>
+		<<set $slaves[_i].drugs to "no drugs">>
 	<</if>>
 	/* We don't know they're pregnant for a month or so by game logic */
-	<<if ($slaves[$i].preg >= 4)>>
+	<<if ($slaves[_i].preg >= 4)>>
 	/* Once we know they're knocked up, get the counter going. */
 	<<set $masterSuitePregnantSlaves += 1>>
 	/* Don't know about twins/triplets etc until 10 weeks. Once we do, get the counter going */
-	<<if ($slaves[$i].pregType > 1) && ($slaves[$i].preg >= 10)>>
+	<<if ($slaves[_i].pregType > 1) && ($slaves[_i].preg >= 10)>>
 		<<set $masterSuitePregnantSlavesMultiple += 1>>
 	<</if>>
 	/* If they're preggo and in the upgraded suite, give them extra devotion. More if they're being given lighter duties. */
-	<<if ($slaves[$i].devotion <= 100)>>
+	<<if ($slaves[_i].devotion <= 100)>>
 	<<if ($masterSuitePregnancySlaveLuxuries == 0)>>
-		<<set $slaves[$i].devotion += 2>>
+		<<set $slaves[_i].devotion += 2>>
 	<<else>>
-		<<set $slaves[$i].devotion += 5>>
+		<<set $slaves[_i].devotion += 5>>
 	<</if>>
 	<</if>>
 	/* If they're preggo and in the upgraded suite, give them extra trust. More if they're being given lighter duties. */
-	<<if ($slaves[$i].trust <= 100)>>
+	<<if ($slaves[_i].trust <= 100)>>
 	<<if ($masterSuitePregnancySlaveLuxuries == 0)>>
-		<<set $slaves[$i].trust += 2>>
+		<<set $slaves[_i].trust += 2>>
 	<<else>>
-		<<set $slaves[$i].trust += 5>>
+		<<set $slaves[_i].trust += 5>>
 	<</if>>
 	<</if>>
 	/* If they're preggo and in the upgraded suite, give them extra health. More if they're being given lighter duties. */
-	<<if ($slaves[$i].health < 100)>>
-	<<if ($slaves[$i].health < 100) && ($masterSuitePregnancySlaveLuxuries == 0)>>
-		<<set $slaves[$i].health += 15>>
+	<<if ($slaves[_i].health < 100)>>
+	<<if ($masterSuitePregnancySlaveLuxuries == 0)>>
+		<<set $slaves[_i].health += 15>>
 	<<else>>
-		<<set $slaves[$i].health += 25>>
+		<<set $slaves[_i].health += 25>>
 	<</if>>
 	<</if>>
 	<</if>>
@@ -322,6 +312,10 @@ The level of sexual energy in the suite is
 
 <</if>>
 <</for>>
+
+<<if _CCB != -1>>
+	<<set $Concubine = $slaves[_CCB]>>
+<</if>>
 
 <<if $masterSuiteDecoration != "standard">>
 	<br><br>

--- a/src/uncategorized/masterSuiteReport.tw
+++ b/src/uncategorized/masterSuiteReport.tw
@@ -2,26 +2,26 @@
 
 ''Master Suite Report''<hr style="margin:0">
 
-<<set $legendaryAbolitionistID = 0, $masterSuiteAverageEnergy = 0, $masterSuiteSlaves = 0, _masterSuiteAverageCum = 0, _masterSuiteAverageDick = 0, _masterSuiteAverageDom = 0, _masterSuiteAverageMilk = 0, _masterSuiteAveragePreg = 0, _masterSuiteAverageSadism = 0, _masterSuitePregnantSlaves = 0, _SL = $slaves.length, _CCB = -1>>
+<<set $legendaryAbolitionistID = 0, $masterSuiteAverageEnergy = 0, $masterSuiteSlaves = 0, _masterSuiteAverageCum = 0, _masterSuiteAverageDick = 0, _masterSuiteAverageDom = 0, _masterSuiteAverageMilk = 0, _masterSuiteAveragePreg = 0, _masterSuiteAverageSadism = 0, _masterSuitePregnantSlaves = 0, _masterSuitePregnantSlavesMultiple = 0, _SL = $slaves.length, _CCB = -1>>
 
-<<for _i to 0; _i < _SL; _i++>>
+<<for _i = 0; _i < _SL; _i++>>
 <<if ($slaves[_i].assignment is "serve in the master suite") || ($slaves[_i].assignment is "be your Concubine")>>
 	<<if $seeImages == 1>><<SlaveArt $slaves[_i] 0 0>><</if>>
 	<<set $masterSuiteSlaves += 1, $masterSuiteAverageEnergy += $slaves[_i].energy>>
 	<<if $masterSuiteUpgradeLuxury == 2>>
 	<<if canAchieveErection($slaves[_i])>>
-		<<set $masterSuiteAverageCum += $slaves[_i].balls, $masterSuiteAverageDick += $slaves[_i].dick>>
+		<<set _masterSuiteAverageCum += $slaves[_i].balls, _masterSuiteAverageDick += $slaves[_i].dick>>
 	<</if>>
-	<<set $masterSuiteAverageMilk += $slaves[_i].lactation*($slaves[_i].boobs-$slaves[_i].boobsImplant)>>
-	<<set $masterSuiteAveragePreg += $slaves[_i].preg>>
+	<<set _masterSuiteAverageMilk += $slaves[_i].lactation*($slaves[_i].boobs-$slaves[_i].boobsImplant)>>
+	<<set _masterSuiteAveragePreg += $slaves[_i].preg>>
 	<<if $slaves[_i].fetish is "dom">>
-		<<set $masterSuiteAverageDom += $slaves[_i].fetishStrength>>
+		<<set _masterSuiteAverageDom += $slaves[_i].fetishStrength>>
 	<<elseif $slaves[_i].fetish is "submissive">>
-		<<set $masterSuiteAverageDom -= $slaves[_i].fetishStrength>>
+		<<set _masterSuiteAverageDom -= $slaves[_i].fetishStrength>>
 	<<elseif $slaves[_i].fetish is "sadist">>
-		<<set $masterSuiteAverageSadism += $slaves[_i].fetishStrength>>
+		<<set _masterSuiteAverageSadism += $slaves[_i].fetishStrength>>
 	<<elseif $slaves[_i].fetish is "masochist">>
-		<<set $masterSuiteAverageSadism -= $slaves[_i].fetishStrength>>
+		<<set _masterSuiteAverageSadism -= $slaves[_i].fetishStrength>>
 	<</if>>
 	<</if>>
 	<<if ($legendaryAbolitionistID == 0) && ($slaves[_i].devotion > 95) && ($slaves[_i].prestige == 0)>>
@@ -35,12 +35,12 @@
 <<if ($masterSuiteSlaves > 0)>>
 
 <<set $masterSuiteAverageEnergy to $masterSuiteAverageEnergy/$masterSuiteSlaves>>
-<<set $masterSuiteAverageMilk to $masterSuiteAverageMilk/$masterSuiteSlaves>>
-<<set $masterSuiteAverageCum to $masterSuiteAverageCum/$masterSuiteSlaves>>
-<<set $masterSuiteAverageDick to $masterSuiteAverageDick/$masterSuiteSlaves>>
-<<set $masterSuiteAveragePreg to $masterSuiteAveragePreg/$masterSuiteSlaves>>
-<<set $masterSuiteAverageDom to $masterSuiteAverageDom/$masterSuiteSlaves>>
-<<set $masterSuiteAverageSadism to $masterSuiteAverageSadism/$masterSuiteSlaves>>
+<<set _masterSuiteAverageMilk to _masterSuiteAverageMilk/$masterSuiteSlaves>>
+<<set _masterSuiteAverageCum to _masterSuiteAverageCum/$masterSuiteSlaves>>
+<<set _masterSuiteAverageDick to _masterSuiteAverageDick/$masterSuiteSlaves>>
+<<set _masterSuiteAveragePreg to _masterSuiteAveragePreg/$masterSuiteSlaves>>
+<<set _masterSuiteAverageDom to _masterSuiteAverageDom/$masterSuiteSlaves>>
+<<set _masterSuiteAverageSadism to _masterSuiteAverageSadism/$masterSuiteSlaves>>
 
 <<if $seeImages == 1>><br style="clear:both" /><</if>>
 ''There <<if ($masterSuiteSlaves == 1)>>is one slave<<else>>are $masterSuiteSlaves slaves<</if>>
@@ -50,7 +50,7 @@ seeing to your pleasure in the master suite.'' Such sexual opulence @@color:gree
 	<<set $repGain += 0.2*$masterSuiteSlaves*$FSSingleSlaveRep*($arcologies[0].FSEgyptianRevivalist/$FSLockinLevel)>>
 	<<set $arcologies[0].FSEgyptianRevivalist += 0.01*$masterSuiteSlaves*$FSSingleSlaveRep>>
 <</if>>
-<<if ($masterSuitePregnantSlaves >= 1)>>
+<<if (_masterSuitePregnantSlaves >= 1)>>
 	The suite is supporting the pregnancies of the slaves
 	<<if ($masterSuitePregnancyFertilityDrugs == 1)>>
 		within, and is providing them with fertility drugs
@@ -81,10 +81,10 @@ The level of sexual energy in the suite is
 	<<else>>
 	relatively normal; the girls lounging in the fuckpit get each other off when they feel like it.
 	<</if>>
-	<<if $masterSuiteAverageCum > 4>>
+	<<if _masterSuiteAverageCum > 4>>
 	Unless it's right after an automated cleaning, everything in the fuckpit is spattered with cum.
 	<</if>>
-	<<if $masterSuiteAverageMilk > 4000>>
+	<<if _masterSuiteAverageMilk > 4000>>
 	There's so much lactation going on that the lowest level of the fuckpit is a pool of milk.
 	<</if>>
 <<else>>
@@ -92,7 +92,7 @@ The level of sexual energy in the suite is
 <</if>>
 <</if>>
 
-<<for _i to 0; _i < _SL; _i++>>
+<<for _i = 0; _i < _SL; _i++>>
 <<if ($slaves[_i].assignment is "serve in the master suite") || ($slaves[_i].assignment is "be your Concubine")>>
 <<set $i = _i>>
 <<silently>><<display "SA please you">><</silently>>
@@ -173,7 +173,7 @@ The level of sexual energy in the suite is
 		<<set _Verb = $slaves[_i].slaveName>>
 	<</if>>
 	<<fetishChangeChance $slaves[_i]>>
-	<<if ($masterSuiteAverageMilk > 2000) && ($fetishChangeChance > random(0,50))>>
+	<<if (_masterSuiteAverageMilk > 2000) && ($fetishChangeChance > random(0,50))>>
 	<<if $slaves[_i].fetish is "boobs">>
 		<<if $verboseDescriptions == 1>>Her<<else>>$slaves[_i].slaveName's<</if>> @@color:lightcoral;boob fetish is strengthened@@ by the constant availability of milky nipples for her to play with.
 		<<set $slaves[_i].fetishStrength += 4>>
@@ -181,7 +181,7 @@ The level of sexual energy in the suite is
 		<<if $verboseDescriptions == 1>>She<<else>>$slaves[_i].slaveName<</if>> @@color:lightcoral;acquires a boob fetish@@ after spending a lot of time in the fuckpit drinking from her fellow fucktoys' tits.
 		<<set $slaves[_i].fetish to "boobs", $slaves[_i].fetishStrength = 65>>
 	<</if>>
-	<<elseif ($masterSuiteAverageDick > 3) && ($slaves[_i].anus > 0) && ($fetishChangeChance > random(0,50))>>
+	<<elseif (_masterSuiteAverageDick > 3) && ($slaves[_i].anus > 0) && ($fetishChangeChance > random(0,50))>>
 	_Verb
 	<<if $slaves[_i].fetish is "buttslut">>
 		@@color:lightcoral;sinks farther into anal pleasure,@@ since she spends her time in the fuckpit with at least one of the many available cocks up her butt.
@@ -190,7 +190,7 @@ The level of sexual energy in the suite is
 		@@color:lightcoral;acquires an anal fetish@@ after helplessly orgasming at the mercy of your many fucktoys eager to shove their big stiff penises up her ass.
 		<<set $slaves[_i].fetish to "buttslut", $slaves[_i].fetishStrength = 65>>
 	<</if>>
-	<<elseif ($masterSuiteAverageCum > 3) && ($fetishChangeChance > random(0,50))>>
+	<<elseif (_masterSuiteAverageCum > 3) && ($fetishChangeChance > random(0,50))>>
 	_Verb
 	<<if $slaves[_i].fetish is "cumslut">>
 		@@color:lightcoral;sinks farther into cum addiction,@@ since she spends her time in the fuckpit eagerly sucking down ejaculate, straight from the many sources.
@@ -199,7 +199,7 @@ The level of sexual energy in the suite is
 		@@color:lightcoral;acquires an oral fixation@@ after orally servicing your many fucktoys eager to blow their loads down her throat.
 		<<set $slaves[_i].fetish to "cumslut", $slaves[_i].fetishStrength = 65>>
 	<</if>>
-	<<elseif ($masterSuiteAveragePreg > 10) && ($fetishChangeChance > random(0,50))>>
+	<<elseif (_masterSuiteAveragePreg > 10) && ($fetishChangeChance > random(0,50))>>
 	_Verb
 	<<if $slaves[_i].fetish is "pregnancy">>
 		@@color:lightcoral;sinks farther into pregnancy obession,@@ since she never wants for a pregnant girl to make love to.
@@ -208,7 +208,7 @@ The level of sexual energy in the suite is
 		@@color:lightcoral;acquires an pregnancy fetish,@@ since many of her sexual partners in the fuckpit are heavily pregnant.
 		<<set $slaves[_i].fetish to "pregnancy", $slaves[_i].fetishStrength = 65>>
 	<</if>>
-	<<elseif ($masterSuiteAverageDom < 50) && ($fetishChangeChance > random(0,50))>>
+	<<elseif (_masterSuiteAverageDom < 50) && ($fetishChangeChance > random(0,50))>>
 	_Verb
 	<<if $slaves[_i].fetish is "dom">>
 		@@color:lightcoral;becomes more dominant,@@ since there are so many subs in the fuckpit who beg her to fuck them hard.
@@ -217,7 +217,7 @@ The level of sexual energy in the suite is
 		@@color:lightcoral;becomes sexually dominant@@ after having fun satisfying the many submissive fucktoys in the fuckpit who beg her to top them.
 		<<set $slaves[_i].fetish to "dom", $slaves[_i].fetishStrength = 65>>
 	<</if>>
-	<<elseif ($masterSuiteAverageDom > 50) && ($fetishChangeChance > random(0,50))>>
+	<<elseif (_masterSuiteAverageDom > 50) && ($fetishChangeChance > random(0,50))>>
 	_Verb
 	<<if $slaves[_i].fetish is "submissive">>
 		@@color:lightcoral;becomes even more submissive,@@ since there are so many doms in the fuckpit that she's often used by more than one at once.
@@ -226,7 +226,7 @@ The level of sexual energy in the suite is
 		@@color:lightcoral;becomes sexually submissive@@ after the many dominant slaves in the fuckpit hold her down and use her for their pleasure.
 		<<set $slaves[_i].fetish to "sub", $slaves[_i].fetishStrength = 65>>
 	<</if>>
-	<<elseif ($masterSuiteAverageSadism < 50) && ($fetishChangeChance > random(0,50))>>
+	<<elseif (_masterSuiteAverageSadism < 50) && ($fetishChangeChance > random(0,50))>>
 	_Verb
 	<<if $slaves[_i].fetish is "sadist">>
 		@@color:lightcoral;becomes more sadistic,@@ since there are so many girls in the fuckpit who will do anything for her if she'll only spank them.
@@ -235,7 +235,7 @@ The level of sexual energy in the suite is
 		@@color:lightcoral;becomes a bit of a sadist@@ after she notices that so many of her fellow fucktoys cum harder if she gives them a good slap.
 		<<set $slaves[_i].fetish to "sadist", $slaves[_i].fetishStrength = 65>>
 	<</if>>
-	<<elseif ($masterSuiteAverageSadism > 50) && ($fetishChangeChance > random(0,50))>>
+	<<elseif (_masterSuiteAverageSadism > 50) && ($fetishChangeChance > random(0,50))>>
 	<<if $slaves[_i].fetish is "masochist">>
 		<<if $verboseDescriptions == 1>>Her<<else>>$slaves[_i].slaveName's<</if>> @@color:lightcoral;pain addiction deepens,@@ since the fuckpit is full of ladies happy to fuck her while she screams.
 		<<set $slaves[_i].fetishStrength += 4>>
@@ -250,12 +250,32 @@ The level of sexual energy in the suite is
 <</if>>
 
 <<if $verboseDescriptions == 1>>
+	<<if $slaves[_i].choosesOwnClothes == 1>>
+	<<display "SA chooses own clothes">>
+	<<if ($slaves[_i].devotion <= 20)>>
+		<<set $slaves[_i].devotion -= 5>>
+	<<else>>
+		<<set $slaves[_i].devotion += 1>>
+	<</if>>
+	<</if>>
+	<<display "SA diet">>
 	<<display "SA long term effects">>
+	<<display "SA drugs">>
 	<<display "SA relationships">>
 	<<display "SA rivalries">>
 <<else>>
 	<<silently>>
+	<<if $slaves[_i].choosesOwnClothes == 1>>
+	<<display "SA chooses own clothes">>
+	<<if ($slaves[_i].devotion <= 20)>>
+		<<set $slaves[_i].devotion -= 5>>
+	<<else>>
+		<<set $slaves[_i].devotion += 1>>
+	<</if>>
+	<</if>>
+	<<display "SA diet">>
 	<<display "SA long term effects">>
+	<<display "SA drugs">>
 	<<display "SA relationships">>
 	<<display "SA rivalries">>
 	<</silently>>
@@ -278,10 +298,10 @@ The level of sexual energy in the suite is
 	/* We don't know they're pregnant for a month or so by game logic */
 	<<if ($slaves[_i].preg >= 4)>>
 	/* Once we know they're knocked up, get the counter going. */
-	<<set $masterSuitePregnantSlaves += 1>>
+	<<set _masterSuitePregnantSlaves += 1>>
 	/* Don't know about twins/triplets etc until 10 weeks. Once we do, get the counter going */
 	<<if ($slaves[_i].pregType > 1) && ($slaves[_i].preg >= 10)>>
-		<<set $masterSuitePregnantSlavesMultiple += 1>>
+		<<set _masterSuitePregnantSlavesMultiple += 1>>
 	<</if>>
 	/* If they're preggo and in the upgraded suite, give them extra devotion. More if they're being given lighter duties. */
 	<<if ($slaves[_i].devotion <= 100)>>


### PR DESCRIPTION
Synced the $Concubine vars with her $slaves[] var.
On line 274 added what appears to be a missing <<set>> for drugs. <<set $slaves[_i].drugs = "fertility drugs">>
On lines 54 to 64 fixed tests for displaying text about fertility drugs and supplements.

More vars changed over to _temps; _masterSuiteAverageCum, _masterSuiteAverageDick, _masterSuiteAverageDom, _masterSuiteAverageMilk, _masterSuiteAveragePreg, _masterSuiteAverageSadism, _masterSuitePregnantSlaves. The ones that are in mastersuite.tw can also be made into _temps and are unaffected by these ones.