### PR TITLE
Fixes-Update assignWidgets.tw

### DIFF
--- a/src/utility/assignWidgets.tw
+++ b/src/utility/assignWidgets.tw
@@ -26,7 +26,7 @@
 /% use .toLowerCase() to get rid of a few dupe conditions. %/
 <<switch $args[1].toLowerCase()>>
 <<case "clinic" "get treatment in the clinic">>
-	<<set $args[0].assignment = "get treatment in the clinic", $clinicSlaves++, $CliniciDSs.push({ID: _wID, Index: _wi})>>
+	<<set $args[0].assignment = "get treatment in the clinic", $clinicSlaves++, $CliniciIDs.push({ID: _wID, Index: _wi})>>
 <<case "schoolroom" "learn in the schoolroom">>
 	<<set $args[0].assignment = "learn in the schoolroom", $schoolroomSlaves++, $SchlRiIDs.push({ID: _wID, Index: _wi})>>
 <<case "spa" "rest in the spa">>
@@ -50,15 +50,19 @@
 <</switch>>
 
 <<set $args[0].assignmentVisible = 0, $args[0].choosesOwnAssignment = 0>>
+
+/% Stop creating Starving/overweight deaths?, Endless drug supply etc. %/
+<<set $args[0].diet = "healthy", $args[0].drugs = "no drugs", $args[0].curatives = 0, $args[0].hormones = 0, $args[0].aphrodisiacs = 0>>
+
 <<if _wID == $personalAttention>><<set $personalAttention = "business">><</if>>
 
 <<set $slaves[_wi] = $args[0], $i = _wi>>
-<<if $slaves[_wi].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+<<if $slaves[_wi].choosesOwnClothes == 1>><<include "SA chooses own clothes">><<set $args[0] = $slaves[_wi]>><</if>>
 <</if>>
 <</widget>>
 
 /%
-	Call as <<removeJob slaveObject $returnto | _currentRule.facilityRemove | "serve in the master suite" ["rest"]
+	Call as <<removeJob slaveObject $returnto | _currentRule.facilityRemove | "serve in the master suite"
 	$args[0] slave object. *MUST be present*
 	$args[1] Job to remove slave from. Will accept the $returnto vars and the _currentRule.assignFacility vars and the actual job assignments "serve in the master suite" etc.
 
@@ -166,7 +170,7 @@
 	<<set $slaves[$i] = $args[0]>>
 <<else>>
 	<<for _wi = 0; _wi < _SL; _wi++>>
-	<<if _wID == $slaves[_wi]>>
+	<<if _wID == $slaves[_wi].ID>>
 		<<set $slaves[_wi] = $args[0]>>
 	<</if>>
 	<</for>>


### PR DESCRIPTION
Fixes slaves returning from facilities during endweek and not showing up in the Penthouse report as 'resting'.

Also does a bit of management for diet, and drugs. It sets the diet to healthy and drugs/injections etc to 0. To prevent getting starving/overweight slaves or breasts expansion going nuts. lol. I consider this more or less a quick fix to prevent these things from happening, and was planning on doing a widget to handle these things without bringing in the RA to manage such as it's a slow beast when it works right. But I got two essays to work on and other things in my life that are going to hamper my time working on things.
