### PR TITLE
fix toychest bug, remove left-over events

### DIFF
--- a/src/uncategorized/randomNonindividualEvent.tw
+++ b/src/uncategorized/randomNonindividualEvent.tw
@@ -39,26 +39,6 @@
 <</if>>
 <</if>> /* closes no nicknames option */
 
-<<if ($eventSlave.assignment == "serve in the master suite")>>
-<<if ($eventSlave.devotion > 20)>>
-<<if ($eventSlave.trust > -20)>>
-<<if ($activeSlave.anus > 0)>>
-<<if ($activeSlave.vagina != 0)>>
-	<<if ($corpIncorporated != 0)>>
-		<<set $events.push("RE shift sleep")>>
-	<</if>>
-	<<if ($activeSlave.releaseRules != "restrictive")>>
-		<<set $events.push("RE shift masturbation")>>
-	<</if>>
-	<<if ($activeSlave.entertainSkill >= 60)>>
-		<<set $events.push("RE shift doorframe")>>
-	<</if>>
-<</if>>
-<</if>>
-<</if>>
-<</if>>
-<</if>>
-
 <</if>> /* CLOSES FUCKDOLL CHECK */
 
 <<set $legendaryFacility = 1>>

--- a/src/uncategorized/toychest.tw
+++ b/src/uncategorized/toychest.tw
@@ -53,11 +53,11 @@
 	Her uncomfortable straps force her to constantly present her holes.
 <<elseif ($slaves[$i].clothes == "restrictive latex") || ($slaves[$i].clothes == "a latex catsuit")>>
 	Her complete suit of latex makes her a nice, artistic display, a plastic work of art in the shape of a female form.
-<<elseif ($activeSlave.clothes == "a military uniform")>>
+<<elseif ($slaves[$i].clothes == "a military uniform")>>
 	Her uniformed presence lends your office the air of a military command center.
-<<elseif ($activeSlave.clothes == "a mini skirt")>>
+<<elseif ($slaves[$i].clothes == "a mini skirt")>>
 	Her flattering mini dress makes her the perfect office ornament for the modern captain of industry.
-<<elseif ($activeSlave.clothes == "a nice nurse outfit")>>
+<<elseif ($slaves[$i].clothes == "a nice nurse outfit")>>
 	Her proper nurse's outfit gives the office a clinical air.
 <<elseif ($slaves[$i].clothes == "a fallen nuns habit")>>
 	Her latex parody of a nuns habit gives the office a sacrilegious air.
@@ -121,17 +121,17 @@
 	Her harem girl outfit lends her corner of your office an Eastern opulence.
 <<elseif ($slaves[$i].clothes == "slutty jewelry")>>
 	The bangles she's wearing make little noises every time she moves, serving as a constant reminder of her sexual availability.
-<<elseif ($activeSlave.clothes == "conservative clothing")>>
+<<elseif ($slaves[$i].clothes == "conservative clothing")>>
 	Her clothes make it look like she's here for some other purpose than sexual slavery.
-<<elseif ($activeSlave.clothes == "chains")>>
+<<elseif ($slaves[$i].clothes == "chains")>>
 	Her chains make it obvious that she's here as an office sex toy.
-<<elseif ($activeSlave.clothes == "Western clothing")>>
+<<elseif ($slaves[$i].clothes == "Western clothing")>>
 	Her Western clothing is comically out of place in a modern office.
-<<elseif ($activeSlave.clothes == "body oil")>>
+<<elseif ($slaves[$i].clothes == "body oil")>>
 	Her body oil makes her muscles a lovely ornament to the office, and makes all her holes nice and inviting.
-<<elseif ($activeSlave.clothes == "a toga")>>
+<<elseif ($slaves[$i].clothes == "a toga")>>
 	Her toga lends an air of antiquity to the office.
-<<elseif ($activeSlave.clothes == "a slutty qipao")>>
+<<elseif ($slaves[$i].clothes == "a slutty qipao")>>
 	Her lovely qipao is a delicious contradiction of conservative silk patterns and scandalously high cuts.
 <<elseif ($slaves[$i].vaginalAccessory == "chastity belt")>>
 	Her chastity belt covers and protects her, but leaves her breasts naked, her mouth available, and her asshole vulnerable.


### PR DESCRIPTION
toychest is occassionally referencing $activeSlave, which may lead to interesting results.

the 'RE shift' events are leftovers and are now duplicates of the similarly named 'shift' events.