### PR TITLE
assignWidgets.tw Remove ghost workers

### DIFF
--- a/src/utility/assignWidgets.tw
+++ b/src/utility/assignWidgets.tw
@@ -22,6 +22,7 @@
 	<</for>>
 <</if>>
 
+<<removeJob $args[0] $args[0].assignment>>
 /% use .toLowerCase() to get rid of a few dupe conditions. %/
 <<switch $args[1].toLowerCase()>>
 <<case "clinic" "get treatment in the clinic">>


### PR DESCRIPTION
My original Widget I was working on was going to clear any jobs first, but it failed to work right, so I came up with this simpler one and forgot to place the clearing of the job back in. Lol. Moving between facilities won't have ghosts now.