### PR TITLE
Ignore missing start.tw file

### DIFF
--- a/compile
+++ b/compile
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Will add all *.tw files to StoryIncludes.
-rm src/config/start.tw
+rm -f src/config/start.tw
 cp src/config/start.tw.proto start.tw.tmp
 find src -name '*.tw' -print >>start.tw.tmp
 mv start.tw.tmp src/config/start.tw


### PR DESCRIPTION
On linux/OS X, if the start.tw file is missing, then rm will complain. Ignore the error.