### PR TITLE
WIP (no version number/release schedule)

### DIFF
--- a/src/init/storyInit.tw
+++ b/src/init/storyInit.tw
@@ -839,6 +839,7 @@
 <<set $AnalDiscouragement = 0>>
 <<set $CashForRep = 0>>
 <<set $RepForCash = 0>>
+<<set $RegularParties = 1>>
 <<set $PAPublic = 0>>
 <<set $CoursingAssociation = 0>>
 	<<set $Lurcher = 0>>
@@ -1131,9 +1132,11 @@
 <<set $ArcologyNamesSupremacistBlack = ["United Africa", "Benin"]>>
 <<set $ArcologyNamesSupremacistIndoAryan = ["Swarga Loka", "New New Delhi"]>>
 <<set $ArcologyNamesSupremacistPacificIslander = ["Maui", "Rapa Nui"]>>
+<<set $ArcologyNamesSupremacistMalay = ["Brunei", "Patani"]>>
 <<set $ArcologyNamesSupremacistAmerindian = ["Cahokia", "The Confederated Tribes"]>>
 <<set $ArcologyNamesSupremacistSouthernEuropean = ["New Athens", "Olympus"]>>
 <<set $ArcologyNamesSupremacistSemitic = ["The Fifth Temple", "The Promised Land"]>>
+<<set $ArcologyNamesSupremacistMixedRace = ["Hybrid Vigor", "Meltingpot"]>>
 <<set $ArcologyNamesSubjugationistWhite = ["The World Turned Upside Down", "Anticolonialism One"]>>
 <<set $ArcologyNamesSubjugationistAsian = ["The East India Company", "Pearl of the Orient"]>>
 <<set $ArcologyNamesSubjugationistLatina = ["Fort Veracruz", "The Halls of Montezuma"]>>
@@ -1141,9 +1144,11 @@
 <<set $ArcologyNamesSubjugationistBlack = ["Dixie", "The Plantation"]>>
 <<set $ArcologyNamesSubjugationistIndoAryan = ["The East India Company", "Trade Fort"]>>
 <<set $ArcologyNamesSubjugationistPacificIslander = ["Cargo Cult", "Moro Castle"]>>
+<<set $ArcologyNamesSubjugationistMalay = ["Pulo Prabang", "Eastern Emporium"]>>
 <<set $ArcologyNamesSubjugationistAmerindian = ["Fort Laramie", "The Rez"]>>
 <<set $ArcologyNamesSubjugationistSouthernEuropean = ["Istanbul", "Al-Andalus"]>>
 <<set $ArcologyNamesSubjugationistSemitic = ["Solomon's Lament", "New Canaan"]>>
+<<set $ArcologyNamesSubjugationistMixedRace = ["Purity", "Bloodlines"]>>
 <<set $ArcologyNamesGenderRadicalist = ["Saturnalia", "Bacchanalia", "Gomorrah", "Sodom", "The Rosebud"]>>
 <<set $ArcologyNamesGenderFundamentalist = ["The Arbor", "The Rose", "The Source"]>>
 <<set $ArcologyNamesPaternalist = ["Sanctum", "Asylum", "Sanctuary", "Haven", "New Springfield", "The Sanctuary", "Glory"]>>

--- a/src/npc/takeoverTarget.tw
+++ b/src/npc/takeoverTarget.tw
@@ -20,7 +20,7 @@ Alternatively, arcologies are being built every day, and their owners' control i
 <<if $seeExtreme != 0>><<set _arcologyTypes.push("Degradationist")>><</if>>
 <<set _terrainTypes = ["urban", "urban", "rural", "rural", "rural", "marine", "marine", "oceanic"]>>
 <<set _continents = ["North America", "North America", "South America", "Europe", "Europe", "the Middle East", "Africa", "Asia", "Asia", "Australia"]>>
-<<set _races = ["white", "asian", "latina", "middle eastern", "indo-aryan", "pacific islander", "amerindian", "southern european", "semitic"]>>
+<<set _races = ["white", "asian", "latina", "middle eastern", "indo-aryan", "pacific islander", "malay", "amerindian", "southern european", "semitic", "mixed race"]>>
 <<set _targetArcologies = []>>
 <<set _targets = 4>>
 <<if $PC.career == "arcology owner">><<set _targets += 2>><</if>>
@@ -45,6 +45,8 @@ Alternatively, arcologies are being built every day, and their owners' control i
 			<<set $targetArcology.name to $ArcologyNamesSupremacistIndoAryan.random()>>
 		<<case "pacific islander">>
 			<<set $targetArcology.name to $ArcologyNamesSupremacistPacificIslander.random()>>
+		<<case "malay">>
+			<<set $targetArcology.name to $ArcologyNamesSupremacistMalay.random()>>
 		<<case "amerindian">>
 			<<set $targetArcology.name to $ArcologyNamesSupremacistAmerindian.random()>>
 		<<case "southern european">>
@@ -52,7 +54,7 @@ Alternatively, arcologies are being built every day, and their owners' control i
 		<<case "semitic">>
 			<<set $targetArcology.name to $ArcologyNamesSupremacistSemitic.random()>>
 		<<default>>
-			<<set $targetArcology.name to "Arcology X-4">>
+			<<set $targetArcology.name to $ArcologyNamesSupremacistMixedRace.random()>>
 		<</switch>>
 	<<case "Subjugationist">>
 		<<set $targetArcology.race = _races.random()>>
@@ -71,14 +73,16 @@ Alternatively, arcologies are being built every day, and their owners' control i
 			<<set $targetArcology.name to $ArcologyNamesSubjugationistIndoAryan.random()>>
 		<<case "pacific islander">>
 			<<set $targetArcology.name to $ArcologyNamesSubjugationistPacificIslander.random()>>
+		<<case "malay">>
+			<<set $targetArcology.name to $ArcologyNamesSubjugationistMalay.random()>>
 		<<case "amerindian">>
 			<<set $targetArcology.name to $ArcologyNamesSubjugationistAmerindian.random()>>
 		<<case "southern european">>
 			<<set $targetArcology.name to $ArcologyNamesSubjugationistSouthernEuropean.random()>>
 		<<case "semitic">>
-			<<set $targetArcology.name to $ArcologyNamesSubjugationistSemitic.random()>>
+			<<set $targetArcology.name to $ArcologyNamesSubjugationistSemitic.random()>>\
 		<<default>>
-			<<set $targetArcology.name to "Arcology X-4">>
+			<<set $targetArcology.name to $ArcologyNamesSubjugationistMixedRace.random()>>
 		<</switch>>
 	<<case "GenderRadicalist">><<set $targetArcology.name to $ArcologyNamesGenderRadicalist.random()>>
 	<<case "GenderFundamentalist">><<set $targetArcology.name to $ArcologyNamesGenderFundamentalist.random()>>

--- a/src/uncategorized/RESSTR.tw
+++ b/src/uncategorized/RESSTR.tw
@@ -42,6 +42,12 @@ You're nude, a consequence of <<if $Concubine != 0>>recent activities involving 
 <<if $activeSlave.vaginalLube > 0>>Her wet cunt is already lubricating itself generously for you, slicking her labia with female arousal.<</if>>
 The slutty $desc wants it badly.
 
+<<case "arcade sadist">>
+
+You happen to come across <span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink to passage(), $eventDescription to 1]]">></span> during one of her rest periods. She's lying on a couch in the slave areas, staring at the ceiling above her with a dreamy expression on her face. She's <<if $activeSlave.releaseRules == "permissive">>touching herself idly.<<else>>not allowed to touch herself, but she's extremely aroused.<</if>> Whatever's on her mind, it's so absorbing that she doesn't realize you're there until you're standing over her.
+<br><br>
+"<<S>>orry, <<Master>>," she <<say>>s apologetically, scrambling to her feet. "I didn't noti<<c>>e you there." Seeing your questioning look, she explains herself further. "I was ju<<s>>t thinking about, um, my favorite pla<<c>>e. I can almo<<s>>t get off ju<<s>>t by thinking about it." There's a wild, perverted gleam in her $activeSlave.eyeColor eyes. She's a confirmed sadist, so whatever her favorite mental masturbation is probably quite strong.
+
 <<default>>
 	ERROR: bad event
 <</switch>>
@@ -168,6 +174,97 @@ The slutty $desc wants it badly.
 		You command her to turn around and show you her ass. She obeys eagerly, spinning and bringing you face to face with her <<if $activeSlave.butt > 5>>monstrous bottom<<elseif $activeSlave.butt > 2>>womanly butt<<else>>cute little rear end<</if>>. She's expecting something sexy, and she's wrong. You give her right asscheek a stinging, open-handed slap. It's so unexpected that she jumps with surprise, takes a step forward, and instantly bursts into tears. Knowing that she has to accept whatever you think she deserves, she takes a step back towards you to come back within range. <<if canTalk($activeSlave)>>"<<Master>>, I'm <<s>>-<<s>>orry," she sobs. "I d-don't understand. What did I d-do?"<<else>>She shakily gestures a question, begging to know what she did.<</if>> You tell her not to disturb you when you're working, tanning her ass viciously, first one buttock and then the other. She stands there and takes her beating, weeping, more from the @@color:gold;bitter disappointment that she's not allowed to approach you@@ like that.
 	<</replace>>
 	<<set $activeSlave.trust -= 5>>
+<</link>>
+
+<<case "arcade sadist">>
+
+<br><<link "Ask her about her fantasy">>
+	<<replace "#name">>$activeSlave.slaveName<</replace>>
+	<<replace "#result">>
+		<<set _pussy = false>>
+		<<for $i to 0; $i < $slaves.length; $i++>>
+		<<if $slaves[$i].assignment == "be confined in the arcade">>
+		<<if $slaves[$i].vagina > 0>>
+			<<set _pussy = true>><<break>>
+		<</if>>
+		<</if>>
+		<</for>>
+		<<set _balls = false>>
+		<<for $i to 0; $i < $slaves.length; $i++>>
+		<<if $slaves[$i].assignment == "be confined in the arcade">>
+		<<if $slaves[$i].balls > 0>>
+			<<set _balls = true>><<break>>
+		<</if>>
+		<</if>>
+		<</for>>
+		You order her to explain further. "<<Master>>," she <<say>>s carefully, "it'<<s>> $arcadeName. There'<<s>> a <<s>>pe<<c>>ific pla<<c>>e there, and, well, I can't de<<s>>cribe it. It'<<s>> in the <<s>>ervi<<c>>e area under $arcadeName. Can I show you what I mean?" Intrigued, you order her to show you the place she's talking about, and lead her to $arcadeName through the access hallway. She points to the service tunnel under one of the rows of inmates, which allows trusted slaves to clean up and perform maintenance. Once you've led her in there, she stops and watches. Inside the industrial access corridor, above you both is a row of bodies. The slaves' faces and hips are pressed against the aperatures that present their holes to customers, but the rest of them is visible from here.
+		<br><br>
+		There is little noise; the slaves are closely restrained. Indeed, you have to look closely to see that they're being fucked at all. Here and there, though, there are signs. When someone fucks a slave's face, her throat bulges, and she often gags and struggles a little within the restraints. When their <<if _pussy>>pussies<<else>>assholes<</if>> get fucked, there's also some involuntary struggling, and if the phallus being thrust into them is particularly large, a rhythmic bulging of their abdomens can be discerned.
+		<<if $arcadeUpgradeInjectors == 1>>
+			The quiet hissing of the drug injectors adds a menacing undertone, and the bodies frequently jerk as electrostimulation is applied to force them to tighten their holes.
+		<</if>>
+		<<if $arcadeUpgradeCollectors == 1>>
+			The pumping collectors attached to the slaves' breasts<<if _dick>> and cocks<</if>> carry the white fluid away to be processed elsewhere.
+		<</if>>
+		The overall effect is subtle, but powerful. There's a sense of total servitude, overlaid with a certain feeling, or perhaps even a scent, of mindless despair. There's no wonder $activeSlave.slaveName likes it; there's an infinite supply of uncomplicated human anguish here.
+		<br><br>
+		<span id="result2">
+			<<link "Fuck her here">>
+				<<replace "#result2">>
+					You reach out for $activeSlave.slaveName, not taking your eyes off the mesmerizing sight above. She's enjoying the spectacle too, and is so aroused that your rough handling of her breasts almost brings her to an immediate orgasm. Pinching her $activeSlave.nipples nipples to stop her from getting off too soon, you
+					<<if $PC.dick == 0>>
+						hug her to your chest and start playing with her pussy, commanding her to reach around and do the same for you.
+						<<set $activeSlave.oralCount++, $oralTotal++>>
+					<<elseif canDoVaginal($activeSlave) && ($activeSlave.vagina > 0)>>
+						pull her up to the right height and slide your dick inside her, keeping both of you on your feet so you can take her standing.
+						<<set $activeSlave.vaginalCount++, $vaginalTotal++>>
+					<<elseif canDoAnal($activeSlave) && ($activeSlave.anus > 0)>>
+						shove your cock roughly up her asshole, letting her struggle a little as she finds the right angle to take standing anal here.
+						<<set $activeSlave.analCount++, $analTotal++>>
+					<<else>>
+						slide your stiff prick up between the virgin's thighs for some intercrural sex.
+						<<set $activeSlave.oralCount++, $oralTotal++>>
+					<</if>>
+					As you fuck, her gaze flicks up and down along the row of suffering bodies. She climaxes again and again, shuddering at each new subtle sign that another one of the slaves here is being degraded by yet another cock inserted into yet another of her defenseless holes. By the time you're satisfied, she's so exhausted that her legs are shuddering uncontrollably as she struggles to remain standing with you. You drop her, leaving her to find her own way out of this place. You look back from the entrance, seeing that she's following you on shaky legs, staring at you with a profound look of mixed @@color:mediumaquamarine;trust for your understanding of her horrible sadism,@@ and deep unease that this is what truly gets her off.
+				<</replace>>
+				<<set $activeSlave.trust += 5>>
+			<</link>>
+			<br><<link "Teach her about true sadism">>
+				<<replace "#result2">>
+					She seems to be focusing on the purely physical aspects of the degradation here. The true meaning of this place is so much more, and you decide to share it with her. You call her name, tearing her attention away from the spectacle mere centimeters over your heads, and point to a particular slave. You tell $activeSlave.slaveName that this particular Arcade inmate's name is
+					<<for $i to 0; $i < $slaves.length; $i++>>
+					<<if $slaves[$i].assignment == "be confined in the arcade">>
+						$slaves[$i].slaveName. You tell her that she is $slaves[$i].age years old, that she is $slaves[$i].nationality, and that she was once $slaves[$i].career. You list more details of her life before she was placed here to be fucked endlessly. $activeSlave.slaveName's eyes widen as you recite the details of the prior life of this piece of human sexual equipment and the sheer weight of the intellectual sadism smashes into her. Then the slave above you both jerks a little. <<if $activeSlave.dick == 0>>There's no visible sign her pussy's being fucked, so it must be<<else>>Her cock hardens involuntarily, indicating that it's<</if>> going into her ass. You resume, mentioning that she's been buttfucked $slaves[$i].slaveName times.
+						<<break>>
+					<</if>>
+					<</for>>
+					$activeSlave.slaveName jerks suddenly, <<if canAchieveErection($activeSlave)>>shooting her cum onto the floor<<elseif $activeSlave.vagina < 0>>dribbling a weak ejaculation<<elseif $activeSlave.vaginalLube > 0>>squirting onto the floor<<else>>orgasming<</if>>. She came without being touched. She stares at you helplessly, in the presence of the arcology's @@color:hotpink;undisputed preeminent sadist,@@ shuddering at the sheer gothic glory of it. She has a new moment to think of when she feels like @@color:lightsalmon;indulging her own sadism.@@
+				<</replace>>
+				<<set $activeSlave.devotion += 5, $activeSlave.fetishStrength = Math.clamp($activeSlave.fetishStrength+10, 0, 100)>>
+			<</link>>
+		</span>
+	<</replace>>
+<</link>>
+<br><<link "Just fuck her">>
+	<<replace "#name">>$activeSlave.slaveName<</replace>>
+	<<replace "#result">>
+		You're not particularly interested in what she dreams about when she gets the chance, and you tell her so. Whatever sadistic little fantasies she keeps locked away to bring out when she's got a moment to satiate her perversions is less interesting to you than the prospect of
+		<<if $PC.dick == 0>>
+			her mouth on your cunt. So, you shove her down to sit on the couch and straddle her face, cutting off any further whimsies by pressing your wet pussy against her lips. She eats you out obediently, accepting
+			<<set $activeSlave.oralCount++, $oralTotal++>>
+		<<elseif canDoVaginal($activeSlave) && ($activeSlave.vagina > 0)>>
+			giving it to her. So, you shove her down to sit on the couch, nudge her legs apart, kneel between them, and pound her pussy. You fuck her so hard that she doesn't have the attention for further whimsies, and she accepts
+			<<set $activeSlave.vaginalCount++, $vaginalTotal++>>
+		<<elseif canDoAnal($activeSlave) && ($activeSlave.anus > 0)>>
+			fucking her butt. So, you shove her down to kneel on the couch facing away from you, and ram your cock up her asshole. You assfuck her so hard that she doesn't have the attention for further whimsies, and she accepts
+			<<set $activeSlave.analCount++, $analTotal++>>
+		<<else>>
+			her sucking your dick. So, you shove her down to sit on the couch and give her your cock to keep her mouth occupied, cutting off any further whimsies. She blows you obediently, accepting
+			<<set $activeSlave.oralCount++, $oralTotal++>>
+		<</if>>
+		the implicit message that @@color:hotpink;she's your slut@@ in the real world, whatever thoughts she may find appealing in the privacy of her own mind.
+	<</replace>>
+	<<set $activeSlave.devotion += 3>>
 <</link>>
 
 <<default>>

--- a/src/uncategorized/costs.tw
+++ b/src/uncategorized/costs.tw
@@ -224,6 +224,9 @@
 <<if $alwaysSubsidizeRep == 1>>
 	<<set $costs += $policyCost>>
 <</if>>
+<<if $RegularParties == 1>>
+	<<set $costs += $policyCost>>
+<</if>>
 
 <<if $ProImmigrationCash == 1>>
 	<<set $costs += $policyCost>>

--- a/src/uncategorized/costsReport.tw
+++ b/src/uncategorized/costsReport.tw
@@ -102,6 +102,9 @@
 <<if $alwaysSubsidizeRep == 1>>
 	<br>Weekly self-promotion budget: $policyCost
 <</if>>
+<<if $RegularParties == 1>>
+	<br>Weekly social gatherings: $policyCost
+<</if>>
 
 <<if $ProImmigrationCash == 1>>
 	<br>Pro-immigration promotion budget: $policyCost

--- a/src/uncategorized/degradingName.tw
+++ b/src/uncategorized/degradingName.tw
@@ -21,6 +21,8 @@
 	<<set $prefixes.push("Black", "Dark")>>
 <<elseif ($activeSlave.race is "pacific islander")>>
 	<<set $prefixes.push("Islander", "Sea")>>
+<<elseif ($activeSlave.race is "malay")>>
+	<<set $prefixes.push("Spice", "Cinnamon", "Pinoy")>>
 <<elseif ($activeSlave.race is "southern European")>>
 	<<set $prefixes.push("Mediterranean", "Olive")>>
 <<elseif ($activeSlave.race is "amerindian")>>

--- a/src/uncategorized/economics.tw
+++ b/src/uncategorized/economics.tw
@@ -183,17 +183,25 @@ __Personal Business__
 <<else>>
 	You have enough cash to manage your affairs, but not enough to do much business.
 <</if>>
-<<if ($cash > 1000)>>
-	<<set $seed to random(500,1500)>>
-	<<if $CashForRep == 1>>
-	This week, you gave up business opportunities worth ¤$seed to help deserving citizens, @@color:green;burnishing your reputation.@@
-	<<set $cash -= $seed>>
-	<<set $rep += 100>>
-	<<elseif $RepForCash == 1>>
-	This week, you used your position to secure business opportunities worth ¤$seed at the expense of citizens, @@color:red;damaging your reputation.@@
-	<<set $cash += $seed>>
+<<if $cash > 1000>>
+<<if $CashForRep == 1>>
+	This week you gave up business opportunities worth ¤$policyCost to help deserving citizens, @@color:green;burnishing your reputation.@@
+	<<set $rep += 100, $cash -= $policyCost>>
+<</if>>
+<</if>>
+<<if $rep > 100>>
+<<if $RepForCash == 1>>
+	This week you used your position to secure business opportunities worth ¤$policyCost at the expense of citizens, @@color:red;damaging your reputation.@@
+	<<set $rep -= 100, $cash += $policyCost>>
+<</if>>
+<</if>>
+<<if $rep <= 18000>>
+<<if $rep > 100>>
+<<if $RegularParties != 1>>
+	Your @@color:red;reputation is damaged@@ by your not hosting regular social events for your leading citizens.
 	<<set $rep -= 100>>
-	<</if>>
+<</if>>
+<</if>>
 <</if>>
 
 Routine upkeep of your demesne costs @@color:yellow;¤$costs.@@
@@ -919,116 +927,118 @@ earning you @@color:yellowgreen;¤$seed.@@
 	<</if>>
 <</for>>
 <<if $seed > 0>>
-	Some refugees and other desperate people filtered towards the arcology during the week: as owner, you were able to enslave $seed of them.
+	Some desperate people filtered into the arcology during the week: as owner, you were able to enslave $seed of them.
 	<<set $helots += $seed>>
 <</if>>
 
-<<set $AWeekGrowth to $AGrowth>>
-<<if $AWeekGrowth+$arcologies[0].prosperity > $AProsperityCap>>
-	@@color:yellow;$arcologies[0].name is taxed to capacity by its own prosperity, so your rents will not increase until it is upgraded.@@
-<<elseif (2*$AWeekGrowth)+$arcologies[0].prosperity >= $AProsperityCap>>
-	@@color:yellow;Your arcology is nearly at its maximum prosperity, and your rents will not increase further once it is at maximum capacity.@@
-	<<set $arcologies[0].prosperity += $AWeekGrowth>>
+<<set _AWeekGrowth to $AGrowth>>
+<<if _AWeekGrowth+$arcologies[0].prosperity > $AProsperityCap>>
+	@@color:yellow;$arcologies[0].name is at its maximum prosperity, so rents will not increase until it is upgraded.@@
+<<elseif (2*_AWeekGrowth)+$arcologies[0].prosperity >= $AProsperityCap>>
+	@@color:yellow;Your arcology is nearly at its maximum prosperity.@@
+	<<set $arcologies[0].prosperity += _AWeekGrowth>>
 <<else>>
-	<<if $arcologies[0].ownership >= random(40,100)>>
-		Your controlling interest in $arcologies[0].name allows you to lead it economically, @@color:green;speeding growth.@@
-		<<set $AWeekGrowth += 1>>
+	<<if $arcologies[0].ownership >= 100>>
+		Your controlling interest in $arcologies[0].name allows you to lead it economically, @@color:green;supercharging growth.@@
+		<<set _AWeekGrowth += 3>>
+	<<elseif $arcologies[0].ownership >= random(40,100)>>
+		Your interest in $arcologies[0].name allows you to lead it economically, @@color:green;boosting growth.@@
+		<<set _AWeekGrowth++>>
 	<</if>>
 	<<if $arcologies[0].prosperity < ($rep/100)>>
 		Your impressive reputation relative to $arcologies[0].name's prosperity @@color:green;drives an increase in business.@@
-		<<set $AWeekGrowth += 1>>
+		<<set _AWeekGrowth++>>
 	<<elseif $rep > 18000>>
 	<<elseif $arcologies[0].prosperity > ($rep/60)>>
 		Your low reputation relative to $arcologies[0].name's prosperity @@color:red;seriously impedes business growth.@@
-		<<set $AWeekGrowth -= 2>>
+		<<set _AWeekGrowth -= 2>>
 	<<elseif $arcologies[0].prosperity > ($rep/80)>>
 		Your unimpressive reputation relative to $arcologies[0].name's prosperity @@color:yellow;slows business growth.@@
-		<<set $AWeekGrowth -= 1>>
+		<<set _AWeekGrowth-->>
 	<</if>>
 	<<if $personalAttention is "business">>
 		<<if ($PC.career is "capitalist") || ($PC.career is "arcology owner")>>
-		Your @@color:springgreen;business focus and your experience@@ allows you to greatly assist in advancing the arcology's prosperity.
-		<<set $AWeekGrowth += 2>>
+			Your @@color:springgreen;business focus and your experience@@ allow you to greatly assist in advancing the arcology's prosperity.
+			<<set _AWeekGrowth += 2>>
 		<<else>>
-		Your business focus allows you to help improve the arcology's prosperity.
-		<<set $AWeekGrowth += 1>>
+			Your business focus allows you to help improve the arcology's prosperity.
+			<<set _AWeekGrowth++>>
 		<</if>>
-		<<if $arcologies[0].FSMaturityPreferentialistLaw == 1>>
-		<<if $PC.age is 3>>
-		You are able to leverage your long seniority in the business community using the arcology's favorable laws to further advance prosperity.
-		<<set $AWeekGrowth += 1>>
-		<</if>>
-		<</if>>
-		<<if $arcologies[0].FSYouthPreferentialistLaw == 1>>
-		<<if $PC.age == 1>>
-		You are able to leverage your freshness in the business community using the arcology's favorable laws to further advance prosperity.
-		<<set $AWeekGrowth += 1>>
-		<</if>>
+		<<if $PC.age == 3>>
+			<<if $arcologies[0].FSMaturityPreferentialistLaw == 1>>
+				You are able to leverage your long seniority in the business community using the arcology's favorable laws to further advance prosperity.
+				<<set _AWeekGrowth++>>
+			<</if>>
+		<<elseif $PC.age == 1>>
+			<<if $arcologies[0].FSYouthPreferentialistLaw == 1>>
+				You are able to leverage your freshness in the business community using the arcology's favorable laws to further advance prosperity.
+				<<set _AWeekGrowth++>>
+			<</if>>
 		<</if>>
 	<</if>>
 	<<if $arcologies[0].FSNull != "unset">>
 		Your cultural openness is a powerful driver of economic activity.
-		<<set $AWeekGrowth += Math.trunc($arcologies[0].FSNull/25)>>
+		<<set _AWeekGrowth += Math.trunc($arcologies[0].FSNull/25)>>
 	<</if>>
 	<<if $arcologies[0].FSPaternalist >= random(1,100)>>
 		This week, the careful attention to slave welfare your new society emphasizes has been a driver of prosperity.
-		<<set $AWeekGrowth += 1>>
+		<<set _AWeekGrowth++>>
 	<</if>>
 	<<if $arcologies[0].FSChattelReligionistCreed == 1>>
 	<<if $nicaeaFocus == "owners">>
 		The focus on slaveowners' whims in the creed of $nicaeaName interests the rich and powerful, increasing prosperity.
-		<<set $AWeekGrowth += $nicaeaPower>>
+		<<set _AWeekGrowth += $nicaeaPower>>
 	<</if>>
 	<</if>>
 	<<if $arcologies[0].FSRomanRevivalist >= random(1,100)>>
 		This week, intense interest in your project to revive Roman values has driven prosperity.
-		<<set $AWeekGrowth += 1>>
+		<<set _AWeekGrowth++>>
 	<<elseif $arcologies[0].FSChineseRevivalist != "unset">>
-	  <<if ($HeadGirl != 0) && ($Recruiter != 0) && ($Bodyguard != 0)>>
-		This week, your imperial administration, staffed with a Head Girl, a Recruiter, and a Bodyguard, has improved prosperity.
-		<<set $AWeekGrowth += 2>>
-	  <</if>>
+		<<if ($HeadGirl != 0) && ($Recruiter != 0) && ($Bodyguard != 0)>>
+			This week, your imperial administration, staffed with a Head Girl, a Recruiter, and a Bodyguard, has improved prosperity.
+			<<set _AWeekGrowth += 2>>
+		<</if>>
 	<</if>>
 	<<if $PC.career is "capitalist">>
 		Your @@color:springgreen;business skills@@ drive increased prosperity.
-		<<set $AWeekGrowth += 1>>
+		<<set _AWeekGrowth++>>
 	<<elseif $PC.career is "arcology owner">>
 		Your @@color:springgreen;experience in the Free Cities@@ helps increase prosperity.
-		<<set $AWeekGrowth += 1>>
+		<<set _AWeekGrowth++>>
 	<</if>>
-	<<set $seed to $TSS.schoolPresent+$GRI.schoolPresent+$SCP.schoolPresent+$LDE.schoolPresent+$TGA.schoolPresent+$TFS.schoolPresent>>
-	<<if $seed == 1>>
+	<<set _schools to $TSS.schoolPresent+$GRI.schoolPresent+$SCP.schoolPresent+$LDE.schoolPresent+$TGA.schoolPresent+$TFS.schoolPresent>>
+	<<if _schools == 1>>
 		The presence of a slave school in the arcology improves the local economy.
-	<<elseif $seed > 0>>
+	<<elseif _schools > 0>>
 		The presence of slave schools in the arcology greatly improves the local economy.
 	<<elseif $arcologies[0].prosperity > 80>>
 		The lack of a branch campus from a reputable slave school is slowing further development of the local economy.
-		<<set $AWeekGrowth -= 1>>
+		<<set _AWeekGrowth-->>
 	<</if>>
-	<<set $AWeekGrowth += $seed>>
+	<<set _AWeekGrowth += _schools>>
 	<<if $arcologies[0].FSDegradationistLaw == 1>>
 		Requiring menials to be given time to fuck human sex toys in the arcade reduces labor efficiency, slowing growth.
-		<<set $AWeekGrowth -= 1>>
+		<<set _AWeekGrowth-->>
 	<</if>>
 	<<if $arcologies[0].FSBodyPuristLaw == 1>>
 		The drug surcharge used to fund the purity regime reduces growth.
-		<<set $AWeekGrowth -= 1>>
+		<<set _AWeekGrowth-->>
 	<</if>>
 	<<if $arcologies[0].FSPastoralistLaw == 1>>
 		Prosperity improvement is slowed by the regulations on animal products.
-		<<set $AWeekGrowth -= 1>>
+		<<set _AWeekGrowth-->>
 	<</if>>
 	<<if $arcologies[0].FSPaternalistSMR == 1>>
 		Your slave market regulations slow the flow of chattel through the arcology.
-		<<set $AWeekGrowth -= 1>>
+		<<set _AWeekGrowth-->>
 	<</if>>
 	<<if $terrain is "urban">>
 		Since your arcology is located in the heart of an urban area, its commerce is naturally vibrant.
-		<<set $AWeekGrowth += 1>>
+		<<set _AWeekGrowth++>>
 	<</if>>
 	<<if def $arcologies[0].embargoTarget and $arcologies[0].embargoTarget != -1>>
 		The local economy is hurt by the double edged sword of your economic warfare.
-		<<set $AWeekGrowth -= $arcologies[0].embargo*2>>
+		<<set _AWeekGrowth -= $arcologies[0].embargo*2>>
 	<</if>>
 	<<set $desc to []>>
 	<<set $descNeg to []>>
@@ -1058,7 +1068,7 @@ earning you @@color:yellowgreen;¤$seed.@@
 		<<else>>
 		''$desc[0]''<<if $descNeg.length > 0>>, but<<else>>.<</if>>
 		<</if>>
-		<<set $AWeekGrowth += $desc.length>>
+		<<set _AWeekGrowth += $desc.length>>
 	<</if>>
 	<<if $descNeg.length > 0>>
 		<<if $desc.length > 0>>Your arcology's economy<</if>>
@@ -1077,20 +1087,21 @@ earning you @@color:yellowgreen;¤$seed.@@
 		<<else>>
 		''$descNeg[0]''.
 		<</if>>
-		<<set $AWeekGrowth -= $descNeg.length>>
+		<<set _AWeekGrowth -= $descNeg.length>>
 	<</if>>
-	<<if $AWeekGrowth > 0>>
+	<<if $alwaysSubsidizeGrowth == 1>>
+		Growth was subsidized as planned.
+		<<set _AWeekGrowth++>>
+	<</if>>
+	<<set _AWeekGrowth = Math.trunc(0.5*_AWeekGrowth)>>
+	<<if _AWeekGrowth > 0>>
 		Since $arcologies[0].name can support more citizens and more activity, @@color:green;its prosperity improved this week.@@
-	<<elseif $AWeekGrowth == 0>>
+	<<elseif _AWeekGrowth == 0>>
 		Though $arcologies[0].name can support more citizens and more activity, @@color:yellow;growth was moribund this week.@@
 	<<else>>
 		Though $arcologies[0].name can support more citizens and more activity, @@color:red;it lost prosperity this week.@@
 	<</if>>
-	<<set $arcologies[0].prosperity += $AWeekGrowth>>
-	<<if $alwaysSubsidizeGrowth == 1>>
-		<<set $arcologies[0].prosperity += 1>>
-		Growth subsidized as planned.
-	<</if>>
+	<<set $arcologies[0].prosperity += _AWeekGrowth>>
 <</if>>
 
 <<if $TSS.schoolPresent+$GRI.schoolPresent+$SCP.schoolPresent+$LDE.schoolPresent+$TGA.schoolPresent+$TFS.schoolPresent > 0>>

--- a/src/uncategorized/futureSocities.tw
+++ b/src/uncategorized/futureSocities.tw
@@ -543,8 +543,10 @@ You are spending ¤$FSSpending each week to support your societal goals.
 <<if $arcologies[0].FSSupremacistRace != "indo-aryan">>[[Indo-Aryan|Future Society][$arcologies[0].FSSupremacistRace to "indo-aryan"]]<<else>>Indo-Aryan<</if>> |
 <<if $arcologies[0].FSSupremacistRace != "amerindian">>[[Amerindian|Future Society][$arcologies[0].FSSupremacistRace to "amerindian"]]<<else>>Amerindian<</if>> |
 <<if $arcologies[0].FSSupremacistRace != "pacific islander">>[[Pacific Islander|Future Society][$arcologies[0].FSSupremacistRace to "pacific islander"]]<<else>>Pacific Islander<</if>> |
+<<if $arcologies[0].FSSupremacistRace != "malay">>[[Malay|Future Society][$arcologies[0].FSSupremacistRace to "malay"]]<<else>>Malay<</if>> |
 <<if $arcologies[0].FSSupremacistRace != "southern european">>[[Southern European|Future Society][$arcologies[0].FSSupremacistRace to "southern european"]]<<else>>Southern European<</if>> |
-<<if $arcologies[0].FSSupremacistRace != "semitic">>[[Semitic|Future Society][$arcologies[0].FSSupremacistRace to "semitic"]]<<else>>Semitic<</if>>
+<<if $arcologies[0].FSSupremacistRace != "semitic">>[[Semitic|Future Society][$arcologies[0].FSSupremacistRace to "semitic"]]<<else>>Semitic<</if>> |
+<<if $arcologies[0].FSSupremacistRace != "mixed race">>[[Mixed Race|Future Society][$arcologies[0].FSSupremacistRace to "mixed race"]]<<else>>Mixed Race<</if>>
 	<<else>>
 	/*//''Racial supremacism'': a belief in the superiority of a chosen race.//*/
 	<</if>>
@@ -600,8 +602,10 @@ You are spending ¤$FSSpending each week to support your societal goals.
 <<if $arcologies[0].FSSubjugationistRace != "indo-aryan">>[[Indo-Aryan|Future Society][$arcologies[0].FSSubjugationistRace to "indo-aryan"]]<<else>>Indo-Aryan<</if>> |
 <<if $arcologies[0].FSSubjugationistRace != "amerindian">>[[Amerindian|Future Society][$arcologies[0].FSSubjugationistRace to "amerindian"]]<<else>>Amerindian<</if>> |
 <<if $arcologies[0].FSSubjugationistRace != "pacific islander">>[[Pacific Islander|Future Society][$arcologies[0].FSSubjugationistRace to "pacific islander"]]<<else>>Pacific Islander<</if>> |
+<<if $arcologies[0].FSSubjugationistRace != "malay">>[[Malay|Future Society][$arcologies[0].FSSubjugationistRace to "malay"]]<<else>>Malay<</if>> |
 <<if $arcologies[0].FSSubjugationistRace != "southern european">>[[Southern European|Future Society][$arcologies[0].FSSubjugationistRace to "southern european"]]<<else>>Southern European<</if>> |
-<<if $arcologies[0].FSSubjugationistRace != "semitic">>[[Semitic|Future Society][$arcologies[0].FSSubjugationistRace to "semitic"]]<<else>>Semitic<</if>>
+<<if $arcologies[0].FSSubjugationistRace != "semitic">>[[Semitic|Future Society][$arcologies[0].FSSubjugationistRace to "semitic"]]<<else>>Semitic<</if>> |
+<<if $arcologies[0].FSSubjugationistRace != "mixed race">>[[Mixed Race|Future Society][$arcologies[0].FSSubjugationistRace to "mixed race"]]<<else>>Mixed Race<</if>>
 	<<else>>
 	/*//''Racial subjugationism'': a belief in the inferiority of a subject race.//*/
 	<</if>>

--- a/src/uncategorized/manageArcology.tw
+++ b/src/uncategorized/manageArcology.tw
@@ -24,8 +24,19 @@ A 1% interest in $arcologies[0].name is worth ¤$price and will require a transa
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
 <<if $arcologies[0].ownership+$arcologies[0].minority < 100>>
 	[[Buy|Manage Arcology][$cash -= $price+10000, $arcologies[0].ownership += 1, $arcologies[0].demandFactor += 5]]
+	<<if $arcologies[0].ownership+$arcologies[0].minority <= 90>>
+	<<if $cash > $price*10>>
+		[[x10|Manage Arcology][$cash -= ($price*10)+10000, $arcologies[0].ownership += 10, $arcologies[0].demandFactor += 50]]
+		//Transaction costs will only be paid once//
+	<</if>>
+	<</if>>
 <<else>>Buy<</if>> |
-[[Sell|Manage Arcology][$cash += $price, $arcologies[0].ownership -= 1, $arcologies[0].demandFactor -= 5]]
+<<if $arcologies[0].ownership > 0>>
+	[[Sell|Manage Arcology][$cash += $price, $arcologies[0].ownership -= 1, $arcologies[0].demandFactor -= 5]]
+	<<if $arcologies[0].ownership >= 10>>
+		| [[Sell 10%|Manage Arcology][$cash += $price*10, $arcologies[0].ownership -= 10, $arcologies[0].demandFactor -= 50]]
+	<</if>>
+<</if>>
 <<if $arcologies[0].ownership+$arcologies[0].minority < 100>>
 <<if $rep >= 10000>>
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;

--- a/src/uncategorized/neighborInteract.tw
+++ b/src/uncategorized/neighborInteract.tw
@@ -12,10 +12,10 @@
 <<if $buyArcologyDirection != 0>>
 <<for $i to 0; $i < $arcologies.length; $i++>>
   <<if $arcologies[$i].direction == $buyArcologyDirection>>
-	<<set $cash -= 500*Math.trunc($arcologies[$i].prosperity*(1+($arcologies[$i].demandFactor/100)))>>
+	<<set $cash -= $transaction*(500*Math.trunc($arcologies[$i].prosperity*(1+($arcologies[$i].demandFactor/100))))>>
 	<<set $cash -= 10000>>
-	<<set $arcologies[$i].PCminority += 1>>
-	<<set $arcologies[$i].demandFactor += 5>>
+	<<set $arcologies[$i].PCminority += $transaction>>
+	<<set $arcologies[$i].demandFactor += $transaction*5>>
 	<<break>>
   <</if>>
 <</for>>
@@ -24,14 +24,15 @@
 <<if $sellArcologyDirection != 0>>
 <<for $i to 0; $i < $arcologies.length; $i++>>
   <<if $arcologies[$i].direction == $sellArcologyDirection>>
-	<<set $cash += 500*Math.trunc($arcologies[$i].prosperity*(1+($arcologies[$i].demandFactor/100)))>>
-	<<set $arcologies[$i].PCminority -= 1>>
-	<<set $arcologies[$i].demandFactor -= 2>>
+	<<set $cash += $transaction*(500*Math.trunc($arcologies[$i].prosperity*(1+($arcologies[$i].demandFactor/100))))>>
+	<<set $arcologies[$i].PCminority -= $transaction>>
+	<<set $arcologies[$i].demandFactor -= $transaction*2>>
 	<<break>>
   <</if>>
 <</for>>
 <</if>>
 <<set $sellArcologyDirection = 0>>
+<<set $transaction = 0>>
 
 <<if $arcologies[0].embargoTarget == -1>>
 	You are not engaged in economic warfare against a neighboring arcology.
@@ -159,15 +160,22 @@
 <</if>>
 <br>&nbsp;&nbsp;&nbsp;&nbsp;You own ''$activeArcology.PCminority%'' of $activeArcology.name.
 <<set $seed to 500*Math.trunc($activeArcology.prosperity*(1+($activeArcology.demandFactor/100)))>>
-A 1% interest in $activeArcology.name is worth ¤$seed and will require an transaction cost of ¤10000 to acquire.
+A 1% interest in $activeArcology.name is worth ¤$seed and will require a transaction cost of ¤10000 to acquire.
 <<if ($activeArcology.ownership + $activeArcology.PCminority + $activeArcology.minority < 100)>>
-	[[Buy|Neighbor Interact][$buyArcologyDirection to $activeArcology.direction]]
+	[[Buy|Neighbor Interact][$buyArcologyDirection to $activeArcology.direction, $transaction = 1]]
+	<<if ($activeArcology.ownership + $activeArcology.PCminority + $activeArcology.minority <= 90)>>
+	<<if $cash > 10*(500*Math.trunc($arcologies[$i].prosperity*(1+($arcologies[$i].demandFactor/100))))>>
+		[[Buy 10%|Neighbor Interact][$buyArcologyDirection to $activeArcology.direction, $transaction = 10]]
+		//Transaction costs will only be paid once//
+	<</if>>
+	<</if>>
 <</if>>
-<<if ($activeArcology.ownership + $activeArcology.PCminority + $activeArcology.minority < 100) && ($activeArcology.PCminority > 0)>>
-	|
-<</if>>
+<<if ($activeArcology.ownership + $activeArcology.PCminority + $activeArcology.minority < 100) && ($activeArcology.PCminority > 0)>>|<</if>>
 <<if $activeArcology.PCminority > 0>>
-	[[Sell|Neighbor Interact][$sellArcologyDirection to $activeArcology.direction]]
+	[[Sell|Neighbor Interact][$sellArcologyDirection to $activeArcology.direction, $transaction = 1]]
+	<<if $activeArcology.PCminority >= 10>>
+		| [[Sell 10%|Neighbor Interact][$sellArcologyDirection to $activeArcology.direction, $transaction = 10]]
+	<</if>>
 <</if>>
 <br>
 <<if ($activeArcology.government == "your trustees") || ($activeArcology.government == "your agent")>>

--- a/src/uncategorized/neighborsDevelopment.tw
+++ b/src/uncategorized/neighborsDevelopment.tw
@@ -1,15 +1,13 @@
 :: Neighbors Development [nobr]
 
 <<set $averageProsperity to 0>>
-<<set $seed to 0>>
 <<for $i to 0; $i < $arcologies.length; $i++>>
 	<<if $arcologies[$i].prosperity < 10>>
 		<<set $arcologies[$i].prosperity to 10>>
 	<</if>>
 	<<set $averageProsperity += $arcologies[$i].prosperity>>
-	<<set $seed += 1>>
 <</for>>
-<<set $averageProsperity to $averageProsperity/$seed>>
+<<set $averageProsperity to $averageProsperity/$arcologies.length>>
 
 <<set _corpBonus = Math.trunc($corpProfit*0.05)>>
 
@@ -28,19 +26,17 @@ __Arcologies in the Free City__
 <<else>>
 	<<switch $arcologies[$i].government>>
 	<<case "elected officials">>
+		<<set $arcologies[$i].prosperity += random(-1,1)>>
+	<<case "a corporation" "an oligarchy">>
 		<<set $arcologies[$i].prosperity += random(-1,2)>>
-	<<case "a committee">>
+	<<case "a committee" "your trustees">>
 		<<set $arcologies[$i].prosperity += random(0,2)>>
-	<<case "an oligarchy" "your trustees">>
-		<<set $arcologies[$i].prosperity += random(0,3)>>
 	<<case "an individual">>
-		<<set $arcologies[$i].prosperity += random(0,4)>>
+		<<set $arcologies[$i].prosperity += random(0,3)>>
 	<<case "your agent">>
-		<<set $arcologies[$i].prosperity += random(0,4)>>
+		<<set $arcologies[$i].prosperity += random(0,3)>>
 		<<agentLeadership>>
 		<<set $arcologies[$i].prosperity += $agentBonus>>
-	<<case "a corporation">>
-		<<set $arcologies[$i].prosperity += random(1,3)>>
 	<<default>>
 		<<set $arcologies[$i].prosperity += random(-1,1)>>
 	<</switch>>
@@ -62,12 +58,12 @@ __Arcologies in the Free City__
 <</if>>
 
 <<if $arcologies[$i].direction == 0>>
-  <<set $seed to 5>>
+  <<set _error to 5>>
 <<else>>
-  <<set $seed to 10>>
+  <<set _error to 10>>
 <</if>>
-<<set $seed -= 2*$assistantPower>>
-has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologies[$i].prosperity*random(100-$seed,100+$seed))/100)>>m,@@
+<<set _error -= 2*$assistantPower>>
+has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologies[$i].prosperity*random(100-_error,100+_error))/100)>>m,@@
 
 <<if ($arcologies[$i].rival == 1) && ($arcologies[$i].government != "an individual")>>
 	undergoing some internal turmoil. @@color:yellow;It undergoes a change of government.@@ A power struggle is won by a single individual, leaving the arcology ruled like yours is.
@@ -393,13 +389,13 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<if $arcologies[$i].government != "your agent">>
 <<if $arcologies[$i].government != "your trustees">>
 <<if $arcologies[$i].minority + $arcologies[$i].ownership + $arcologies[$i].PCminority < 100>>
-	<<set $seed to $arcologies[$i].prosperity-$averageProsperity>>
-	<<if $seed > random(-10,50)>>
+	<<set _prosperityDiff to $arcologies[$i].prosperity-$averageProsperity>>
+	<<if _prosperityDiff > random(-10,50)>>
 		Its leadership acquires an increased share of its ownership.
 		<<set $arcologies[$i].ownership += 1>>
 		<<set $arcologies[$i].prosperity -= 5>>
 		This places its government in control of approximately <<print Math.trunc(($arcologies[$i].ownership*random(100-$economicUncertainty,100+$economicUncertainty))/100)>>% of the arcology<<if $arcologies[$i].minority > 0>>, against its most prominent competition, with a <<print Math.trunc(($arcologies[$i].minority*random(100-$economicUncertainty,100+$economicUncertainty))/100)>>% share<</if>>.
-	<<elseif $seed < random(-50,10)>>
+	<<elseif _prosperityDiff < random(-50,10)>>
 		<<if $arcologies[$i].ownership > 0>>
 			Its leadership sells off some of of its ownership to stay afloat.
 			<<set $arcologies[$i].ownership -= 1>>
@@ -451,7 +447,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 
 /* FUTURE SOCIETY PROGRESS */
 
-<<set $seed to 0>>
+<<set _societiesAdopted to 0>>
 <<switch $arcologies[$i].government>>
 <<case "elected officials">>
 	<<set $efficiency to random(-2,2)>>
@@ -474,17 +470,25 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<<set $efficiency += random(0,2)>>
 <</if>>
 
+<<set _FSCrossThresh = 5>>
+<<if $arcologies[$i].direction == 0>>
+	<<set _FSCrossThresh -= $CulturalOpenness*5>>
+<</if>>
+<<if $arcologies[$i].ownership >= 100>>
+	<<set _FSCrossThresh += 5>>
+<</if>>
+
 <<if $arcologies[$i].FSSupremacist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSSupremacist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if ($arcologies[$j].FSSupremacist > $arcologies[$i].FSSupremacist + $FSCrossThresh) && ($arcologies[$j].FSSupremacistRace is $arcologies[$i].FSSupremacistRace)>>
+		<<if ($arcologies[$j].FSSupremacist > $arcologies[$i].FSSupremacist + _FSCrossThresh) && ($arcologies[$j].FSSupremacistRace is $arcologies[$i].FSSupremacistRace)>>
 			<<if $showNeighborDetails != 0>>Racial Supremacy for $arcologies[$i].FSSupremacistRace people in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSSupremacist += 1>>
-		<<elseif ($arcologies[$j].FSSubjugationist > $arcologies[$i].FSSupremacist + $FSCrossThresh) && ($arcologies[$j].FSSubjugationist is $arcologies[$i].FSSupremacistRace)>>
+		<<elseif ($arcologies[$j].FSSubjugationist > $arcologies[$i].FSSupremacist + _FSCrossThresh) && ($arcologies[$j].FSSubjugationist is $arcologies[$i].FSSupremacistRace)>>
 		<<if $showNeighborDetails != 0>>Development of $arcologies[$i].FSSupremacistRace Supremacy in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's more advanced Subjugationist society.<</if>>
 		<<set $arcologies[$i].FSSupremacist -= 1>>
 		<</if>>
@@ -512,6 +516,8 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 			<<set $arcologies[$i].name to $ArcologyNamesSupremacistIndoAryan.random()>>
 		<<case "pacific islander">>
 			<<set $arcologies[$i].name to $ArcologyNamesSupremacistPacificIslander.random()>>
+		<<case "malay">>
+			<<set $arcologies[$i].name to $ArcologyNamesSupremacistMalay.random()>>
 		<<case "amerindian">>
 			<<set $arcologies[$i].name to $ArcologyNamesSupremacistAmerindian.random()>>
 		<<case "southern european">>
@@ -519,7 +525,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 		<<case "semitic">>
 			<<set $arcologies[$i].name to $ArcologyNamesSupremacistSemitic.random()>>
 		<<default>>
-			<<set $arcologies[$i].name to either("Purity")>>
+			<<set $arcologies[$i].name to $ArcologyNamesSupremacistMixedRace.random()>>
 		<</switch>>
 		''$arcologies[$i].name'' to mark the occasion.
 		<</if>>
@@ -542,16 +548,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <</if>>
 
 <<if $arcologies[$i].FSSubjugationist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSSubjugationist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if ($arcologies[$j].FSSubjugationist > $arcologies[$i].FSSubjugationist + $FSCrossThresh) && ($arcologies[$j].FSSubjugationistRace is $arcologies[$i].FSSubjugationistRace)>>
+		<<if ($arcologies[$j].FSSubjugationist > $arcologies[$i].FSSubjugationist + _FSCrossThresh) && ($arcologies[$j].FSSubjugationistRace is $arcologies[$i].FSSubjugationistRace)>>
 		<<if $showNeighborDetails != 0>>Racial Subjugationism of $arcologies[$i].FSSubjugationistRace people in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSSubjugationist += 1>>
-		<<elseif ($arcologies[$j].FSSupremacist > $arcologies[$i].FSSubjugationist + $FSCrossThresh) && ($arcologies[$j].FSSupremacist is $arcologies[$i].FSSubjugationistRace)>>
+		<<elseif ($arcologies[$j].FSSupremacist > $arcologies[$i].FSSubjugationist + _FSCrossThresh) && ($arcologies[$j].FSSupremacist is $arcologies[$i].FSSubjugationistRace)>>
 		<<if $showNeighborDetails != 0>>Development of $arcologies[$i].FSSubjugationistRace Supremacy in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's more advanced Supremacist society.<</if>>
 		<<set $arcologies[$i].FSSubjugationist -= 1>>
 		<</if>>
@@ -579,6 +585,8 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 			<<set $arcologies[$i].name to $ArcologyNamesSubjugationistIndoAryan.random()>>
 		<<case "pacific islander">>
 			<<set $arcologies[$i].name to $ArcologyNamesSubjugationistPacificIslander.random()>>
+		<<case "malay">>
+			<<set $arcologies[$i].name to $ArcologyNamesSubjugationistMalay.random()>>
 		<<case "amerindian">>
 			<<set $arcologies[$i].name to $ArcologyNamesSubjugationistAmerindian.random()>>
 		<<case "southern european">>
@@ -586,7 +594,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 		<<case "semitic">>
 			<<set $arcologies[$i].name to $ArcologyNamesSubjugationistSemitic.random()>>
 		<<default>>
-			<<set $arcologies[$i].name to "Purity">>
+			<<set $arcologies[$i].name to $ArcologyNamesSubjugationistMixedRace.random()>>
 		<</switch>>
 		''$arcologies[$i].name'' to mark the occasion.
 		<</if>>
@@ -605,16 +613,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <</if>>
 
 <<if $arcologies[$i].FSGenderRadicalist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSGenderRadicalist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSGenderRadicalist > $arcologies[$i].FSGenderRadicalist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSGenderRadicalist > $arcologies[$i].FSGenderRadicalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Gender Radicalism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSGenderRadicalist += 1>>
-		<<elseif $arcologies[$j].FSGenderFundamentalist > $arcologies[$i].FSGenderRadicalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSGenderFundamentalist > $arcologies[$i].FSGenderRadicalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Gender Radicalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Gender Fundamentalist society.<</if>>
 		<<set $arcologies[$i].FSGenderRadicalist -= 1>>
 		<</if>>
@@ -659,16 +667,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<</if>>
 	<</if>>
 <<elseif $arcologies[$i].FSGenderFundamentalist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSGenderFundamentalist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSGenderFundamentalist > $arcologies[$i].FSGenderFundamentalist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSGenderFundamentalist > $arcologies[$i].FSGenderFundamentalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Gender Fundamentalism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSGenderFundamentalist += 1>>
-		<<elseif $arcologies[$j].FSGenderRadicalist > $arcologies[$i].FSGenderFundamentalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSGenderRadicalist > $arcologies[$i].FSGenderFundamentalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Gender Fundamentalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Gender Radicalist society.<</if>>
 		<<set $arcologies[$i].FSGenderFundamentalist -= 1>>
 		<</if>>
@@ -699,16 +707,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <</if>>
 
 <<if $arcologies[$i].FSPaternalist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSPaternalist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSPaternalist > $arcologies[$i].FSPaternalist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSPaternalist > $arcologies[$i].FSPaternalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Paternalism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSPaternalist += 1>>
-		<<elseif $arcologies[$j].FSDegradationist > $arcologies[$i].FSPaternalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSDegradationist > $arcologies[$i].FSPaternalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Paternalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Degradationist society.<</if>>
 		<<set $arcologies[$i].FSPaternalist -= 1>>
 		<</if>>
@@ -742,16 +750,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<</if>>
 	<</if>>
 <<elseif $arcologies[$i].FSDegradationist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSDegradationist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSDegradationist > $arcologies[$i].FSDegradationist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSDegradationist > $arcologies[$i].FSDegradationist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Degradationism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSDegradationist += 1>>
-		<<elseif $arcologies[$j].FSPaternalist > $arcologies[$i].FSDegradationist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSPaternalist > $arcologies[$i].FSDegradationist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Degradationism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Paternalist society.<</if>>
 		<<set $arcologies[$i].FSDegradationist -= 1>>
 		<</if>>
@@ -791,16 +799,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <</if>>
 
 <<if $arcologies[$i].FSBodyPurist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSBodyPurist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSBodyPurist > $arcologies[$i].FSBodyPurist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSBodyPurist > $arcologies[$i].FSBodyPurist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Body Purism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSBodyPurist += 1>>
-		<<elseif $arcologies[$j].FSTransformationFetishist > $arcologies[$i].FSBodyPurist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSTransformationFetishist > $arcologies[$i].FSBodyPurist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Body Purism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Transformation Fetishist society.<</if>>
 		<<set $arcologies[$i].FSBodyPurist -= 1>>
 		<</if>>
@@ -831,16 +839,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<</if>>
 	<</if>>
 <<elseif $arcologies[$i].FSTransformationFetishist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSTransformationFetishist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSTransformationFetishist > $arcologies[$i].FSTransformationFetishist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSTransformationFetishist > $arcologies[$i].FSTransformationFetishist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Transformation Fetishism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSTransformationFetishist += 1>>
-		<<elseif $arcologies[$j].FSBodyPurist > $arcologies[$i].FSTransformationFetishist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSBodyPurist > $arcologies[$i].FSTransformationFetishist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Transformation Fetishism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Body Purist society.<</if>>
 		<<set $arcologies[$i].FSTransformationFetishist -= 1>>
 		<</if>>
@@ -875,16 +883,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <</if>>
 
 <<if $arcologies[$i].FSYouthPreferentialist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSYouthPreferentialist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSYouthPreferentialist > $arcologies[$i].FSYouthPreferentialist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSYouthPreferentialist > $arcologies[$i].FSYouthPreferentialist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Youth Preferentialism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSYouthPreferentialist += 1>>
-		<<elseif $arcologies[$j].FSMaturityPreferentialist > $arcologies[$i].FSYouthPreferentialist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSMaturityPreferentialist > $arcologies[$i].FSYouthPreferentialist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Youth Preferentialism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Maturity Preferentialist society.<</if>>
 		<<set $arcologies[$i].FSYouthPreferentialist -= 1>>
 		<</if>>
@@ -913,16 +921,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<</if>>
 	<</if>>
 <<elseif $arcologies[$i].FSMaturityPreferentialist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSMaturityPreferentialist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSMaturityPreferentialist > $arcologies[$i].FSMaturityPreferentialist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSMaturityPreferentialist > $arcologies[$i].FSMaturityPreferentialist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Maturity Preferentialism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSMaturityPreferentialist += 1>>
-		<<elseif $arcologies[$j].FSYouthPreferentialist > $arcologies[$i].FSMaturityPreferentialist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSYouthPreferentialist > $arcologies[$i].FSMaturityPreferentialist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Maturity Preferentialism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Youth Preferentialist society.<</if>>
 		<<set $arcologies[$i].FSMaturityPreferentialist -= 1>>
 		<</if>>
@@ -953,16 +961,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <</if>>
 
 <<if $arcologies[$i].FSSlimnessEnthusiast != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSSlimnessEnthusiast += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSSlimnessEnthusiast > $arcologies[$i].FSSlimnessEnthusiast + $FSCrossThresh>>
+		<<if $arcologies[$j].FSSlimnessEnthusiast > $arcologies[$i].FSSlimnessEnthusiast + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Slimness Enthusiasm in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSSlimnessEnthusiast += 1>>
-		<<elseif $arcologies[$j].FSAssetExpansionist > $arcologies[$i].FSSlimnessEnthusiast + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSAssetExpansionist > $arcologies[$i].FSSlimnessEnthusiast + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Slimness Enthusiasm in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Asset Expansionist society.<</if>>
 		<<set $arcologies[$i].FSSlimnessEnthusiast -= 1>>
 		<</if>>
@@ -999,16 +1007,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<</if>>
 	<</if>>
 <<elseif $arcologies[$i].FSAssetExpansionist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSAssetExpansionist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSAssetExpansionist > $arcologies[$i].FSAssetExpansionist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSAssetExpansionist > $arcologies[$i].FSAssetExpansionist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Asset Expansionism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSAssetExpansionist += 1>>
-		<<elseif $arcologies[$j].FSSlimnessEnthusiast > $arcologies[$i].FSAssetExpansionist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSSlimnessEnthusiast > $arcologies[$i].FSAssetExpansionist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Asset Expansionism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Slimness Enthusiast society.<</if>>
 		<<set $arcologies[$i].FSAssetExpansionist -= 1>>
 		<</if>>
@@ -1047,16 +1055,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <</if>>
 
 <<if $arcologies[$i].FSPastoralist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSPastoralist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSPastoralist > $arcologies[$i].FSPastoralist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSPastoralist > $arcologies[$i].FSPastoralist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Pastoralism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSPastoralist += 1>>
-		<<elseif $arcologies[$j].FSPhysicalIdealist > $arcologies[$i].FSPastoralist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSPhysicalIdealist > $arcologies[$i].FSPastoralist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Asset Expansionism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Physical Idealist society.<</if>>
 		<<set $arcologies[$i].FSPastoralist -= 1>>
 		<</if>>
@@ -1085,16 +1093,16 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<</if>>
 	<</if>>
 <<elseif $arcologies[$i].FSPhysicalIdealist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSPhysicalIdealist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSPhysicalIdealist > $arcologies[$i].FSPhysicalIdealist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSPhysicalIdealist > $arcologies[$i].FSPhysicalIdealist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Physical Idealism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSPhysicalIdealist += 1>>
-		<<elseif $arcologies[$j].FSPastoralist > $arcologies[$i].FSPhysicalIdealist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSPastoralist > $arcologies[$i].FSPhysicalIdealist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Asset Expansionism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Pastoralist society.<</if>>
 		<<set $arcologies[$i].FSPhysicalIdealist -= 1>>
 		<</if>>
@@ -1129,13 +1137,13 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <</if>>
 
 <<if $arcologies[$i].FSChattelReligionist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSChattelReligionist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSChattelReligionist > $arcologies[$i].FSChattelReligionist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSChattelReligionist > $arcologies[$i].FSChattelReligionist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Chattel Religionism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSChattelReligionist += 1>>
 		<</if>>
@@ -1170,25 +1178,25 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <</if>>
 
 <<if $arcologies[$i].FSRomanRevivalist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSRomanRevivalist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSRomanRevivalist > $arcologies[$i].FSRomanRevivalist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSRomanRevivalist > $arcologies[$i].FSRomanRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Roman Revivalism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSRomanRevivalist += 1>>
-		<<elseif $arcologies[$j].FSChineseRevivalist > $arcologies[$i].FSRomanRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSChineseRevivalist > $arcologies[$i].FSRomanRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Roman Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Chinese Revivalist society.<</if>>
 		<<set $arcologies[$i].FSRomanRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSRomanRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSRomanRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Roman Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Egyptian Revivalist society.<</if>>
 		<<set $arcologies[$i].FSRomanRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSEdoRevivalist > $arcologies[$i].FSRomanRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSEdoRevivalist > $arcologies[$i].FSRomanRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Roman Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Edo Revivalist society.<</if>>
 		<<set $arcologies[$i].FSRomanRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSArabianRevivalist > $arcologies[$i].FSRomanRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSArabianRevivalist > $arcologies[$i].FSRomanRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Roman Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Arabian Revivalist society.<</if>>
 		<<set $arcologies[$i].FSRomanRevivalist -= 1>>
 		<</if>>
@@ -1217,25 +1225,25 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<</if>>
 	<</if>>
 <<elseif $arcologies[$i].FSEgyptianRevivalist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSEgyptianRevivalist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSEgyptianRevivalist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSEgyptianRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Egyptian Revivalism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSEgyptianRevivalist += 1>>
-		<<elseif $arcologies[$j].FSRomanRevivalist > $arcologies[$i].FSEgyptianRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSRomanRevivalist > $arcologies[$i].FSEgyptianRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Egyptian Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Roman Revivalist society.<</if>>
 		<<set $arcologies[$i].FSEgyptianRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSChineseRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSChineseRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Egyptian Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Chinese Revivalist society.<</if>>
 		<<set $arcologies[$i].FSEgyptianRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSEdoRevivalist > $arcologies[$i].FSEgyptianRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSEdoRevivalist > $arcologies[$i].FSEgyptianRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Egyptian Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Edo Revivalist society.<</if>>
 		<<set $arcologies[$i].FSEgyptianRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSArabianRevivalist > $arcologies[$i].FSEgyptianRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSArabianRevivalist > $arcologies[$i].FSEgyptianRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Egyptian Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Arabian Revivalist society.<</if>>
 		<<set $arcologies[$i].FSEgyptianRevivalist -= 1>>
 		<</if>>
@@ -1264,25 +1272,25 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<</if>>
 	<</if>>
 <<elseif $arcologies[$i].FSEdoRevivalist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSEdoRevivalist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSEdoRevivalist > $arcologies[$i].FSEdoRevivalist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSEdoRevivalist > $arcologies[$i].FSEdoRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Edo Revivalism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSEdoRevivalist += 1>>
-		<<elseif $arcologies[$j].FSRomanRevivalist > $arcologies[$i].FSEdoRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSRomanRevivalist > $arcologies[$i].FSEdoRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Edo Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Roman Revivalist society.<</if>>
 		<<set $arcologies[$i].FSEdoRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSEdoRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSEdoRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Edo Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Egyptian Revivalist society.<</if>>
 		<<set $arcologies[$i].FSEdoRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSChineseRevivalist > $arcologies[$i].FSEdoRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSChineseRevivalist > $arcologies[$i].FSEdoRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Edo Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Chinese Revivalist society.<</if>>
 		<<set $arcologies[$i].FSEdoRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSArabianRevivalist > $arcologies[$i].FSEdoRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSArabianRevivalist > $arcologies[$i].FSEdoRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Edo Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Arabian Revivalist society.<</if>>
 		<<set $arcologies[$i].FSEdoRevivalist -= 1>>
 		<</if>>
@@ -1311,25 +1319,25 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<</if>>
 	<</if>>
 <<elseif $arcologies[$i].FSArabianRevivalist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSArabianRevivalist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSArabianRevivalist > $arcologies[$i].FSArabianRevivalist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSArabianRevivalist > $arcologies[$i].FSArabianRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Arabian Revivalism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSArabianRevivalist += 1>>
-		<<elseif $arcologies[$j].FSRomanRevivalist > $arcologies[$i].FSArabianRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSRomanRevivalist > $arcologies[$i].FSArabianRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Arabian Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Roman Revivalist society.<</if>>
 		<<set $arcologies[$i].FSArabianRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSArabianRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSArabianRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Arabian Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Egyptian Revivalist society.<</if>>
 		<<set $arcologies[$i].FSArabianRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSEdoRevivalist > $arcologies[$i].FSArabianRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSEdoRevivalist > $arcologies[$i].FSArabianRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Arabian Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Edo Revivalist society.<</if>>
 		<<set $arcologies[$i].FSArabianRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSChineseRevivalist > $arcologies[$i].FSArabianRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSChineseRevivalist > $arcologies[$i].FSArabianRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Arabian Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Chinese Revivalist society.<</if>>
 		<<set $arcologies[$i].FSArabianRevivalist -= 1>>
 		<</if>>
@@ -1362,25 +1370,25 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<</if>>
 	<</if>>
 <<elseif $arcologies[$i].FSChineseRevivalist != "unset">>
-	<<set $seed += 1>>
+	<<set _societiesAdopted += 1>>
 	<<if $arcologies[$i].direction != 0>>
 	<<set $arcologies[$i].FSChineseRevivalist += $efficiency>>
 	<</if>>
 	<<for $j to 0; $j < $arcologies.length; $j++>>
 	<<if $arcologies[$i].direction != $arcologies[$j].direction>>
-		<<if $arcologies[$j].FSChineseRevivalist > $arcologies[$i].FSChineseRevivalist + $FSCrossThresh>>
+		<<if $arcologies[$j].FSChineseRevivalist > $arcologies[$i].FSChineseRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Chinese Revivalism in $arcologies[$i].name is influenced by $arcologies[$j].name's more advanced society.<</if>>
 		<<set $arcologies[$i].FSChineseRevivalist += 1>>
-		<<elseif $arcologies[$j].FSRomanRevivalist > $arcologies[$i].FSChineseRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSRomanRevivalist > $arcologies[$i].FSChineseRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Chinese Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Roman Revivalist society.<</if>>
 		<<set $arcologies[$i].FSChineseRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSChineseRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSEgyptianRevivalist > $arcologies[$i].FSChineseRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Chinese Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Egyptian Revivalist society.<</if>>
 		<<set $arcologies[$i].FSChineseRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSEdoRevivalist > $arcologies[$i].FSChineseRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSEdoRevivalist > $arcologies[$i].FSChineseRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Chinese Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Edo Revivalist society.<</if>>
 		<<set $arcologies[$i].FSChineseRevivalist -= 1>>
-		<<elseif $arcologies[$j].FSArabianRevivalist > $arcologies[$i].FSChineseRevivalist + $FSCrossThresh>>
+		<<elseif $arcologies[$j].FSArabianRevivalist > $arcologies[$i].FSChineseRevivalist + _FSCrossThresh>>
 		<<if $showNeighborDetails != 0>>Development of Chinese Revivalism in $arcologies[$i].name is slowed by contact with $arcologies[$j].name's  more advanced Arabian Revivalist society.<</if>>
 		<<set $arcologies[$i].FSChineseRevivalist -= 1>>
 		<</if>>
@@ -1413,8 +1421,8 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 /* FUTURE SOCIETY ADOPTION */
 
 <<if $arcologies[$i].direction != 0>>
-<<if $seed < 4>>
-<<if $seed < ($arcologies[$i].prosperity/25)+($week/25)-3>>
+<<if _societiesAdopted < 4>>
+<<if _societiesAdopted < ($arcologies[$i].prosperity/25)+($week/25)-3>>
 
 <<include "Neighbors FS Adoption">>
 
@@ -1440,14 +1448,17 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 		<<set $appliedInfluenceBonus /= 2>>
 	<</if>>
 <</if>>
+<<if $arcologies[$i].ownership >= 100>>
+	<<set $appliedInfluenceBonus /= 2>>
+<</if>>
 <<set $desc to []>>
-<<set $seed to 0>>
+<<set _alignment to 0>>
 
 <<if $arcologies[$j].FSSubjugationist > 60>>
 	<<if ($arcologies[$i].FSSubjugationist != "unset")>>
 	<<if ($arcologies[$j].FSSubjugationistRace is $arcologies[$i].FSSubjugationistRace)>>
 			<<set $arcologies[$i].FSSubjugationist += Math.trunc(($arcologies[$j].FSSubjugationist-60)/4)+$appliedInfluenceBonus>>
-		<<if $arcologies[$i].FSSubjugationist > $FSLockinLevel>><<set $seed += 1>><</if>>
+		<<if $arcologies[$i].FSSubjugationist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 		<<set $desc.push("helping to advance its racially aligned Subjugationism")>>
 	<<else>>
 			<<set $arcologies[$i].FSSubjugationist -= Math.trunc(($arcologies[$j].FSSubjugationist-60)/4)+$appliedInfluenceBonus>>
@@ -1462,7 +1473,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<<if ($arcologies[$i].FSSupremacist != "unset")>>
 	<<if ($arcologies[$j].FSSupremacistRace is $arcologies[$i].FSSupremacistRace)>>
 			<<set $arcologies[$i].FSSupremacist += Math.trunc(($arcologies[$j].FSSupremacist-60)/4)+$appliedInfluenceBonus>>
-		<<if $arcologies[$i].FSSupremacist > $FSLockinLevel>><<set $seed += 1>><</if>>
+		<<if $arcologies[$i].FSSupremacist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 		<<set $desc.push("helping to advance its racially aligned Supremacism")>>
 		<<else>>
 			<<set $arcologies[$i].FSSupremacist -= Math.trunc(($arcologies[$j].FSSupremacist-60)/4)+$appliedInfluenceBonus>>
@@ -1476,7 +1487,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<if $arcologies[$j].FSGenderRadicalist > 60>>
 	<<if $arcologies[$i].FSGenderRadicalist != "unset">>
 		<<set $arcologies[$i].FSGenderRadicalist += Math.trunc(($arcologies[$j].FSGenderRadicalist-60)/4)+$appliedInfluenceBonus>>
-		<<if $arcologies[$i].FSGenderRadicalist > $FSLockinLevel>><<set $seed += 1>><</if>>
+		<<if $arcologies[$i].FSGenderRadicalist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Gender Radicalism")>>
 	<<elseif $arcologies[$i].FSGenderFundamentalist != "unset">>
 		<<set $arcologies[$i].FSGenderFundamentalist -= Math.trunc(($arcologies[$j].FSGenderRadicalist-60)/4)+$appliedInfluenceBonus>>
@@ -1485,7 +1496,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<elseif $arcologies[$j].FSGenderFundamentalist > 60>>
 	<<if $arcologies[$i].FSGenderFundamentalist != "unset">>
 		<<set $arcologies[$i].FSGenderFundamentalist += Math.trunc(($arcologies[$j].FSGenderFundamentalist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSGenderFundamentalist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSGenderFundamentalist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Gender Fundamentalism")>>
 	<<elseif $arcologies[$i].FSGenderRadicalist != "unset">>
 		<<set $arcologies[$i].FSGenderRadicalist -= Math.trunc(($arcologies[$j].FSGenderFundamentalist-60)/4)+$appliedInfluenceBonus>>
@@ -1495,7 +1506,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<if $arcologies[$j].FSPaternalist > 60>>
 	<<if $arcologies[$i].FSPaternalist != "unset">>
 		<<set $arcologies[$i].FSPaternalist += Math.trunc(($arcologies[$j].FSPaternalist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSPaternalist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSPaternalist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Paternalism")>>
 	<<elseif $arcologies[$i].FSDegradationist != "unset">>
 		<<set $arcologies[$i].FSDegradationist -= Math.trunc(($arcologies[$j].FSPaternalist-60)/4)+$appliedInfluenceBonus>>
@@ -1504,7 +1515,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<elseif $arcologies[$j].FSDegradationist > 60>>
 	<<if $arcologies[$i].FSDegradationist != "unset">>
 		<<set $arcologies[$i].FSDegradationist += Math.trunc(($arcologies[$j].FSDegradationist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSDegradationist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSDegradationist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Degradationism")>>
 	<<elseif $arcologies[$i].FSPaternalist != "unset">>
 		<<set $arcologies[$i].FSPaternalist -= Math.trunc(($arcologies[$j].FSDegradationist-60)/4)+$appliedInfluenceBonus>>
@@ -1514,7 +1525,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<if $arcologies[$j].FSBodyPurist > 60>>
 	<<if $arcologies[$i].FSBodyPurist != "unset">>
 		<<set $arcologies[$i].FSBodyPurist += Math.trunc(($arcologies[$j].FSBodyPurist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSBodyPurist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSBodyPurist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Body Purism")>>
 	<<elseif $arcologies[$i].FSTransformationFetishist != "unset">>
 		<<set $arcologies[$i].FSTransformationFetishist -= Math.trunc(($arcologies[$j].FSBodyPurist-60)/4)+$appliedInfluenceBonus>>
@@ -1523,7 +1534,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<elseif $arcologies[$j].FSTransformationFetishist > 60>>
 	<<if $arcologies[$i].FSTransformationFetishist != "unset">>
 		<<set $arcologies[$i].FSTransformationFetishist += Math.trunc(($arcologies[$j].FSTransformationFetishist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSTransformationFetishist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSTransformationFetishist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Transformation Fetishism")>>
 	<<elseif $arcologies[$i].FSBodyPurist != "unset">>
 		<<set $arcologies[$i].FSBodyPurist -= Math.trunc(($arcologies[$j].FSTransformationFetishist-60)/4)+$appliedInfluenceBonus>>
@@ -1533,7 +1544,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<if $arcologies[$j].FSYouthPreferentialist > 60>>
 	<<if $arcologies[$i].FSYouthPreferentialist != "unset">>
 		<<set $arcologies[$i].FSYouthPreferentialist += Math.trunc(($arcologies[$j].FSYouthPreferentialist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSYouthPreferentialist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSYouthPreferentialist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Youth Preferentialism")>>
 	<<elseif $arcologies[$i].FSMaturityPreferentialist != "unset">>
 		<<set $arcologies[$i].FSMaturityPreferentialist -= Math.trunc(($arcologies[$j].FSYouthPreferentialist-60)/4)+$appliedInfluenceBonus>>
@@ -1542,7 +1553,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<elseif $arcologies[$j].FSMaturityPreferentialist > 60>>
 	<<if $arcologies[$i].FSMaturityPreferentialist != "unset">>
 		<<set $arcologies[$i].FSMaturityPreferentialist += Math.trunc(($arcologies[$j].FSMaturityPreferentialist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSMaturityPreferentialist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSMaturityPreferentialist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Maturity Preferentialism")>>
 	<<elseif $arcologies[$i].FSYouthPreferentialist != "unset">>
 		<<set $arcologies[$i].FSYouthPreferentialist -= Math.trunc(($arcologies[$j].FSMaturityPreferentialist-60)/4)+$appliedInfluenceBonus>>
@@ -1552,7 +1563,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<if $arcologies[$j].FSSlimnessEnthusiast > 60>>
 	<<if $arcologies[$i].FSSlimnessEnthusiast != "unset">>
 		<<set $arcologies[$i].FSSlimnessEnthusiast += Math.trunc(($arcologies[$j].FSSlimnessEnthusiast-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSSlimnessEnthusiast > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSSlimnessEnthusiast > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Slimness Enthusiasm")>>
 	<<elseif $arcologies[$i].FSAssetExpansionist != "unset">>
 		<<set $arcologies[$i].FSAssetExpansionist -= Math.trunc(($arcologies[$j].FSSlimnessEnthusiast-60)/4)+$appliedInfluenceBonus>>
@@ -1561,7 +1572,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<elseif $arcologies[$j].FSAssetExpansionist > 60>>
 	<<if $arcologies[$i].FSAssetExpansionist != "unset">>
 		<<set $arcologies[$i].FSAssetExpansionist += Math.trunc(($arcologies[$j].FSAssetExpansionist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSAssetExpansionist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSAssetExpansionist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Asset Expansionism")>>
 	<<elseif $arcologies[$i].FSSlimnessEnthusiast != "unset">>
 		<<set $arcologies[$i].FSSlimnessEnthusiast -= Math.trunc(($arcologies[$j].FSAssetExpansionist-60)/4)+$appliedInfluenceBonus>>
@@ -1571,7 +1582,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<if $arcologies[$j].FSPastoralist > 60>>
 	<<if $arcologies[$i].FSPastoralist != "unset">>
 		<<set $arcologies[$i].FSPastoralist += Math.trunc(($arcologies[$j].FSPastoralist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSPastoralist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSPastoralist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Pastoralism")>>
 	<<elseif $arcologies[$i].FSPhysicalIdealist != "unset">>
 		<<set $arcologies[$i].FSPhysicalIdealist -= Math.trunc(($arcologies[$j].FSPastoralist-60)/4)+$appliedInfluenceBonus>>
@@ -1580,7 +1591,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<elseif $arcologies[$j].FSPhysicalIdealist > 60>>
 	<<if $arcologies[$i].FSPhysicalIdealist != "unset">>
 		<<set $arcologies[$i].FSPhysicalIdealist += Math.trunc(($arcologies[$j].FSPhysicalIdealist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSPhysicalIdealist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSPhysicalIdealist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Physical Idealism")>>
 	<<elseif $arcologies[$i].FSPastoralist != "unset">>
 		<<set $arcologies[$i].FSPastoralist -= Math.trunc(($arcologies[$j].FSPhysicalIdealist-60)/4)+$appliedInfluenceBonus>>
@@ -1590,14 +1601,14 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<if $arcologies[$j].FSChattelReligionist > 60>>
 	<<if $arcologies[$i].FSChattelReligionist != "unset">>
 		<<set $arcologies[$i].FSChattelReligionist += Math.trunc(($arcologies[$j].FSChattelReligionist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSChattelReligionist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSChattelReligionist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Chattel Religionism")>>
 	<</if>>
 <</if>>
 <<if $arcologies[$j].FSRomanRevivalist > 60>>
 	<<if $arcologies[$i].FSRomanRevivalist != "unset">>
 		<<set $arcologies[$i].FSRomanRevivalist += Math.trunc(($arcologies[$j].FSRomanRevivalist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSRomanRevivalist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSRomanRevivalist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Roman Revivalism")>>
 	<<elseif $arcologies[$i].FSEgyptianRevivalist != "unset">>
 		<<set $arcologies[$i].FSEgyptianRevivalist -= Math.trunc(($arcologies[$j].FSRomanRevivalist-60)/4)+$appliedInfluenceBonus>>
@@ -1615,7 +1626,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<elseif $arcologies[$j].FSEgyptianRevivalist > 60>>
 	<<if $arcologies[$i].FSEgyptianRevivalist != "unset">>
 		<<set $arcologies[$i].FSEgyptianRevivalist += Math.trunc(($arcologies[$j].FSEgyptianRevivalist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSEgyptianRevivalist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSEgyptianRevivalist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Egyptian Revivalism")>>
 	<<elseif $arcologies[$i].FSRomanRevivalist != "unset">>
 		<<set $arcologies[$i].FSRomanRevivalist -= Math.trunc(($arcologies[$j].FSEgyptianRevivalist-60)/4)+$appliedInfluenceBonus>>
@@ -1633,7 +1644,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<elseif $arcologies[$j].FSEdoRevivalist > 60>>
 	<<if $arcologies[$i].FSEdoRevivalist != "unset">>
 		<<set $arcologies[$i].FSEdoRevivalist += Math.trunc(($arcologies[$j].FSEdoRevivalist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSEdoRevivalist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSEdoRevivalist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Edo Revivalism")>>
 	<<elseif $arcologies[$i].FSEgyptianRevivalist != "unset">>
 		<<set $arcologies[$i].FSEgyptianRevivalist -= Math.trunc(($arcologies[$j].FSEdoRevivalist-60)/4)+$appliedInfluenceBonus>>
@@ -1651,7 +1662,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<elseif $arcologies[$j].FSArabianRevivalist > 60>>
 	<<if $arcologies[$i].FSArabianRevivalist != "unset">>
 		<<set $arcologies[$i].FSArabianRevivalist += Math.trunc(($arcologies[$j].FSArabianRevivalist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSArabianRevivalist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSArabianRevivalist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Arabian Revivalism")>>
 	<<elseif $arcologies[$i].FSEgyptianRevivalist != "unset">>
 		<<set $arcologies[$i].FSEgyptianRevivalist -= Math.trunc(($arcologies[$j].FSArabianRevivalist-60)/4)+$appliedInfluenceBonus>>
@@ -1669,7 +1680,7 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<elseif $arcologies[$j].FSChineseRevivalist > 60>>
 	<<if $arcologies[$i].FSChineseRevivalist != "unset">>
 		<<set $arcologies[$i].FSChineseRevivalist += Math.trunc(($arcologies[$j].FSChineseRevivalist-60)/4)+$appliedInfluenceBonus>>
-	<<if $arcologies[$i].FSChineseRevivalist > $FSLockinLevel>><<set $seed += 1>><</if>>
+	<<if $arcologies[$i].FSChineseRevivalist > $FSLockinLevel>><<set _alignment += 1>><</if>>
 	<<set $desc.push("helping to advance its Chinese Revivalism")>>
 	<<elseif $arcologies[$i].FSEgyptianRevivalist != "unset">>
 		<<set $arcologies[$i].FSEgyptianRevivalist -= Math.trunc(($arcologies[$j].FSChineseRevivalist-60)/4)+$appliedInfluenceBonus>>
@@ -1703,19 +1714,22 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
   ''$arcologies[$j].name'''s culture is beginning to influence $arcologies[$i].name's $desc[0].
 <</if>>
 
-<<if $appliedInfluenceBonus != 0>>
+<<if $appliedInfluenceBonus < 0>>
 <<if $appliedInfluenceBonus < 5>>
 	$arcologies[$j].name is societally advanced, giving it extra influence.
 <<else>>
 	$arcologies[$j].name is societally fanatical, lending it great influence.
 <</if>>
 <</if>>
+<<if $arcologies[$i].ownership >= 100>>
+	<<if $appliedInfluenceBonus < 0>>However, <</if>>$arcologies[$i].name is under completely unified control, making it resistant to change.
+<</if>>
 
 <<if $arcologies[$j].direction != 0>>
 	<<if $desc.length == 0>>
 	''$arcologies[$j].name'' is not satisfied with the impact its directed influence is having, and withdraws it with the intention of targeting it elsewhere.
 	<<set $arcologies[$j].influenceTarget to -1>>
-	<<elseif $seed >= 4>>
+	<<elseif _alignment >= 4>>
 	''$arcologies[$j].name'' is satisfied that its influence has brought $arcologies[$i].name into alignment, and withdraws its direct influence with the intention of targeting it elsewhere.
 	<<set $arcologies[$j].influenceTarget to -1>>
 	<</if>>
@@ -1730,61 +1744,61 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <<if $arcologies[$i].direction != 0>>
 <<if $arcologies[$i].influenceTarget == -1>>
 
-<<set $seed to 0>> /* CHECK IF INFLUENTIAL */
+<<set _influential to 0>> /* CHECK IF INFLUENTIAL */
 <<if $arcologies[$i].FSSubjugationist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <</if>>
 <<if $arcologies[$i].FSSupremacist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <<elseif $arcologies[$i].FSGenderRadicalist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <</if>>
 <<if $arcologies[$i].FSGenderFundamentalist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <</if>>
 <<if $arcologies[$i].FSPaternalist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <<elseif $arcologies[$i].FSDegradationist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <</if>>
 <<if $arcologies[$i].FSBodyPurist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <<elseif $arcologies[$i].FSTransformationFetishist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <</if>>
 <<if $arcologies[$i].FSYouthPreferentialist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <<elseif $arcologies[$i].FSMaturityPreferentialist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <</if>>
 <<if $arcologies[$i].FSSlimnessEnthusiast > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <<elseif $arcologies[$i].FSAssetExpansionist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <</if>>
 <<if $arcologies[$i].FSPastoralist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <<elseif $arcologies[$i].FSPhysicalIdealist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <</if>>
 <<if $arcologies[$i].FSChattelReligionist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <</if>>
 <<if $arcologies[$i].FSRomanRevivalist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <<elseif $arcologies[$i].FSEgyptianRevivalist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <<elseif $arcologies[$i].FSEdoRevivalist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <<elseif $arcologies[$i].FSArabianRevivalist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <<elseif $arcologies[$i].FSChineseRevivalist > 60>>
-	<<set $seed to 1>>
+	<<set _influential to 1>>
 <</if>>
 
-<<if $seed == 1>> /* SELECT AN ARCOLOGY TO INFLUENCE */
+<<if _influential == 1>> /* SELECT AN ARCOLOGY TO INFLUENCE */
 
-<<set $seed to []>>
+<<set _eligibleTargets to []>>
 <<for $j to 0; $j < $arcologies.length; $j++>>
 <<if $arcologies[$j].direction != $arcologies[$i].direction>>
 <<if ($arcologies[$i].government != "your trustees" && $arcologies[$i].government != "your agent") || ($arcologies[$j].direction != 0)>>
@@ -1793,14 +1807,14 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<<if $arcologies[$j].FSSubjugationist != "unset">>
 	<<if $arcologies[$j].FSSubjugationistRace is $arcologies[$i].FSSubjugationistRace>>
 		<<if $arcologies[$j].FSSubjugationist < $FSLockinLevel>>
-		<<set $seed.push($arcologies[$j].direction)>>
+		<<set _eligibleTargets.push($arcologies[$j].direction)>>
 		<</if>>
 	<<else>>
-		<<set $seed.push($arcologies[$j].direction)>>
+		<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSSupremacist != "unset">>
 	<<if $arcologies[$j].FSSupremacistRace is $arcologies[$i].FSSubjugationistRace>>
-		<<set $seed.push($arcologies[$j].direction)>>
+		<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<</if>>
 <</if>>
@@ -1808,195 +1822,195 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 	<<if $arcologies[$j].FSSupremacist != "unset">>
 	<<if $arcologies[$j].FSSupremacistRace is $arcologies[$i].FSSupremacistRace>>
 		<<if $arcologies[$j].FSSupremacist < $FSLockinLevel>>
-		<<set $seed.push($arcologies[$j].direction)>>
+		<<set _eligibleTargets.push($arcologies[$j].direction)>>
 		<</if>>
 	<<else>>
-		<<set $seed.push($arcologies[$j].direction)>>
+		<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSSubjugationist != "unset">>
 	<<if $arcologies[$j].FSSubjugationistRace is $arcologies[$i].FSSupremacistRace>>
-		<<set $seed.push($arcologies[$j].direction)>>
+		<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<</if>>
 <</if>>
 <<if $arcologies[$i].FSGenderRadicalist != "unset">>
 	<<if $arcologies[$j].FSGenderRadicalist != "unset">>
 	<<if $arcologies[$j].FSGenderRadicalist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSGenderFundamentalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <<elseif $arcologies[$i].FSGenderFundamentalist != "unset">>
 	<<if $arcologies[$j].FSGenderFundamentalist != "unset">>
 	<<if $arcologies[$j].FSGenderFundamentalist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSGenderRadicalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <</if>>
 <<if $arcologies[$i].FSPaternalist != "unset">>
 	<<if $arcologies[$j].FSPaternalist != "unset">>
 	<<if $arcologies[$j].FSPaternalist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSDegradationist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <<elseif $arcologies[$i].FSDegradationist != "unset">>
 	<<if $arcologies[$j].FSDegradationist != "unset">>
 	<<if $arcologies[$j].FSDegradationist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSPaternalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <</if>>
 <<if $arcologies[$i].FSBodyPurist != "unset">>
 	<<if $arcologies[$j].FSBodyPurist != "unset">>
 	<<if $arcologies[$j].FSBodyPurist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSTransformationFetishist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <<elseif $arcologies[$i].FSTransformationFetishist != "unset">>
 	<<if $arcologies[$j].FSTransformationFetishist != "unset">>
 	<<if $arcologies[$j].FSTransformationFetishist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSBodyPurist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <</if>>
 <<if $arcologies[$i].FSYouthPreferentialist != "unset">>
 	<<if $arcologies[$j].FSYouthPreferentialist != "unset">>
 	<<if $arcologies[$j].FSYouthPreferentialist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSMaturityPreferentialist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <<elseif $arcologies[$i].FSMaturityPreferentialist != "unset">>
 	<<if $arcologies[$j].FSMaturityPreferentialist != "unset">>
 	<<if $arcologies[$j].FSMaturityPreferentialist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSYouthPreferentialist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <</if>>
 <<if $arcologies[$i].FSSlimnessEnthusiast != "unset">>
 	<<if $arcologies[$j].FSSlimnessEnthusiast != "unset">>
 	<<if $arcologies[$j].FSSlimnessEnthusiast < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSAssetExpansionist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <<elseif $arcologies[$i].FSAssetExpansionist != "unset">>
 	<<if $arcologies[$j].FSAssetExpansionist != "unset">>
 	<<if $arcologies[$j].FSAssetExpansionist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSSlimnessEnthusiast != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <</if>>
 <<if $arcologies[$i].FSPastoralist != "unset">>
 	<<if $arcologies[$j].FSPastoralist != "unset">>
 	<<if $arcologies[$j].FSPastoralist < $FSLockinLevel>>
-		<<set $seed.push($arcologies[$j].direction)>>
+		<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSPhysicalIdealist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <<elseif $arcologies[$i].FSPhysicalIdealist != "unset">>
 	<<if $arcologies[$j].FSPhysicalIdealist != "unset">>
 	<<if $arcologies[$j].FSPhysicalIdealist < $FSLockinLevel>>
-		<<set $seed.push($arcologies[$j].direction)>>
+		<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSPastoralist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <</if>>
 <<if $arcologies[$i].FSChattelReligionist != "unset">>
 	<<if $arcologies[$j].FSChattelReligionist != "unset">>
 	<<if $arcologies[$j].FSChattelReligionist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<</if>>
 <</if>>
 <<if $arcologies[$i].FSRomanRevivalist != "unset">>
 	<<if $arcologies[$j].FSRomanRevivalist != "unset">>
 	<<if $arcologies[$j].FSRomanRevivalist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSEgyptianRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSEdoRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSArabianRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSChineseRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <<elseif $arcologies[$i].FSEgyptianRevivalist != "unset">>
 	<<if $arcologies[$j].FSEgyptianRevivalist != "unset">>
 	<<if $arcologies[$j].FSEgyptianRevivalist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSRomanRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSEdoRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSArabianRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSChineseRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <<elseif $arcologies[$i].FSEdoRevivalist != "unset">>
 	<<if $arcologies[$j].FSEdoRevivalist != "unset">>
 	<<if $arcologies[$j].FSEdoRevivalist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSEgyptianRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSRomanRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSArabianRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSChineseRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <<elseif $arcologies[$i].FSArabianRevivalist != "unset">>
 	<<if $arcologies[$j].FSArabianRevivalist != "unset">>
 	<<if $arcologies[$j].FSArabianRevivalist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSEgyptianRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSEdoRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSRomanRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSChineseRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <<elseif $arcologies[$i].FSChineseRevivalist != "unset">>
 	<<if $arcologies[$j].FSChineseRevivalist != "unset">>
 	<<if $arcologies[$j].FSChineseRevivalist < $FSLockinLevel>>
-			<<set $seed.push($arcologies[$j].direction)>>
+			<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 	<<elseif $arcologies[$j].FSEgyptianRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSEdoRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSArabianRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<<elseif $arcologies[$j].FSRomanRevivalist != "unset">>
-	<<set $seed.push($arcologies[$j].direction)>>
+	<<set _eligibleTargets.push($arcologies[$j].direction)>>
 	<</if>>
 <</if>>
 
@@ -2004,8 +2018,8 @@ has an estimated GSP of @@color:yellowgreen;¤<<print Math.trunc((0.1*$arcologie
 <</if>>
 <</for>>
 
-<<if $seed.length > 0>>
-	<<set $arcologies[$i].influenceTarget to $seed.random()>>
+<<if _eligibleTargets.length > 0>>
+	<<set $arcologies[$i].influenceTarget to _eligibleTargets.random()>>
 <</if>>
 
 <</if>> /* CLOSES SELECT AN ARCOLOGY TO INFLUENCE */

--- a/src/uncategorized/neighborsFSAdoption.tw
+++ b/src/uncategorized/neighborsFSAdoption.tw
@@ -735,7 +735,7 @@ societal development.
 <</switch>>
 <<switch random(1,20)>>
 <<case 1>>
-	<<set $seed to either("white", "asian", "latina", "middle eastern", "black", "indo-aryan", "pacific islander", "amerindian", "southern european", "semitic")>>
+	<<set $seed to either("white", "asian", "latina", "middle eastern", "black", "indo-aryan", "pacific islander", "malay", "amerindian", "southern european", "semitic", "mixed race")>>
 	<<if ($arcologies[$i].FSSubjugationist is "unset")>>
 	<<if ($arcologies[$i].FSSupremacist is "unset") || ($seed != $arcologies[$i].FSSupremacistRace)>>
 	$desc preoccupied by a racial animus towards $seed people, leading the arcology to @@color:yellow;adopt $seed Subjugation.@@
@@ -744,7 +744,7 @@ societal development.
 	<</if>>
 	<</if>>
 <<case 2>>
-	<<set $seed to either("white", "asian", "latina", "middle eastern", "black", "indo-aryan", "pacific islander", "amerindian", "southern european", "semitic")>>
+	<<set $seed to either("white", "asian", "latina", "middle eastern", "black", "indo-aryan", "pacific islander", "malay", "amerindian", "southern european", "semitic", "mixed race")>>
 	<<if ($arcologies[$i].FSSupremacist is "unset")>>
 	<<if ($arcologies[$i].FSSubjugationist is "unset") || ($seed != $arcologies[$i].FSSubjugationistRace)>>
 	$desc preoccupied by belief in the superiority of the $seed race, leading the arcology to @@color:yellow;adopt $seed Supremacy.@@

--- a/src/uncategorized/policies.tw
+++ b/src/uncategorized/policies.tw
@@ -141,7 +141,7 @@
 <</if>>
 
 <</if>>
-<<if $alwaysSubsidizeGrowth + $alwaysSubsidizeRep + $CashForRep + $RepForCash + $PAPublic + $CoursingAssociation > 0>>
+<<if $alwaysSubsidizeGrowth + $alwaysSubsidizeRep + $CashForRep + $RepForCash + $RegularParties + $PAPublic + $CoursingAssociation > 0>>
 <br>__Domestic Policy__
 
 <<if $alwaysSubsidizeGrowth == 1>>
@@ -162,6 +162,14 @@
 <<if $RepForCash == 1>>
 	<br>''Business Selfishness:'' you are leveraging your position as arcology owner for money, even when it disadvantages citizens.
 	[[Repeal|Policies][$RepForCash = 0]]
+<</if>>
+
+<<if $RegularParties == 0>>
+	<br>''Regular Entertainments:'' you are hosting regular parties for prominent citizens, an expected social duty of an arcology owner.
+	[[Repeal|Policies][$RegularParties = 0]]
+	<<if $rep > 18000>>
+		<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will damage your reputation//
+	<</if>>
 <</if>>
 
 <<if $PAPublic == 1>>
@@ -642,7 +650,7 @@
 <<if $AntiImmigrationCash == 0>>
 	<br>''Immigrant Information Brokerage:'' you will covertly sell information on troubled potential immigrants to your arcology to their old world enemies.
 	[[Implement|Policies][$AntiImmigrationCash to 1, $cash -=5000, $rep -= 1000]]
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will produce approximately ¤$policyCost weekly, and slow growth of the citizen population//
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will produce ¤$policyCost weekly, and slow growth of the citizen population//
 <</if>>
 <</if>>
 
@@ -658,7 +666,7 @@
 <<if $ProEnslavementCash == 0>>
 	<br>''Enslavement Kickbacks:'' you will take kickbacks in return for turning a  blind eye to enslavement of poor citizens.
 	[[Implement|Policies][$ProEnslavementCash to 1, $cash -=5000, $rep -= 1000]]
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will produce approximately ¤$policyCost weekly, and reduce the population of citizens//
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will produce ¤$policyCost weekly, and reduce the population of citizens//
 <</if>>
 <</if>>
 
@@ -707,8 +715,14 @@
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will cost approximately ¤$policyCost weekly, and improve your reputation//
 	<br>''Business Selfishness:'' you will leverage your position as arcology owner for money, even when it disadvantages citizens.
 	[[Implement|Policies][$RepForCash to 1, $cash -=5000, $rep -= 1000]]
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will cost some reputation, and produce a small amount of ¤ weekly//
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will cost some reputation, and produce approximately ¤$policyCost weekly//
 <</if>>
+<</if>>
+
+<<if $RegularParties == 0>>
+	<br>''Regular Entertainments:'' you will host regular parties for prominent citizens, an expected social duty of an arcology owner.
+	[[Implement|Policies][$RegularParties to 1, $cash -=5000, $rep -= 1000]]
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will cost ¤$policyCost weekly<<if $rep > 18000>> , and prevent damage to your reputation<</if>>//
 <</if>>
 
 <<if $PAPublic == 0>>

--- a/src/uncategorized/randomIndividualEvent.tw
+++ b/src/uncategorized/randomIndividualEvent.tw
@@ -738,6 +738,18 @@
 <</if>>
 <</if>>
 
+<<if $eventSlave.fetish == "sadist">>
+<<if $eventSlave.fetishStrength > 20>>
+<<if $eventSlave.arcade != 0>>
+<<if $eventSlave.trust > -20>>
+<<if $eventSlave.devotion > 50>>
+	<<set $RESSevent.push("arcade sadist")>>
+<</if>>
+<</if>>
+<</if>>
+<</if>>
+<</if>>
+
 <</if>> /* closes mute exempt */
 
 <<if $eventSlave.trust > 20>>

--- a/src/uncategorized/randomNonindividualEvent.tw
+++ b/src/uncategorized/randomNonindividualEvent.tw
@@ -1019,8 +1019,11 @@
 	<<set $events.push("REM merger")>>
 <</if>>
 
-<<if $rep-10000 > random(1,10000)>>
-	<<set $events.push("RE female arcology owner")>>
+<<if $RegularParties == 1>>
+	<<set $events.push("RE citizen hookup")>>
+	<<if $rep-10000 > random(1,10000)>>
+		<<set $events.push("RE female arcology owner")>>
+	<</if>>
 <</if>>
 
 <<set $REM to []>>

--- a/src/uncategorized/reCitizenHookup.tw
+++ b/src/uncategorized/reCitizenHookup.tw
@@ -1,0 +1,298 @@
+:: RE citizen hookup [nobr]
+
+<<set $nextButton to "Continue", $nextLink to "RIE Eligibility Check">>
+
+<<set _FS = []>>
+<<if $arcologies[0].FSSubjugationist != "unset">>
+	<<set _FS.push("Subjugationist")>>
+<</if>>
+<<if $arcologies[0].FSSupremacist != "unset">>
+	<<set _FS.push("Supremacist")>>
+<</if>>
+<<if $arcologies[0].FSGenderRadicalist != "unset">>
+	<<set _FS.push("Gender Radicalist")>>
+<<elseif $arcologies[0].FSGenderFundamentalist != "unset">>
+	<<set _FS.push("Gender Fundamentalist")>>
+<</if>>
+<<if $arcologies[0].FSPaternalist != "unset">>
+	<<set _FS.push("Paternalist")>>
+<<elseif $arcologies[0].FSDegradationist != "unset">>
+	<<set _FS.push("Degradationist")>>
+<</if>>
+<<if $arcologies[0].FSBodyPurist != "unset">>
+	<<set _FS.push("Body Purist")>>
+<<elseif $arcologies[0].FSTransformationFetishist != "unset">>
+	<<set _FS.push("Transformation Fetishist")>>
+<</if>>
+<<if $arcologies[0].FSYouthPreferentialist != "unset">>
+	<<set _FS.push("Youth Preferentialist")>>
+<<elseif $arcologies[0].FSMaturityPreferentialist != "unset">>
+	<<set _FS.push("Maturity Preferentialist")>>
+<</if>>
+<<if $arcologies[0].FSSlimnessEnthusiast != "unset">>
+	<<set _FS.push("Slimness Enthusiast")>>
+<<elseif $arcologies[0].FSAssetExpansionist != "unset">>
+	<<set _FS.push("Asset Expansionist")>>
+<</if>>
+<<if $arcologies[0].FSPastoralist != "unset">>
+	<<set _FS.push("Pastoralist")>>
+<<elseif $arcologies[0].FSPhysicalIdealist != "unset">>
+	<<set _FS.push("Physical Idealist")>>
+<</if>>
+<<if $arcologies[0].FSChattelReligionist != "unset">>
+	<<set _FS.push("Chattel Religionist")>>
+<</if>>
+<<if $arcologies[0].FSRomanRevivalist != "unset">>
+	<<set _FS.push("Roman Revivalist")>>
+<<elseif $arcologies[0].FSEgyptianRevivalist != "unset">>
+	<<set _FS.push("Egyptian Revivalist")>>
+<<elseif $arcologies[0].FSEdoRevivalist != "unset">>
+	<<set _FS.push("Edo Revivalist")>>
+<<elseif $arcologies[0].FSArabianRevivalist != "unset">>
+	<<set _FS.push("Arabian Revivalist")>>
+<<elseif $arcologies[0].FSChineseRevivalist != "unset">>
+	<<set _FS.push("Chinese Revivalist")>>
+<</if>>
+<<if _FS.length > 0>>
+	<<set _FS = _FS.random()>>
+<<else>>
+	<<set _FS = "none">>
+<</if>>
+
+At night, the best living areas in the arcology offer a constant melange of selective entertainments. There's a perpetual social scrum of who is to be invited to what going on, and you occupy a preeminent place atop it, mostly aloof from the struggles of your citizens for recognition and influence. You're invited to almost everything, since everyone who lives here knows the value of being in favor with the owner of the arcology. Invitations to your parties, of course, are some of the most valuable social currency in the arcology and one of $assistantName's most important duties is to help you manage them without wasting your valuable time. It's not actually necessary for you to attend your own parties, since almost everyone will be glad to be seen in the entertainment area of the penthouse whether or not the propriet<<if $PC.title == 1>>or<<else>>ress<</if>> is actually present.
+<br><br>
+But tonight, you've put in an appearance. Your citizens are drinking your <<if $arcologies[0].FSPastoralist != "unset">>milk<<else>>alcohol<</if>> and eating your food, though of course they helped pay for it through their rent. They're performing a complex dance of social dominance, and it all radiates around you, with complex unspoken rules of collective approval governing which citizens cycle past you for a word, and for how long. During a low point in the ebb and flow, a
+<<switch _FS>>
+<<case "Supremacist" "Subjugationist">>
+	pretty, racially pure young woman
+<<case "Gender Radicalist">>
+	beautiful young futa
+<<case "Gender Fundamentalist">>
+	good-looking young lady
+<<case "Paternalist">>
+	pretty, cheerful young woman
+<<case "Degradationist">>
+	confident girl
+<<case "Body Purist">>
+	clean-looking young woman
+<<case "Transformation Fetishist">>
+	nicely augmented girl
+<<case "Youth Preferentialist">>
+	nice looking girl
+<<case "Maturity Preferentialist">>
+	attractive, mature woman
+<<case "Slimness Enthusiast">>
+	slim young thing
+<<case "Asset Expansionist">>
+	curvaceous young woman
+<<case "Pastoralist">>
+	hot little lady
+<<case "Physical Idealist">>
+	hot little amazon
+<<case "Chattel Religionist">>
+	pretty, devout-looking young woman
+<<case "Roman Revivalist">>
+	proper young Roman lady
+<<case "Egyptian Revivalist">>
+	pretty, sun-kissed lady
+<<case "Edo Revivalist">>
+	proper Edo lady
+<<case "Arabian Revivalist">>
+	pretty Arabian princess
+<<case "Chinese Revivalist">>
+	pretty Chinese lady
+<<default>>
+	pretty young woman
+<</switch>>
+sidles up to you. She begins to introduce herself, but one of the advantages of your connection to the arcology is that you always know who everyone is, and you greet her by name, which people have never learned not to be impressed by. She gushes about some of your recent <<if _FS != "none">>_FS <</if>>actions, displaying an unusual grasp of what you've been planning. Despite her obviously sincere interest, she's obviously got something else on her mind.
+<br><br>
+She's yours for the taking, if you want her, and if her praise and proximity weren't enough to make that clear, she manages to
+<<switch _FS>>
+<<case "Supremacist" "Subjugationist">>
+	give you an excellent view straight down her ethnically superior cleavage, straining against the top of her fashionable dress.
+<<case "Gender Radicalist">>
+	simultaneously give you an excellent view straight down her cleavage, and bring the material of her sheer dress tight across her legs in a way that outlines her dick.
+<<case "Gender Fundamentalist">>
+	press her flirting as far she can decorously take it, batting her eyes at you coquettishly.
+<<case "Paternalist">>
+	brush her breasts against your arm, presuming on the egalitarian nature of your Paternalist society to flirt a little aggressively.
+<<case "Degradationist">>
+	raise one shoulder far enough that her breast on that side pulls its nipple just clear of her tight leather dress, revealing a spiked piercing.
+<<case "Body Purist">>
+	arch her back with such warm propinquity that her natural breasts almost spill out of her tight little dress, and actually reveal the upper edges of their areolae.
+<<case "Transformation Fetishist">>
+	pop her huge fake boobs entirely out of her tight little evening dress without even using her hands.
+<<case "Youth Preferentialist">>
+	perfectly balance her youthful, innocent appeal with the proper decorum between you and a citizen.
+<<case "Maturity Preferentialist">>
+	perfectly balance her matronly, sensual appeal with the proper decorum between you and a citizen.
+<<case "Slimness Enthusiast">>
+	turn from side to side as she flirts with you in a way that shows off the coquettish forum under her tight dress to great effect.
+<<case "Asset Expansionist">>
+	arch her back with such warm propinquity that her huge breasts spill out of her tight little dress, springing clear to offer themselves glorious and nude.
+<<case "Pastoralist">>
+	let you know that she's almost entirely milk-fed, while giving you quite an eyeful of her straining cleavage.
+<<case "Physical Idealist">>
+	get a pretty good flex going without being obvious about it, outlining her abs against the sheer midsection of her tight dress.
+<<case "Chattel Religionist">>
+	assume just a hint of a Chattel Religionist devotional pose used to request penetration. It's heavy flirting, of a modern religious sort.
+<<case "Roman Revivalist">>
+	hint that her pudicitia, that is her purity, would be if anything enhanced by sexual commerce with someone as powerful as you.
+<<case "Egyptian Revivalist">>
+	hint that she would like nothing better than to bask in the pharaonic light in the arcology, very close to its source, while loosening her linen dress a little.
+<<case "Edo Revivalist">>
+	allude to the refined pleasures, while assuming a slightly less dignified posture in her gorgeous kimono.
+<<case "Arabian Revivalist">>
+	reference young Scheherazade and mighty Shahryar in a way that suggests she's quite willing to play the former.
+<<case "Chinese Revivalist">>
+	allude to the divinity that resides with the powerful, implying that she'd very much like to come closer to it.
+<<default>>
+	flirt with you quite hard without crossing any lines between a citizen and an arcology owner.
+<</switch>>
+She's clearly attracted to you; even the most consummate actress would have difficulty fooling you, and her breath is a little quick, her pupils are a bit dilated, and she's blushing cutely. But she's no fool, either. A casual liasion with <<PCTitle>>$PCTitle would be a tremendous social boost for her.
+<br><br>
+
+<span id="result">
+<<link "Keep aloof without offending her">>
+	<<replace "#result">>
+	You thank her for her praise, weighting the words in just the right way to communicate that you consider her flirtations worthy compliments, and nothing more. She understands immediately, communicating acceptance and pleasure at her own daring with nothing more than a thankful look in your eyes. This is how you approach matters like this. You are the ruler of this place and it behooves you to maintain a balance atop all your citizens without showing any susceptibility to solicitation. A little incident like this has little effect on its own, but your habit of maintaining proper reserve creates a reputation for judiciousness that @@color:green;businesspeople consider attractive for arcology investment.@@
+	<<set $arcologies[0].prosperity += 3>>
+	<</replace>>
+<</link>>
+<br><<link "To them that hath, it shall be given">>
+	<<replace "#result">>
+	You're not exactly starved for casual sex, but you've never thought there was any such thing as too much of a good thing. You place a <<if $PC.title == 1>>masculine<<else>>feminine<</if>> hand against the small of her back, feeling the warmth of her through the material of her evening wear. You hear a slight gasp from her as she realizes that her gambit has succeeded with more immediate effect than she expected. She shivers with anticipation as you steer her back through a side door, making a discreet exit towards your private suite.
+	<<if $Concubine != 0>><<if $Concubine.intelligence > 1>>
+		$Concubine.slaveName is there, of course, and she instantly sees that her continued presence for a menage a trois is wanted by both you and your guest.
+	<</if>><</if>>
+	Your guest restrains her eager praise now that you're in private, but her wide-eyed appreciation of your domain is compliment enough. Once in your suite, she strips, revealing
+	<<switch _FS>>
+	<<case "Supremacist" "Subjugationist">>
+		her fresh, pure body.
+	<<case "Gender Radicalist">>
+		perky young breasts, a pretty pussy, and a stiff dick above it.
+	<<case "Gender Fundamentalist">>
+		perky young breasts and an elegantly coiffed strip of hair that perfectly highlights her demure pussy.
+	<<case "Paternalist">>
+		a nice young body, with all the little attractions and flaws of a free girl's.
+	<<case "Degradationist">>
+		a taut body covered in dominant tattoos and spiky piercings.
+	<<case "Body Purist">>
+		a delectably curvaceous young body unmarred by any trace of surgical intervention.
+	<<case "Transformation Fetishist">>
+		a massive fake bubble butt to go with her fake boobs.
+	<<case "Youth Preferentialist">>
+		that her whole body looks fresh, untouched, and quite young.
+	<<case "Maturity Preferentialist">>
+		a big pair of motherly tits, generous hips, a broad ass, and total self confidence.
+	<<case "Slimness Enthusiast">>
+		perky little breasts, a smooth waist, trim hips, and a cute little ass.
+	<<case "Asset Expansionist">>
+		an inhumanly enormous ass to match her similarly improbable boobs.
+	<<case "Pastoralist">>
+		amply milk-fed assets.
+	<<case "Physical Idealist">>
+		the dimples that form on the sides of her cute buttocks when she flexes.
+	<<case "Chattel Religionist">>
+		a fresh and ready body, adorned here and there with sensual devotional jewelry.
+	<<case "Roman Revivalist">>
+		a graceful, milk-pale vision of classical beauty.
+	<<case "Egyptian Revivalist">>
+		a perfect expanse of smooth, warm, tanned skin.
+	<<case "Edo Revivalist">>
+		a graceful form so perfectly pale that her face requires almost no whitening at all.
+	<<case "Arabian Revivalist">>
+		a nubile young body perfectly formed for a Sultan's bed.
+	<<case "Chinese Revivalist">>
+		a pretty young body that would not look out of place in an Imperial bed.
+	<<default>>
+		a hot young body.
+	<</switch>>
+	Citizens like her often appreciate a good hard fuck, since regular submission to a pounding from sex slaves would be a scandal. There's little opprobium waiting for you if it's known you had her, though, and she's deliciously eager as you press her down onto the bed<<if $PC.dick == 0>> and pull on your usual harness<</if>>. She ruts herself hard back against you as you thrust into her, moaning, and after a short while she begs for it even harder, so you flip her over and mount her like a bitch, making her scream.
+	<<if $Concubine != 0>><<if $Concubine.intelligence > 1>>
+		The view of your conquest's rutting back is nice, of course, but after enjoying it for a few moments you pull $Concubine.slaveName in and kiss your favorite deeply, playing with her as you fuck.
+	<</if>><</if>>
+	When your guest is finally spent, she showers, dresses, and leaves discreetly, offering you a proper thank you. This is the kind of thing that @@color:green;builds a lasting reputation@@ in the Free Cities.
+	<<set $rep += 1000>>
+	<<if _FS != "none">>
+		<<set $desc = "a tasteful morning-after message from a pretty " + _FS + " citizen">>
+		<<set $trinkets.push($desc)>>
+	<<else>>
+		<<set $trinkets.push("a tasteful morning-after message from a pretty citizen")>>
+	<</if>>
+	<</replace>>
+<</link>>
+<<if _FS != "none">>
+<br><<link "Emphasize her societal style with exhibitionism">>
+	<<replace "#result">>
+	You turn to face her straight on, and something about the look in your eye fills her with mixed apprehension and anticipation. You agree with her banter and praise her for being so forward-thinking, before transitioning to more direct praise of her style and then her body. You're speaking in a tone that cuts through the room, and by the time you kiss your willing conquest, there's not a person in the room who isn't paying attention. They all understand the message: this gathering is turning into something else, now. Those few who aren't willing to fuck in public withdraw, and everyone who didn't come with a sexual partner sends urgent messages to have appropriate slaves brought from their apartments. You make out with her for a while, letting everyone make arrangements, and then pull her clothes off, making sure her
+	<<switch _FS>>
+	<<case "Supremacist" "Subjugationist">>
+		superior body
+		<<if $FS == "Supremacist">>
+			<<set $arcologies[0].FSSupremacist += 5>>
+		<<else>>
+			<<set $arcologies[0].FSSubjugationist += 5>>
+		<</if>>
+	<<case "Gender Radicalist">>
+		tits and stiff dick
+		<<set $arcologies[0].FSGenderRadicalist += 5>>
+	<<case "Gender Fundamentalist">>
+		femininity
+		<<set $arcologies[0].FSGenderFundamentalist += 5>>
+	<<case "Paternalist">>
+		appealing body
+		<<set $arcologies[0].FSPaternalist += 5>>
+	<<case "Degradationist">>
+		dominant form
+		<<set $arcologies[0].FSDegradationist += 5>>
+	<<case "Body Purist">>
+		natural body
+		<<set $arcologies[0].FSBodyPurist += 5>>
+	<<case "Transformation Fetishist">>
+		fake butt
+		<<set $arcologies[0].FSTransformationFetishist += 5>>
+	<<case "Youth Preferentialist">>
+		young body
+		<<set $arcologies[0].FSYouthPreferentialist += 5>>
+	<<case "Maturity Preferentialist">>
+		mature body
+		<<set $arcologies[0].FSMaturityPreferentialist += 5>>
+	<<case "Slimness Enthusiast">>
+		slender body
+		<<set $arcologies[0].FSSlimnessEnthusiast += 5>>
+	<<case "Asset Expansionist">>
+		curvaceous form
+		<<set $arcologies[0].FSAssetExpansionist += 5>>
+	<<case "Pastoralist">>
+		milk-fed assets
+		<<set $arcologies[0].FSPastoralist += 5>>
+	<<case "Physical Idealist">>
+		muscular body
+		<<set $arcologies[0].FSPhysicalIdealist += 5>>
+	<<case "Chattel Religionist">>
+		divine sexuality
+		<<set $arcologies[0].FSChattelReligionist += 5>>
+	<<case "Roman Revivalist">>
+		elegant form
+		<<set $arcologies[0].FSRomanRevivalist += 5>>
+	<<case "Egyptian Revivalist">>
+		beautiful tanned body
+		<<set $arcologies[0].FSEgyptianRevivalist += 5>>
+	<<case "Edo Revivalist" "Arabian Revivalist" "Chinese Revivalist">>
+		graceful form
+		<<if $FS == "Edo Revivalist">>
+			<<set $arcologies[0].FSEdoRevivalist += 5>>
+		<<elseif $FS == "Arabian Revivalist">>
+			<<set $arcologies[0].FSArabianRevivalist += 5>>
+		<<else>>
+			<<set $arcologies[0].FSChineseRevivalist += 5>>
+		<</if>>
+	<<default>>
+		hot young body
+	<</switch>>
+	is obvious to everyone. The message is clear, and your guest of honor is the center of attention as you take her there in view of the arcology's leading citizens. Naturally, the story percolates, making it clear that there's nothing you won't do to @@color:green;further acceptance of _FS principles.@@
+	<</replace>>
+<</link>>
+<</if>>
+</span>

--- a/src/uncategorized/reFemaleArcologyOwner.tw
+++ b/src/uncategorized/reFemaleArcologyOwner.tw
@@ -1,26 +1,21 @@
-:: RE female arcology owner
+:: RE female arcology owner [nobr]
 
-<<nobr>>
+<<set $nextButton to "Continue", $nextLink to "RIE Eligibility Check">>
 
-<<set $nextButton to "Continue">>
-<<set $nextLink to "RIE Eligibility Check">>
-<<set $nextButton to "Continue">>
-
-<</nobr>>\
-\
 The more reputable you've gotten, the more rarefied your entertainments have become. Parties featuring celebrities, old world national leaders, and Free Cities arcology owners have become a nearly nightly experience for you, an expected part of your routine as one of the Free Cities' leading citizens. According to your whims and predilections, you have the choice of participating all night or just making a brief appearance at the start. The important thing is that they're here, come to pay tribute by their presence.
-
+<br><br>
 Tonight there are several attendees of such stature that you must exchange pleasantries with each. The last is a fellow arcology owner, not quite up to your stature of course, but certainly worth conciliating. Unusually, she's a woman. She comes up almost to your height, with the aid of very tall spike heels, and is wearing one of the best-tailored suits you've ever seen. The skirt is just short enough to hint at sexuality, and she has lovely, athletic legs; the jacket is feminine, yet makes her trim fitness very clear. She is obviously well into middle age, but has made no attempt to hide the fact, her understated makeup and elegant bun flattering her years rather than concealing them.
-
+<br><br>
 She strikes a fine balance in conversation with you, firm enough for a rising woman of consequence in a world of wealth and power still mostly male, yet neither aggressive nor insistent. She does not take too much of your time, but after you've moved on to your next prominent guest, you receive a brief private message from her. "It's been a while since I've met someone I can allow to treat me like a woman," it reads. "My slaves are fun enough, but letting one of them or some citizen be my man would be fatally stupid. <<if $PC.title == 1>>I don't think anyone would look down on me for hooking up with you, though.<<else>>I'm lucky you're a lady!<</if>> No strings attached." You glance over at where she's standing. She's listening politely to a business proposition, and she turns her head slightly toward you, one corner of her firm mouth quirking upward.
-\
+<br><br>
+
 <span id="result">
 <<link "Head over and assert yourself">>
 	<<replace "#result">>
 	You head over and insert yourself into the conversation between her and the man trying to convince her to invest in his solar power concern. Your presence and power are such that he gives way rapidly, and you ostentatiously yet nonverbally assert your right to first claim to her company and conversation. After a few minutes of this public display, however, it becomes apparent that this is not what she was looking for. She is likely concerned that this is too much public <<if $PC.title == 1>>submission<<else>>vulnerability<</if>> for her to safely manage. She excuses herself and withdraws. You return to your <<if $PC.refreshmentType == 0>>$PC.refreshmentType<<elseif $PC.refreshmentType == 1>>glass of $PC.refreshment<<elseif $PC.refreshmentType == 2>>plate of $PC.refreshment<<elseif $PC.refreshmentType == 3>>pouch of $PC.refreshment<<else>>syringe of $PC.refreshment<</if>>, consoling yourself that you are not exactly starved for company.
 	<</replace>>
 <</link>>
-<<link "Walk past her and out onto an unoccupied balcony">>
+<br><<link "Walk past her and out onto an unoccupied balcony">>
 	<<replace "#result">>
 	You walk past her and out onto a balcony. She politely disengages herself and follows, meeting your gaze with a twinkle in her eye. You start talking of nothing of real consequence, but you find that you do have a fair amount to discuss and joke about, since there are oddities to your life that only another slaveowning arcology owner can really understand. You discover that she is very willing to share $PC.refreshment, and you break out some of your best. The party takes notice of your tete-a-tete, but her judgment was obviously correct. <<if $PC.title == 0>>You are a pair of powerful women who are very obviously in the early stages of an assignation, and it's hard to tell which of you excites more envy.<<else>>Rather than looking down on her, the other prominent guests seem respectfully envious of her access to you.<</if>> This is still the case even when she starts to soften her body language, leaning into you, brushing against you, and more. <<if $assistantName is "your personal assistant">>Your personal assistant<<else>>$assistantName<</if>> cleared your suite long ago, so when she finally nudges her hip against yours and does not take it away, you take her by the hand and lead her there. She stops you with a hand at the door to the suite and then strips off her suit piece by piece, revealing a triathlete's tanned and sculpted body. You crush her naked form in your still-clothed arms, and she softens into you, whispering, "You have no idea how relaxing this is." <<if $PC.title == 1>>It's clear it's been a long time since she's let someone else take the lead,<<else>>She's obviously an occasional lesbian, at best,<</if>> and she's awkward as a girl at times. She leaves a few hours later with a satisfied expression, giving you a kiss on her way out in full public view. @@color:green;Your reputation has greatly improved.@@
 	<<set $rep += 1000>>
@@ -28,8 +23,8 @@ She strikes a fine balance in conversation with you, firm enough for a rising wo
 	<<set $trinkets.push($desc)>>
 	<</replace>>
 <</link>>
-<<if $mercenaries > 0>>\
-<<link "Quickly arrange an anonymous night out for her">>
+<<if $mercenaries > 0>>
+<br><<link "Quickly arrange an anonymous night out for her">>
 	<<replace "#result">>
 	You immediately enlist $assistantName to help you make some hasty preparations, and then send her a message asking her if she'd like to spend a night out with you, as a couple of unremarkable citizens. She glances at you with a curious expression, and you direct her to a side room. She finds you there, changing into the heavy, anonymizing armor of one of your mercenaries; you have a female suit for her, too. Once you're both suited up, you move to show her how to activate the face-obscuring helmet, but you find that she's already got it on and active. "This," she says, "is either the best or the stupidest date idea I have ever heard. Let's fucking do this." You pass a mercenary on your way out onto the club, and he cannot resist giving you a thumbs up, which your fellow arcology owner fortunately fails to notice. You patrol for a while, using internal comms to joke about life as an arcology owner, something she clearly gets to do too infrequently. You don't mind the chance, either. Your mercenaries frequently spend time together off duty, so nobody sees anything unusual about a <<if $PC.title == 1>>male and female<<else>>couple of ladies<</if>> in mercenary armor sharing a milkshake at a dairy bar, even when they start to engage in increasingly rough public flirting, armor and all. Later, your slaves are obliged to pick up and sort a trail of discarded armor pieces leading from the entry to your penthouse all the way to your suite, which is now emitting the indistinct sounds of very energetic sex. A few hours later, when you're showering up together so she can head back to her domain, she looks up at you and says seriously, "That was pretty fun. If things ever go to shit, I wouldn't mind wearing that armor for real." Your mercenaries cannot keep their mouths shut, for once, and the almost unbelievably juicy story of the arcology owners wearing borrowed armor to go on an anonymous <<if $PC.title == 0>>lesbian <</if>>date spreads like wildfire. @@color:green;Your reputation has greatly improved.@@
 	<<set $desc = "a cute thank-you note from a female arcology owner of your acquaintance">>
@@ -37,5 +32,5 @@ She strikes a fine balance in conversation with you, firm enough for a rising wo
 	<<set $rep += 1000>>
 	<</replace>>
 <</link>>
-<</if>>\
+<</if>>
 </span>

--- a/src/uncategorized/slaveInteract.tw
+++ b/src/uncategorized/slaveInteract.tw
@@ -286,6 +286,85 @@ __Fucktoy use preference__: <strong><span id="hole"><<print $activeSlave.toyHole
 | <<link "No Preference">><<set $activeSlave.toyHole to "all her holes">><<replace "#hole">><<print $activeSlave.toyHole>><</replace>><</link>>
 <</if>>
 
+<<if $activeSlave.fuckdoll == 0>>
+<<if $brothel+$club+$dairy+$servantsQuarters+$masterSuite+$spa+$clinic+$schoolroom+$cellblock+$arcade > 0>>
+<br>__Transfer to__:
+	<<if $brothel != 0>>
+	<<if $brothel > $brothelSlaves>>
+	<<if ($activeSlave.devotion > 50) || (($activeSlave.devotion >= -50) && ($activeSlave.trust < -20)) ||  ($activeSlave.trust < -50) || ($activeSlave.trust > 50)>>
+		[[Brothel|Assign][$returnTo = "Brothel"]]
+	<<else>>Brothel<</if>>
+	<<else>>Brothel<</if>>
+	<</if>>
+	<<if $club != 0>>
+	<<if $club > $clubSlaves>>
+	<<if $brothel != 0>><<if $brothel > $brothelSlaves>>|<</if>><</if>>
+	<<if ($activeSlave.devotion > 50) || (($activeSlave.devotion >= -50) && ($activeSlave.trust < -20)) ||  ($activeSlave.trust < -50) || ($activeSlave.trust > 50)>>
+		[[Club|Assign][$returnTo = "Club"]]
+	<<else>>Club<</if>>
+	<<else>>Club<</if>>
+	<</if>>
+	<<if $dairy != 0>>
+	<<if $dairy > $dairySlaves>>|
+	<<if (($activeSlave.indentureRestrictions > 0) && ($dairyRestraintsSetting > 1)) || (($activeSlave.indentureRestrictions > 1) && ($dairyRestraintsSetting > 0))>>
+		Dairy
+	<<elseif (($activeSlave.lactation > 0) || ($activeSlave.balls > 0)) || (($dairyFeedersUpgrade == 1) && ($dairyFeedersSetting > 0) && ($dairySlimMaintainUpgrade == 0))>>
+		[[Dairy|Assign][$returnTo = "Dairy"]]
+	<<else>>Dairy<</if>>
+	<<else>>Dairy<</if>>
+	<</if>>
+	<<if $servantsQuarters != 0>>
+	<<if $servantsQuarters > $servantsQuartersSlaves>>|
+	<<if ($activeSlave.devotion >= -20) || (($activeSlave.devotion >= -50) && ($activeSlave.trust <= 20)) or  ($activeSlave.trust < -20)>>
+		[[Servants' Quarters|Assign][$returnTo = "Servants' Quarters"]]
+	<<else>>Servants' Quarters<</if>>
+	<<else>>Servants' Quarters<</if>>
+	<</if>>
+	<<if $masterSuite != 0>>
+	<<if $masterSuite > $masterSuiteSlaves>>|
+	<<if ($activeSlave.devotion > 20) || (($activeSlave.devotion >= -50) && ($activeSlave.trust < -20)) or  ($activeSlave.trust < -50)>>
+		[[Master Suite|Assign][$returnTo = "Master Suite"]]
+	<<else>>Master Suite<</if>>
+	<<else>>Master Suite<</if>>
+	<</if>>
+	<<if $spa != 0>>
+	<<if $spa > $spaSlaves>>|
+	<<if ($activeSlave.health < 20) || ($activeSlave.trust < 60) || ($activeSlave.devotion <= 60) || ($activeSlave.fetish is "mindbroken")>>
+		[[Spa|Assign][$returnTo = "Spa"]]
+	<<else>>Spa<</if>>
+	<<else>>Spa<</if>>
+	<</if>>
+	<<if $clinic != 0>>
+	<<if $clinic > $clinicSlaves>>|
+	<<if ($activeSlave.health < 20) || (($activeSlave.chem > 15) && ($clinicUpgradeFilters == 1))>>
+		[[Clinic|Assign][$returnTo = "Clinic"]]
+	<<else>>Clinic<</if>>
+	<<else>>Clinic<</if>>
+	<</if>>
+	<<if $schoolroom != 0>>
+	<<if $schoolroom > $schoolroomSlaves>>|
+	<<if ($activeSlave.devotion >= -20) || (($activeSlave.devotion >= -50) && ($activeSlave.trust < -20)) || ($activeSlave.trust < -50)>>
+		[[Schoolroom|Assign][$returnTo = "Schoolroom"]]
+	<<else>>Schoolroom<</if>>
+	<<else>>Schoolroom<</if>>
+	<</if>>
+	<<if $cellblock != 0>>
+	<<if $cellblock > $cellblockSlaves>>|
+	<<if (($activeSlave.devotion < -20) && ($activeSlave.trust >= -20)) || (($activeSlave.devotion < -50) && ($activeSlave.trust >= -50))>>
+		[[Cellblock|Assign][$returnTo = "Cellblock"]]
+	<<else>>Cellblock<</if>>
+	<<else>>Cellblock<</if>>
+	<</if>>
+<</if>>
+<<if $arcade != 0>>
+<<if $arcade > $cellblockSlaves>>|
+<<if ($activeSlave.indentureRestrictions <= 0)>>
+	[[Arcade|Assign][$returnTo = "Arcade"]]
+<<else>>Arcade<</if>>
+<<else>>Arcade<</if>>
+<</if>>
+<</if>>
+
 <</if>>
 
 /* END NOT RECOVERING */

--- a/src/uncategorized/slaveSummary.tw
+++ b/src/uncategorized/slaveSummary.tw
@@ -70,8 +70,8 @@
 <<case "Spa">>
 <<if _Slave.fuckdoll > 0>><<continue>><</if>>
 <<if $Flag == 0>>
-	<<if (_Slave.assignmentVisible != 1) || ($spa <= $spaSlaves)>><<continue>><</if>>
-	<<if (_Slave.health < 20) || (_Slave.trust < 60) || (_Slave.devotion <= 60) || (_Slave.fetish == "mindbroken")>>
+	<<if $spa <= $spaSlaves>><<continue>><</if>>
+	<<if (_Slave.health < 20) || (_Slave.trust < 60) || (_Slave.devotion <= 60) || (_Slave.fetish is "mindbroken")>>
 	<<if _Slave.devotion >= -20>>
 		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if $seeImages == 1>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave to $slaves["+_i+"]]]">>
 	<<else>>
@@ -104,9 +104,9 @@
 <<case "Brothel">>
 <<if _Slave.fuckdoll > 0>><<continue>><</if>>
 <<if $Flag == 0>>
-	<<if (_Slave.assignmentVisible != 1) || ($brothel <= $brothelSlaves)>><<continue>><</if>>
-	<<if (_Slave.devotion > 50) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50) || (_Slave.trust > 50)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if $seeImages == 1>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave to $slaves["+_i+"]]]">>
+	<<if $brothel <= $brothelSlaves>><<continue>><</if>>
+	<<if (_Slave.devotion > 50) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) ||  (_Slave.trust < -50) || (_Slave.trust > 50)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if $seeImages == 1>><div class="imageRef smlImg"><<SlaveArt $slaves[_i] 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave to $slaves[" + _i + "]]]">>
 	<<else>>
 		<br>//_Slave.slaveName must be either more fearful of you or devoted to you//
 		<<continue>>
@@ -133,7 +133,7 @@
 <<case "Club">>
 <<if _Slave.fuckdoll > 0>><<continue>><</if>>
 <<if $Flag == 0>>
-	<<if (_Slave.assignmentVisible) != 1 || ($club <= $clubSlaves)>><<continue>><</if>>
+	<<if $club <= $clubSlaves>><<continue>><</if>>
 	<<if (_Slave.devotion > 50) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50) || (_Slave.trust > 50)>>
 		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if $seeImages == 1>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave to $slaves["+_i+"]]]">>
 	<<else>>
@@ -162,7 +162,7 @@
 <<case "Clinic">>
 <<if _Slave.fuckdoll > 0>><<continue>><</if>>
 <<if $Flag == 0>>
-	<<if (_Slave.assignmentVisible != 1) || ($clinic <= $clinicSlaves)>><<continue>><</if>>
+	<<if $clinic <= $clinicSlaves>><<continue>><</if>>
 	<<if (_Slave.health < 20) || ((_Slave.chem > 15) && ($clinicUpgradeFilters == 1))>>
 		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if $seeImages == 1>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave to $slaves["+_i+"]]]">>
 	<<else>>
@@ -191,7 +191,7 @@
 <<case "Schoolroom">>
 <<if _Slave.fuckdoll > 0>><<continue>><</if>>
 <<if $Flag == 0>>
-	<<if (_Slave.assignmentVisible != 1) || ($schoolroom <= $schoolroomSlaves)>><<continue>><</if>>
+	<<if $schoolroom <= $schoolroomSlaves>><<continue>><</if>>
 	<<if (_Slave.devotion >= -20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50)>>
 		<<if (_Slave.intelligenceImplant < 1) || (_Slave.accent+$schoolroomUpgradeLanguage > 2) || (_Slave.oralSkill <= 10) || (_Slave.whoreSkill <= 10) || (_Slave.entertainSkill <= 10) || (_Slave.analSkill < 1) || ((_Slave.vaginalSkill < 1) && (_Slave.vagina > 0))>>
 			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if $seeImages == 1>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave to $slaves["+_i+"]]]">>
@@ -225,7 +225,7 @@
 <<case "Dairy">>
 <<if _Slave.fuckdoll > 0>><<continue>><</if>>
 <<if $Flag == 0>>
-	<<if (_Slave.assignmentVisible != 1) || ($dairy <= _DairyM)>><<continue>><</if>>
+	<<if $dairy <= $dairySlaves+$bioreactorsXY+$bioreactorsXX+$bioreactorsHerm+$bioreactorsBarren>><<continue>><</if>>
 	<<if (_Slave.indentureRestrictions > 0) && ($dairyRestraintsSetting > 1)>>
 		<br>//_Slave.slaveName's indenture forbids extractive Dairy service.//
 		<<continue>>
@@ -308,9 +308,9 @@
 <</if>>
 <<case "Master Suite">>
 <<if $Flag == 0>>
-	<<if (_Slave.assignmentVisible != 1) || ($masterSuite <= $masterSuiteSlaves)>><<continue>><</if>>
-	<<if (_Slave.devotion > 20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if $seeImages == 1>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave to $slaves["+_i+"]]]">>
+	<<if $masterSuite <= $masterSuiteSlaves>><<continue>><</if>>
+	<<if (_Slave.devotion > 20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) or  (_Slave.trust < -50)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if $seeImages == 1>><div class="imageRef smlImg"><<SlaveArt $slaves[_i] 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave to $slaves[" + _i + "]]]">>
 	<<else>>
 		<br>//_Slave.slaveName is not sufficiently broken for the master suite//
 		<<continue>>
@@ -337,7 +337,7 @@
 <</if>>
 <<case "Cellblock">>
 <<if $Flag == 0>>
-	<<if (_Slave.assignmentVisible != 1) || ($cellblock <= $cellblockSlaves)>><<continue>><</if>>
+	<<if $cellblock <= $cellblockSlaves>><<continue>><</if>>
 	<<if ((_Slave.devotion < -20) && (_Slave.trust >= -20)) || ((_Slave.devotion < -50) && (_Slave.trust >= -50))>>
 		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if $seeImages == 1>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave to $slaves["+_i+"]]]">>
 	<<else>>


### PR DESCRIPTION
Next public build no sooner than April 3. Most UI changes are untested WIP.

UI tweaks
Added links to slaves' individual menus to assign them to facilities directly.
Allowed reassignment of slaves between facilities without removing them from the first facility.
Arcology share purchases can now be made in lots of 10% if sufficient cash is available, limiting transaction costs.
Other minor UI improvements.

Arcology development changes
Reduced the pace of organic prosperity development for all arcologies; event impacts on prosperity are unchanged.
Added a powerful layer of cultural defensiveness to all arcologies under the complete control of their owners.
All cultural influence modifiers now affect the thresholds for organic influence in addition to the efficacy of targeted influence.

Other updates
Updated many Racialist mechanics to properly support the Malay race, which was previously included in some but not all racial situations.
Enabled mixed race Supremacism and Subjugationism.
Added a policy to determine whether the PC is hosting social events, which is active by default.
New random event in which a young social climber flirts with the PC at one of the PC's social events.
New random slave event for trusting sadists when an Arcade is present.
Some very basic cleanup of old code for sanity and legibility.
Bugfixes.