### PR TITLE
Autosurgery Bugfixes

### DIFF
--- a/src/uncategorized/assistantAutosurgery.tw
+++ b/src/uncategorized/assistantAutosurgery.tw
@@ -43,7 +43,7 @@
 	<<set $surgeries.push("a nicer face")>>
 	<<if $slaves[$i].faceShape is "masculine">><<set $slaves[$i].faceShape to "androgynous">><</if>>
 	<<set $slaves[$i].faceImplant to 1>>
-	<<set $slaves[$i].face = Math.trunc($slaves[$i].face+20,-100,100)>>
+	<<set $slaves[$i].face = Math.clamp($slaves[$i].face+20,-100,100)>>
 	<<set $cash -= $surgeryCost>>
 	<<if $PC.medicine >= 100>><<set $slaves[$i].health -= 5>><<else>><<set $slaves[$i].health -= 10>><</if>>
 <<elseif ($slaves[$i].ageImplant != 1) && ($slaves[$i].age >= 25) && ($thisSurgery.cosmetic != 0)>>
@@ -75,21 +75,21 @@
 	<<set $surgeries.push("a nicer face")>>
 	<<if $slaves[$i].faceShape is "masculine">><<set $slaves[$i].faceShape to "androgynous">><</if>>
 	<<set $slaves[$i].faceImplant to 2>>
-	<<set $slaves[$i].face = Math.trunc($slaves[$i].face+20,-100,100)>>
+	<<set $slaves[$i].face = Math.clamp($slaves[$i].face+20,-100,100)>>
 	<<set $cash -= $surgeryCost>>
 	<<if $PC.medicine >= 100>><<set $slaves[$i].health -= 5>><<else>><<set $slaves[$i].health -= 10>><</if>>
 <<elseif ($slaves[$i].faceImplant > 0) && ($slaves[$i].face <= 95) && ($surgeryUpgrade == 1) && ($thisSurgery.cosmetic is 2)>>
 	<<set $surgeries.push("a nicer face")>>
 	<<if $slaves[$i].faceShape is "masculine">><<set $slaves[$i].faceShape to "androgynous">><</if>>
 	<<set $slaves[$i].faceImplant to 2>>
-	<<set $slaves[$i].face = Math.trunc($slaves[$i].face+20,-100,100)>>
+	<<set $slaves[$i].face = Math.clamp($slaves[$i].face+20,-100,100)>>
 	<<set $cash -= $surgeryCost>>
 	<<if $PC.medicine >= 100>><<set $slaves[$i].health -= 5>><<else>><<set $slaves[$i].health -= 10>><</if>>
 <<elseif ($slaves[$i].waist >= -95) && ($thisSurgery.cosmetic is 2) && ($seeExtreme == 1)>>
 	<<set $surgeries.push("a narrower waist")>>
-	<<set $slaves[$i].waist = Math.trunc($slaves[$i].waist-20,-100,100)>>
+	<<set $slaves[$i].waist = Math.clamp($slaves[$i].waist-20,-100,100)>>
 	<<set $cash -= $surgeryCost>>
-	<<if $PC.medicine >= 100>><<set $slaves[$i].health -= 30.5>><<else>><<set $slaves[$i].health -= 4>><</if>>
+	<<if $PC.medicine >= 100>><<set $slaves[$i].health -= 5>><<else>><<set $slaves[$i].health -= 10>><</if>>
 <<elseif ($slaves[$i].voice < 3) && ($slaves[$i].voiceImplant == 0) && ($thisSurgery.cosmetic == 2)>>
 	<<set $surgeries.push("a bimbo's voice")>>
 	<<set $slaves[$i].voice += 1>>

--- a/src/uncategorized/rulesAutosurgery.tw
+++ b/src/uncategorized/rulesAutosurgery.tw
@@ -85,7 +85,7 @@
 	<<set $surgeries.push("a nicer face")>>
 	<<if $slaves[$i].faceShape is "masculine">><<set $slaves[$i].faceShape to "androgynous">><</if>>
 	<<set $slaves[$i].faceImplant to 1>>
-	<<set $slaves[$i].face = Math.trunc($slaves[$i].face+20,-100,100)>>
+	<<set $slaves[$i].face = Math.clamp($slaves[$i].face+20,-100,100)>>
 	<<set $cash -= $surgeryCost>>
 	<<if $PC.medicine >= 100>><<set $slaves[$i].health -= 5>><<else>><<set $slaves[$i].health -= 10>><</if>>
 <<elseif ($slaves[$i].ageImplant != 1) && ($slaves[$i].age >= 25) && ($thisSurgery.cosmetic != 0)>>
@@ -142,21 +142,21 @@
 	<<set $surgeries.push("a nicer face")>>
 	<<if $slaves[$i].faceShape is "masculine">><<set $slaves[$i].faceShape to "androgynous">><</if>>
 	<<set $slaves[$i].faceImplant to 2>>
-	<<set $slaves[$i].face = Math.trunc($slaves[$i].face+20,-100,100)>>
+	<<set $slaves[$i].face = Math.clamp($slaves[$i].face+20,-100,100)>>
 	<<set $cash -= $surgeryCost>>
 	<<if $PC.medicine >= 100>><<set $slaves[$i].health -= 5>><<else>><<set $slaves[$i].health -= 10>><</if>>
 <<elseif ($slaves[$i].faceImplant > 0) && ($slaves[$i].face <= 95) && ($surgeryUpgrade == 1) && ($thisSurgery.cosmetic is 2)>>
 	<<set $surgeries.push("a nicer face")>>
 	<<if $slaves[$i].faceShape is "masculine">><<set $slaves[$i].faceShape to "androgynous">><</if>>
 	<<set $slaves[$i].faceImplant to 2>>
-	<<set $slaves[$i].face = Math.trunc($slaves[$i].face+20,-100,100)>>
+	<<set $slaves[$i].face = Math.clamp($slaves[$i].face+20,-100,100)>>
 	<<set $cash -= $surgeryCost>>
 	<<if $PC.medicine >= 100>><<set $slaves[$i].health -= 5>><<else>><<set $slaves[$i].health -= 10>><</if>>
 <<elseif ($slaves[$i].waist >= -95) && ($thisSurgery.cosmetic is 2) && ($seeExtreme == 1)>>
 	<<set $surgeries.push("a narrower waist")>>
-	<<set $slaves[$i].waist = Math.trunc($slaves[$i].waist-20,-100,100)>>
+	<<set $slaves[$i].waist = Math.clamp($slaves[$i].waist-20,-100,100)>>
 	<<set $cash -= $surgeryCost>>
-	<<if $PC.medicine >= 100>><<set $slaves[$i].health -= 30.5>><<else>><<set $slaves[$i].health -= 4>><</if>>
+	<<if $PC.medicine >= 100>><<set $slaves[$i].health -= 5>><<else>><<set $slaves[$i].health -= 10>><</if>>
 <<elseif ($slaves[$i].voice < 3) && ($slaves[$i].voiceImplant == 0) && ($thisSurgery.cosmetic == 2)>>
 	<<set $surgeries.push("a bimbo's voice")>>
 	<<set $slaves[$i].voice += 1>>


### PR DESCRIPTION
Updates Rules Autosurgery and Assistant Autosurgery to fix some bugs.

- Switched Math.trunc to Math.clamp so that facial and waist surgeries will be properly capped at 100 and -100 respectively.
- Fixed the health loss from invasive waist narrowing to bring it inline with other surgeries.