### PR TITLE
Accordion hotfix

### DIFF
--- a/src/events/intro/introSummary.tw
+++ b/src/events/intro/introSummary.tw
@@ -163,9 +163,9 @@ of the slave girls will have dicks.
 <br />
 	Accordion effects on weekly reports are 
 <<if $useAccordion == 0>>
-	@@color:red;DISABLED@@. [[Enable|Options][$useAccordion to 1]]
+	@@color:red;DISABLED@@. [[Enable|Intro Summary][$useAccordion to 1]]
 <<else>>
-	@@color:cyan;ENABLED@@. [[Disable|Options][$useAccordion to 0]]
+	@@color:cyan;ENABLED@@. [[Disable|Intro Summary][$useAccordion to 0]]
 <</if>>
 /* Accordion 000-250-006 */
 

--- a/src/js/accordionJS.tw
+++ b/src/js/accordionJS.tw
@@ -15,11 +15,19 @@
 */
 
 postdisplay["doAccordionSet"] = function (content) {
+<<<<<<< Updated upstream
     if (variables().useAccordion === 1) {
         Array.prototype.slice.call(document.querySelectorAll(".macro-display"))
             .forEach(function (element) {
                 element.classList.add("accHidden");
             });
+=======
+    if (variables().useAccordion == 1) {
+        Array.prototype.slice.call(document.querySelectorAll('.macro-include'))
+        .forEach(function(element) {
+            element.classList.add('accHidden');
+        });
+>>>>>>> Stashed changes
     }
 }
 


### PR DESCRIPTION
Changed JS to use new sugarcube method

intro screen summary button now goes to the right place