### PR TITLE
PC Skills improvements

### DIFF
--- a/src/events/intro/introSummary.tw
+++ b/src/events/intro/introSummary.tw
@@ -383,6 +383,12 @@ Image display
 		<<set $PC.engineering = 100>>
 	<<elseif $PC.career == "medicine">>
 		<<set $PC.medicine = 100>>
+	<<elseif $PC.career == "arcology owner">>
+		<<set $PC.trading = 100>>
+		<<set $PC.warfare = 100>>
+		<<set $PC.slaving = 100>>
+		<<set $PC.engineering = 100>>
+		<<set $PC.medicine = 100>>
 	<</if>>
 	<<set $girls = 2>>
 	<<goto "init Nationalities">>

--- a/src/uncategorized/costs.tw
+++ b/src/uncategorized/costs.tw
@@ -239,6 +239,18 @@
 	<<set $costs += 1000>>
 <</if>>
 
+<<if ($personalAttention == "trading")>>
+	<<set $costs += 10000>>
+<<elseif ($personalAttention == "warfare")>>
+	<<set $costs += 10000>>
+<<elseif ($personalAttention == "slaving")>>
+	<<set $costs += 10000>>
+<<elseif ($personalAttention == "engineering")>>
+	<<set $costs += 10000>>
+<<elseif ($personalAttention == "medicine")>>
+	<<set $costs += 10000>>
+<</if>>
+
 <<if $cyberMod == 1>>
 <<if $researchLab.built == "true">>
 	<<set $costs += ((100*$researchLab.maxSpace)+(300*$researchLab.hired)+(100*$researchLab.hired))>>

--- a/src/uncategorized/costsReport.tw
+++ b/src/uncategorized/costsReport.tw
@@ -124,6 +124,18 @@
 	<br>Coursing Association membership: ¤1000
 <</if>>
 
+<<if ($personalAttention == "trading")>>
+	<br>Trading trainer fees: ¤10000
+<<elseif ($personalAttention == "warfare")>>
+	<br>Warfare trainer fees: ¤10000
+<<elseif ($personalAttention == "slaving")>>
+	<br>Slaving trainer fees: ¤10000
+<<elseif ($personalAttention == "engineering")>>
+	<br>Engineering trainer fees: ¤10000
+<<elseif ($personalAttention == "medicine")>>
+	<br>Medicine trainer fees: ¤10000
+<</if>>
+
 <br>
 
 <<for $i = 0; $i < $slaves.length; $i++>>

--- a/src/uncategorized/economics.tw
+++ b/src/uncategorized/economics.tw
@@ -181,6 +181,119 @@ __Personal Business__
 <<else>>
 	You have enough cash to manage your affairs, but not enough to do much business.
 <</if>>
+
+<<if ($personalAttention == "trading")>>
+	<<set _oldSkill = $PC.trading>>
+	<<set $PC.trading += random(5,10)>>
+	<<if _oldSkill <= 10>>
+		<<if $PC.trading > 10>>
+			You now have @@color:green;basic knowledge@@ about how to be a venture capitalist.
+		<</if>>
+	<<elseif _oldSkill <= 30>>
+		<<if $PC.trading > 30>>
+			You now have @@color:green;some skill@@ as a venture capitalist.
+		<</if>>
+	<<elseif _oldSkill <= 60>>
+		<<if $PC.trading > 60>>
+			You are now an @@color:green;expert venture capitalist.@@
+		<</if>>
+	<<else>>
+		<<if $PC.trading >= 100>>
+			<<set $personalAttention = "business">>
+			You are now a @@color:green;master venture capitalist.@@
+		<</if>>
+	<</if>>
+	
+<<elseif ($personalAttention == "warfare")>>
+	<<set _oldSkill = $PC.warfare>>
+	<<set $PC.warfare += random(5,10)>>
+	<<if _oldSkill <= 10>>
+		<<if $PC.warfare > 10>>
+			You now have @@color:green;basic knowledge@@ about how to be a mercenary.
+		<</if>>
+	<<elseif _oldSkill <= 30>>
+		<<if $PC.warfare > 30>>
+			You now have @@color:green;some skill@@ as a mercenary.
+		<</if>>
+	<<elseif _oldSkill <= 60>>
+		<<if $PC.warfare > 60>>
+			You are now an @@color:green;expert mercenary.@@
+		<</if>>
+	<<else>>
+		<<if $PC.warfare >= 100>>
+			<<set $personalAttention = "business">>
+			You are now a @@color:green;master mercenary.@@
+		<</if>>
+	<</if>>
+
+<<elseif ($personalAttention == "slaving")>>
+	<<set _oldSkill = $PC.slaving>>
+	<<set $PC.slaving += random(5,10)>>
+	<<if _oldSkill <= 10>>
+		<<if $PC.slaving > 10>>
+			You now have @@color:green;basic knowledge@@ about how to be a slaver.
+		<</if>>
+	<<elseif _oldSkill <= 30>>
+		<<if $PC.slaving > 30>>
+			You now have @@color:green;some skill@@ as a slaver.
+		<</if>>
+	<<elseif _oldSkill <= 60>>
+		<<if $PC.slaving > 60>>
+			You are now an @@color:green;expert slaver.@@
+		<</if>>
+	<<else>>
+		<<if $PC.slaving >= 100>>
+			<<set $personalAttention = "business">>
+			You are now a @@color:green;master slaver.@@
+		<</if>>
+	<</if>>
+	
+<<elseif ($personalAttention == "engineering")>>
+	<<set _oldSkill = $PC.engineering>>
+	<<set $PC.engineering += random(5,10)>>
+	<<if _oldSkill <= 10>>
+		<<if $PC.engineering > 10>>
+			You now have @@color:green;basic knowledge@@ about how to be an arcology engineer.
+		<</if>>
+	<<elseif _oldSkill <= 30>>
+		<<if $PC.engineering > 30>>
+			You now have @@color:green;some skill@@ as an arcology engineer.
+		<</if>>
+	<<elseif _oldSkill <= 60>>
+		<<if $PC.engineering > 60>>
+			You are now an @@color:green;expert arcology engineer.@@
+		<</if>>
+	<<else>>
+		<<if $PC.engineering >= 100>>
+			<<set $personalAttention = "business">>
+			You are now a @@color:green;master arcology engineer.@@
+		<</if>>
+	<</if>>
+	
+<<elseif ($personalAttention == "medicine")>>
+	<<set _oldSkill = $PC.medicine>>
+	<<set $PC.medicine += random(5,10)>>
+	<<if _oldSkill <= 10>>
+		<<if $PC.medicine > 10>>
+			You now have @@color:green;basic knowledge@@ about how to be a slave surgeon.
+		<</if>>
+	<<elseif _oldSkill <= 30>>
+		<<if $PC.medicine > 30>>
+			You now have @@color:green;some skill@@ as a slave surgeon.
+		<</if>>
+	<<elseif _oldSkill <= 60>>
+		<<if $PC.medicine > 60>>
+			You are now an @@color:green;expert slave surgeon.@@
+		<</if>>
+	<<else>>
+		<<if $PC.medicine >= 100>>
+			<<set $personalAttention = "business">>
+			You are now a @@color:green;master slave surgeon.@@
+		<</if>>
+	<</if>>
+	
+<</if>>
+
 <<if $cash > 1000>>
 <<if $CashForRep == 1>>
 	This week you gave up business opportunities worth ¤$policyCost to help deserving citizens, @@color:green;burnishing your reputation.@@

--- a/src/uncategorized/endWeek.tw
+++ b/src/uncategorized/endWeek.tw
@@ -73,18 +73,6 @@
 	<<set $PC.sexualEnergy += 2>>
 <</if>>
 
-<<if ($personalAttention == "trading")>>
-	<<set $PC.trading += random(5,10), $cash -= 10000>><<if $PC.trading >= 100>><<set $personalAttention = "business">><</if>>
-<<elseif ($personalAttention == "warfare")>>
-	<<set $PC.warfare += random(5,10), $cash -= 10000>><<if $PC.warfare >= 100>><<set $personalAttention = "business">><</if>>
-<<elseif ($personalAttention == "slaving")>>
-	<<set $PC.slaving += random(5,10), $cash -= 10000>><<if $PC.slaving >= 100>><<set $personalAttention = "business">><</if>>
-<<elseif ($personalAttention == "engineering")>>
-	<<set $PC.engineering += random(5,10), $cash -= 10000>><<if $PC.engineering >= 100>><<set $personalAttention = "business">><</if>>
-<<elseif ($personalAttention == "medicine")>>
-	<<set $PC.medicine += random(5,10), $cash -= 10000>><<if $PC.medicine >= 100>><<set $personalAttention = "business">><</if>>
-<</if>>
-
 <<set $HGEnergy = 0, $HGCum = 0, $HGSlaveSuccess = 0, $HeadGirl = 0, $HGBalls = 0, $HGRelease = 1, $Recruiter = 0, $Madam = 0, $madamCashBonus = 0, $DJ = 0, $DJRepBonus = 0, $Milkmaid = 0, $Collectrix = 0, $Stewardess = 0, $Schoolteacher = 0, $Wardeness = 0, $Concubine = 0, $Attendant = 0, $Nurse = 0, $Bodyguard = 0, $bedSlaves = 0, $fuckSlaves = 0, $freeSexualEnergy = 0, $publicServants = 0, $cumSlaves = 0, $averageDick = 0, $slavesWithWorkingDicks = 0>>
 
 /* GAMEOVERS */

--- a/src/uncategorized/personalAttentionSelect.tw
+++ b/src/uncategorized/personalAttentionSelect.tw
@@ -7,30 +7,86 @@
 	<br>[[Support your Head Girl|Main][$personalAttention = "HG", $personalAttentionChanged = 1]]
 <</if>>
 <br>[[Have as much sex with your slaves as possible|Main][$personalAttention = "sex", $personalAttentionChanged = 1]]<br><br>
+
 <<if $PC.trading >= 100>>
 	//You are a master trader.//
 <<else>>
-	[[Hire a merchant to train you in commerce|Main][$personalAttention = "trading", $personalAttentionChanged = 1]]
+	<<if $PC.trading > 60>>
+		//You are an expert trader.//
+	<<elseif $PC.trading > 30>>
+		//You have some skill as a trader.//
+	<<elseif $PC.trading > 10>>
+		//You have basic knowledge as a trader.//
+	<</if>>
+	<<if $personalAttention == "trading">>
+		You are training in venture capitalism.
+	<<else>>
+		[[Hire a merchant to train you in commerce|Main][$personalAttention = "trading", $personalAttentionChanged = 1]]
+	<</if>>
 <</if>><br>
 <<if $PC.warfare >= 100>>
 	//You are a master tactician.//
 <<else>>
-	[[Hire a mercenary to train you in warfare|Main][$personalAttention = "warfare", $personalAttentionChanged = 1]]
+	<<if $PC.warfare > 60>>
+		//You are an expert tactician.//
+	<<elseif $PC.warfare > 30>>
+		//You have some skill as a tactician.//
+	<<elseif $PC.warfare > 10>>
+		//You have basic knowledge as a tactician.//
+	<</if>>
+	<<if $personalAttention == "warfare">>
+		You are training in tactics.
+	<<else>>
+		[[Hire a mercenary to train you in warfare|Main][$personalAttention = "warfare", $personalAttentionChanged = 1]]
+	<</if>>
 <</if>><br>
 <<if $PC.slaving >= 100>>
 	//You are a master slaver.//
 <<else>>
-	[[Hire a slaver to train you in slaving|Main][$personalAttention = "slaving", $personalAttentionChanged = 1]]
+	<<if $PC.slaving > 60>>
+		//You are an expert slaver.//
+	<<elseif $PC.slaving > 30>>
+		//You have some skill as a slaver.//
+	<<elseif $PC.slaving > 10>>
+		//You have basic knowledge as a slaver.//
+	<</if>>
+	<<if $personalAttention == "slaving">>
+		You are training in slaving.
+	<<else>>
+		[[Hire a slaver to train you in slaving|Main][$personalAttention = "slaving", $personalAttentionChanged = 1]]
+	<</if>>
 <</if>><br>
 <<if $PC.engineering >= 100>>
-	//You are a master engineer.//
+	//You are a master arcology engineer.//
 <<else>>
-	[[Hire an engineer to train you in engineering|Main][$personalAttention = "engineering", $personalAttentionChanged = 1]]
+	<<if $PC.slaving > 60>>
+		//You are an expert arcology engineer.//
+	<<elseif $PC.slaving > 30>>
+		//You have some skill as an arcology engineer.//
+	<<elseif $PC.slaving > 10>>
+		//You have basic knowledge as an arcology engineer.//
+	<</if>>
+	<<if $personalAttention == "engineering">>
+		You are training in arcology engineering.
+	<<else>>
+		[[Hire an engineer to train you in engineering|Main][$personalAttention = "engineering", $personalAttentionChanged = 1]]
+	<</if>>
 <</if>><br>
 <<if $PC.medicine >= 100>>
 	//You are a master surgeon.//
 <<else>>
-	[[Hire a doctor to train you in medicine|Main][$personalAttention = "medicine", $personalAttentionChanged = 1]]
+	<<if $PC.medicine > 60>>
+		//You are an expert surgeon.//
+	<<elseif $PC.medicine > 30>>
+		//You have some skill as a surgeon.//
+	<<elseif $PC.medicine > 10>>
+		//You have basic knowledge as a surgeon.//
+	<</if>>
+	<<if $personalAttention == "medicine">>
+		You are training in slave surgery.
+	<<else>>
+		[[Hire a doctor to train you in medicine|Main][$personalAttention = "medicine", $personalAttentionChanged = 1]]
+	<</if>>
 <</if>>
 <br>//Training will cost ¤10000 per week.//<br><br>
 


### PR DESCRIPTION
A chunk of improvements to the PC skills system.  

- Training costs moved into cost report.  Will now show up as change to upkeep and has a line in the Costs Summary.
- Made it work better with the arcology owner career (It wasn't setting skill levels on start).  
- Added a simple message on the economics screen to give an indication to skill level increasing.
- Improved the training selection screen to give an indication of current skill level as well as show what skill you are currently training.