### PR TITLE
fix pornfamespending?

### DIFF
--- a/src/uncategorized/saLongTermEffects.tw
+++ b/src/uncategorized/saLongTermEffects.tw
@@ -3403,7 +3403,7 @@ and ($slaves[$i].clothes != "a slutty qipao") and ($slaves[$i].clothes != "restr
 
 <<set $pornFameBonus to 1>>
 <<if $studio == 1>>
-<<if $slaves[$i].pornFameSpending >= 0>>
+<<if $slaves[$i].pornFameSpending > 0>>
 	<<set $pornFameBonus += 0.2 + ($slaves[$i].pornFameSpending/10000)>>
 	<<if ($slaves[$i].pornFameSpending >= 4000)>>
 	$possessiveCap near-ubiquitous presence in arcology pornography greatly increases $possessive impact on society.
@@ -4368,7 +4368,7 @@ and ($slaves[$i].clothes != "a slutty qipao") and ($slaves[$i].clothes != "restr
 <</if>>
 
 <<if $studio == 1>>
-<<if $slaves[$i].pornFameSpending >= 0>>
+<<if $slaves[$i].pornFameSpending > 0>>
 	<<set $seed to $slaves[$i].pornFame>>
 	<<if ($slaves[$i].pornFame < 35) && ($slaves[$i].prestige > 1)>>
 	Interest in porn of $object is very high, since $pronoun's already quite prestigious.


### PR DESCRIPTION
I think both cases are meant to fire only with active spending, otherwise, a slave with prestige>=3 keeps getting the 'Further paid publicity cannot increase ...' message every week.