### PR TITLE
Automated multiple organ and limb application.

### DIFF
--- a/src/uncategorized/multiImplant.tw
+++ b/src/uncategorized/multiImplant.tw
@@ -1,0 +1,180 @@
+:: Multiple Organ Implant [nobr]
+
+You head down to your <<if $surgeryUpgrade == 1>>heavily upgraded and customized remote surgery<<else>>remote surgery<</if>> and start having the slaves with <<if ($organsCompleted > 0) && ($limbsCompleted > 0)>>organs or limbs <<elseif ($organsCompleted > 1)>>organs <<elseif ($limbsCompleted > 1)>>sets of limbs <</if>>that are ready be sent down.
+
+<<for _i = 0; _i < $slaves.length; _i++>>
+	<<if ($organs.length == 0) && ($limbs.length == 0)>><<break>><</if>>
+	<<for _o = 0; _o < $organs.length; _o++>>
+		<<if ($organs[_o].ID == $slaves[_i].ID) && ($organs[_o].weeksToCompletion == 0)>>
+			<<set $activeSlave = $slaves[_i]>>
+			
+			<<switch $organs[_o].type>>
+			<<case "penis">>
+				<<if $activeSlave.dick == 0>>
+					<<set $cash -= $surgeryCost>>
+					<<set $activeSlave.prostate = 1>>
+					<<set $activeSlave.dick to 2>>
+					<<set $activeSlave.clit to 0>>
+					<<set $activeSlave.foreskin to $activeSlave.dick>>
+					<<set $activeSlave.health -= 20>>
+					<<set $surgeryType = "addDick">>
+					<br><hr>
+					<<include "Surgery Degradation">>
+					
+					<<set $dump = $organs.pluck([_o], [_o])>>
+				<</if>>
+			<<case "testicles">>
+				<<if ($activeSlave.dick >= 0) && ($activeSlave.balls == 0)>>
+					<<set $cash -= $surgeryCost>>
+					<<set $activeSlave.prostate = 1>>
+					<<set $activeSlave.balls to 2>>
+					<<set $activeSlave.scrotum to 2>>
+					<<set $activeSlave.health -= 20>>
+					<<set $surgeryType = "addBalls">>
+					<br><hr>
+					<<include "Surgery Degradation">>
+					
+					<<set $dump = $organs.pluck([_o], [_o])>>
+				<</if>>
+			<<case "scrotum">>
+				<<if ($activeSlave.scrotum == 0) && ($activeSlave.balls >= 0)>>
+					<<set $cash -= $surgeryCost>>
+					<<set $activeSlave.scrotum to $activeSlave.balls>>
+					<<set $activeSlave.health -= 10>>
+					<<set $surgeryType = "addScrotum">>
+					<br><hr>
+					<<include "Surgery Degradation">>
+					
+					<<set $dump = $organs.pluck([_o], [_o])>>
+				<</if>>
+			<<case "foreskin">>
+				<<if ($activeSlave.foreskin == 0) && ($activeSlave.penis >= 0)>>
+					<<set $cash -= $surgeryCost>>
+					<<set $activeSlave.foreskin to $activeSlave.balls>>
+					<<set $activeSlave.health -= 10>>
+					<<set $surgeryType = "addForeskin">>
+					<br><hr>
+					<<include "Surgery Degradation">>
+					
+					<<set $dump = $organs.pluck([_o], [_o])>>
+				<</if>>
+			<<case "ovaries">>
+				<<if ($activeSlave.ovaries == 0) && ($activeSlave.vagina >= 0)>>
+					<<set $cash -= $surgeryCost>>
+					<<set $activeSlave.ovaries to 1>>
+					<<set $activeSlave.preg to 0>>
+					<<set $activeSlave.health -= 20>>
+					<<set $surgeryType = "addOvaries">>
+					<br><hr>
+					<<include "Surgery Degradation">>
+
+					<<set $dump = $organs.pluck([_o], [_o])>>
+				<</if>>
+			<<case "prostate">>
+				<<if ($activeSlave.prostate == 0)>>
+					<<set $cash -= $surgeryCost>>
+					<<set $activeSlave.prostate = 1>>
+					<<set $activeSlave.health -= 20>>
+					<<set $surgeryType = "addProstate">>
+					<br><hr>
+					<<include "Surgery Degradation">>
+					
+					<<set $dump = $organs.pluck([_o], [_o])>>
+				<</if>>
+			<<case "eyes">>
+				<<if ($activeSlave.eyes == -2) && ($activeSlave.origEye != "implant")>>
+					<<set $cash -= $surgeryCost>>
+					<<set $activeSlave.eyes to 1>>
+					<<set $activeSlave.eyeColor to "pale pink">>
+					/* no way to salvage original eye color */
+					<<set $activeSlave.health -= 20>>
+					<<set $surgeryType = "unblind">>
+					<br><hr>
+					<<include "Surgery Degradation">>
+					
+					<<set $dump = $organs.pluck([_o], [_o])>>
+				<</if>>
+			<<case "voicebox">>
+				<<if ($activeSlave.voice == 0)>>
+					<<set $cash -= $surgeryCost>>
+					
+					<<if ($activeSlave.ovaries + $activeSlave.hormones) > 1>>
+						<<set $activeSlave.voice = 3>>
+					<<elseif ($activeSlave.balls > 0) || ($activeSlave.hormones < 0)>>
+						<<set $activeSlave.voice = 1>>
+					<<else>>
+						<<set $activeSlave.voice = 2>>
+					<</if>>
+					<<set $activeSlave.health -= 10>>
+					<<set $surgeryType = "restoreVoice">>
+					<br><hr>
+					<<include "Surgery Degradation">>
+				
+					<<set $dump = $organs.pluck([_o], [_o])>>
+				<</if>>
+			<<default>>
+				Error: OrganType: $organs[_o].type not known.
+			<</switch>>
+			
+			<<set $slaves[_i] = $activeSlave>>
+			<<break>>
+		<</if>>
+	<</for>>
+	<<if $slaves[_i].amp != 0>>
+	<<for _l = 0; _l < $limbs.length; _l++>>
+		<<if ($limbs[_l].ID == $slaves[_i].ID) && ($organs[_o].weeksToCompletion == 0)>>
+			<<set $activeSlave = $slaves[_i]>>
+
+			<<switch $limbs[_l].type>>
+			<<case "simple">>
+				<<set $activeSlave.amp = -1>>
+				<<set $surgeryType = "basicPLimbs">>
+			<<case "sex">>
+				<<set $activeSlave.amp = -2>>
+				<<set $surgeryType = "sexPLimbs">>
+			<<case "beauty">>
+				<<set $activeSlave.amp = -3>>
+				<<set $surgeryType = "beautyPLimbs">>
+			<<case "combat">>
+				<<set $activeSlave.amp = -4>>
+				<<set $surgeryType = "combatPLimbs">>
+			<<case "cyber">>
+				<<set $activeSlave.amp = -5>>
+				<<set $surgeryType = "cyberPLimbs">>
+			<</switch>>
+			
+			<<set $cash -= $surgeryCost>>
+			<<set $activeSlave.health -= 10>>
+			<br><hr>
+			<<include "Surgery Degradation">>
+			<<set $dump = $limbs.pluck([_l], [_l])>>
+
+			<<set $slaves[_i] = $activeSlave>>
+			<<break>>
+		<</if>>
+	<</for>>
+	<</if>>
+		
+<</for>>
+
+/* This needs to be down here to over-ride any Surgery Degredation calls */
+<<set $nextButton = "Continue">>
+<<set $nextLink = "Main">>
+
+/* Clean-up */
+<<set $organsCompleted = 0>>
+<<for _i = 0; _i < $organs.length; _i++>>
+	<<if $organs[_i].weeksToCompletion == 0>>
+		<<set $organsCompleted++>>
+	<</if>>
+<</for>>
+
+<<set $limbsCompleted = 0>>
+<<for _i = 0; _i < $limbs.length; _i++>>
+	<<if $limbs[_i].weeksToCompletion == 0>>
+		<<set $limbsCompleted++>>
+	<</if>>
+<</for>>
+
+
+

--- a/src/utility/descriptionWidgets.tw
+++ b/src/utility/descriptionWidgets.tw
@@ -41,27 +41,51 @@
 		You have not selected a Bodyguard. <span id="manageBG"><strong><<link "Select one">><<goto "BG Select">><</link>></strong></span> @@color:cyan;[B]@@
 	<</if>>
 <</if>>
+
 <<if $organsCompleted > 0>>
+<<for _j = 0; _j < $organs.length; _j++>>
+	<<set _validHost = 0>>
 	<<set $dumped = 0>>
 	<<for _i = 0; _i < $slaves.length; _i++>>
-	<<set _Slave = $slaves[_i]>>
-	<<for _j = 0; _j < $organs.length; _j++>>
-	<<if ($organs[_j] != 0) && ($organs[_j].ID == _Slave.ID) && ($organs[_j].weeksToCompletion == 0)>>
-		<br>@@color:yellow;The fabricator has completed an organ for@@ <span id="name"><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves[" + _i + "]]]">></span>, @@color:yellow; which is ready to be implanted.@@
+		<<set _Slave = $slaves[_i]>>
+		<<if ($organs[_j] != 0) && ($organs[_j].ID == _Slave.ID)>>
+			<<set _validHost = 1>>
+			<<if ($organs[_j].weeksToCompletion == 0)>>
+				<br>@@color:yellow;The fabricator has completed an organ for@@ <span id="name"><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves[" + _i + "]]]">></span>, @@color:yellow; which is ready to be implanted.@@
+			<</if>>
+		<</if>>
+	<</for>>
+	<<if _validHost == 0>>
+		<<set $dump = $organs.pluck([_j], [_j])>>
+		<<set _j-->>
 	<</if>>
-	<</for>>
-	<</for>>
+<</for>>
 <</if>>
 <<if $limbsCompleted > 0>>
+<<for _j = 0; _j < $limbs.length; _j++>>
+	<<set _validHost = 0>>
 	<<set $dumped = 0>>
 	<<for _i = 0; _i < $slaves.length; _i++>>
-	<<set _Slave = $slaves[_i]>>
-	<<for _j = 0; _j < $limbs.length; _j++>>
-	<<if ($limbs[_j] != 0) && ($limbs[_j].ID == _Slave.ID) && ($limbs[_j].weeksToCompletion == 0)>>
-		<br>@@color:yellow;The facility has completed a set of limbs for@@ <span id="name"><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves[" + _i + "]]]">></span>, @@color:yellow; which is ready to be attached.@@
+		<<set _Slave = $slaves[_i]>>
+		<<if ($limbs[_j] != 0) && ($limbs[_j].ID == _Slave.ID)>>
+			<<set _validHost = 1>>
+			<<if ($limbs[_j].weeksToCompletion == 0)>>
+				<br>@@color:yellow;The facility has completed a set of limbs for@@ <span id="name"><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves[" + _i + "]]]">></span>, @@color:yellow; which is ready to be attached.@@
+			<</if>>
+		<</if>>
+	<</for>>
+	<<if _validHost == 0>>
+		<<set $dump = $organs.pluck([_j], [_j])>>
+		<<set _j-->>
 	<</if>>
-	<</for>>
-	<</for>>
+<</for>>
+<</if>>
+<<if ($organsCompleted > 0) && ($limbsCompleted > 0)>>
+	<br>[[Implant and Attach|Multiple Organ Implant]] @@color:yellow;all organs and limbs that are ready.@@
+<<elseif ($organsCompleted > 1)>>
+	<br>[[Implant|Multiple Organ Implant]] @@color:yellow;all organs that are ready for implantation.@@
+<<elseif ($limbsCompleted > 1)>>
+	<br>[[Attach|Multiple Organ Implant]] @@color:yellow;all sets of limbs that are ready to be attached.@@
 <</if>>
 <br>
 <span id="buySlaves"><strong><<link "Buy Slaves">><<goto "Buy Slaves">><</link>></strong></span> @@color:cyan;[S]@@


### PR DESCRIPTION
Adds the ability to have all completed organs and limbs automatically applied.

- Follows the same rules as manual application (i.e. costs & health losses).
- Will not discard organs or limbs that cannot be applied due to improper slave organs or limbs.
- Gives a single screen of text with all the slave reactions to their surgeries.  
- Does not give messages for ready but not applied organs.
- Discards organs and limbs for slaves you do not have.

Note: the current descriptions do not give the slave names, and can be confusing. surgeryDegradation.tw should be updated to lead with the slave's name.