### PR TITLE
saChoosesOwnClothes mindbroken selections and saChoosesOwnJob overhaul.

### DIFF
--- a/src/uncategorized/saChoosesOwnClothes.tw
+++ b/src/uncategorized/saChoosesOwnClothes.tw
@@ -2,8 +2,66 @@
 
 <<set $bellyAccessory = $slaves[$i].bellyAccessory>>
 
+<<if $slaves[$i].fetish == "mindbroken">>
+	She is fundamentally broken, but still follows some faint memories of standing within the wardrobe.
+	<<if $slaves[$i].amp != 1 && $slaves[$i].heels == 1>>
+		She finds she can inexplicably walk if she wears heels; a daily lesson for her, as she forgets shortly after leaving.
+		<<set $slaves[$i].shoes = either("heels", "extreme heels", "boots")>>
+	<</if>>
+	Faced with so many choices and no thought on the matter;
+	<<if ($arcologies[0].FSChattelReligionist > 0)>>
+		she commonly sees others wearing chattel habits and is drawn to doing so herself.
+		<<set $slaves[$i].clothes = "a chattel habit">>
+	<<elseif ($arcologies[0].FSEgyptianRevivalist > 0) && (random(1,3) == 1)>>
+		she commonly sees others wearing nothing but jewelry and is drawn to doing so herself.
+		<<set $slaves[$i].clothes = "slutty jewelry">>
+	<<elseif ($arcologies[0].FSRomanRevivalist > 0) && (random(1,3) == 1)>>
+		she commonly sees others wearing togas and is drawn to doing so herself.
+		<<set $slaves[$i].clothes = "a toga">>
+	<<elseif ($arcologies[0].FSEdoRevivalist > 0) && (random(1,3) == 1)>>
+		she commonly sees others wearing kimonos and is drawn to doing so herself.
+		<<set $slaves[$i].clothes = "a kimono">>
+	<<elseif ($arcologies[0].FSArabianRevivalist > 0) && (random(1,3) == 1)>>
+		she commonly sees others wearing silk and is drawn to doing so herself.
+		<<set $slaves[$i].clothes = "harem gauze">>
+	<<elseif ($arcologies[0].FSChineseRevivalist > 0) && (random(1,3) == 1)>>
+		she commonly sees others wearing qipaos and is drawn to doing so herself.
+		<<set $slaves[$i].clothes = "a slutty qipao">>
+	<<elseif ($arcologies[0].FSGenderFundamentalist > 0) && (random(1,3) == 1)>>
+		she commonly sees cheerleaders around and instinctually follows along.
+		<<set $slaves[$i].clothes = either("a cheerleader outfit", "a schoolgirl outfit")>>
+	<<elseif ($arcologies[0].FSGenderFundamentalist > 0) && (random(1,3) == 1)>>
+		she commonly sees bunnies around and instinctually follows along.
+		<<set $slaves[$i].clothes = "a bunny outfit">>
+	<<elseif ($arcologies[0].FSPaternalist > 0) && (random(1,3) == 1)>>
+		she commonly sees others wearing clothing and is drawn to doing so herself.
+		<<set $slaves[$i].clothes = "conservative clothing">>
+	<<elseif ($arcologies[0].FSMaturityPreferentialist > 0) && (random(1,3) == 1)>>
+		she commonly sees others wearing suits and is drawn to doing so herself.
+		<<set $slaves[$i].clothes = either("slutty business attire", "a nice maid outfit", "a military uniform", "nice business attire")>>
+	<<elseif ($arcologies[0].FSYouthPreferentialist > 0) && (random(1,3) == 1)>>
+		she commonly sees schoolgirls around and instinctually follows along.
+		<<set $slaves[$i].clothes = either("a schoolgirl outfit", "a cheerleader outfit")>>
+	<<elseif ($arcologies[0].FSDegradationist > 0) && (random(1,3) == 1)>>
+		she commonly sees others wearing chains and is drawn to doing so herself.
+		<<set $slaves[$i].clothes = either("chains", "uncomfortable straps", "shibari ropes")>>
+	<<elseif ($arcologies[0].FSPhysicalIdealist > 0) && (random(1,3) == 1)>>
+		she commonly sees naked girls around and seldom realizes they are coated in oil.
+		<<set $slaves[$i].clothes = either("body oil", "no clothing", "no clothing")>>
+	<<elseif ($arcologies[0].FSPastoralist > 0) && (random(1,3) == 1)>>
+		she commonly sees cowgirls around and instinctually follows along.
+		<<set $slaves[$i].clothes = "Western clothing">>
+	<<elseif ($arcologies[0].FSBodyPurist > 0) && (random(1,3) == 1)>>
+		she commonly sees others wearing tight, form fitting clothes and is drawn to doing so herself.
+		<<set $slaves[$i].clothes = either("a leotard", "a string bikini", "a slave gown", "a comfortable bodysuit", "restrictive latex", "clubslut netting", "a leotard", "a halter top dress")>>
+	<<else>>
+		she chooses to put on underwear, the reasons lost to her, and moves on.
+		<<set $slaves[$i].clothes = "attractive lingerie">>
+	<</if>>
+<<else>>
+
 <<if ($slaves[$i].devotion <= 20)>>
-	and uses the ability to select outfits to cover up with comfortable cut-offs and a t-shirt,
+	$pronounCap uses the ability to select outfits to cover up with comfortable cut-offs and a t-shirt,
 	<<set $slaves[$i].clothes = "cutoffs and a t-shirt">>
 	<<if ($slaves[$i].amp != 1)>>
 	<<if ($slaves[$i].heels == 0)>>
@@ -239,3 +297,5 @@
 <</if>>
 
 <</if>>
+
+<</if>> /* closes MB check */

--- a/src/uncategorized/saChoosesOwnJob.tw
+++ b/src/uncategorized/saChoosesOwnJob.tw
@@ -10,350 +10,370 @@
 	<<set $slaves[$i].assignment = "rest", $slaves[$i].assignmentVisible = 1, $slaves[$i].devotion -= 5>>
 
 <<elseif ($slaves[$i].health < 20)>>
-	<<if $clinic > 0>>
-	is unhealthy, so she goes to get treatment at $clinicName.
-	<<assignJob $slaves[$i] "get treatment in the clinic">>
+	<<if $clinic > $clinicSlaves && $universalRulesAssignsSelfFacility == 1>>
+		is unhealthy, so she goes to get treatment at $clinicName.
+		<<assignJob $slaves[$i] "get treatment in the clinic">>
 	<<else>>
-	is unhealthy, so she chooses to rest.
-	<<set $slaves[$i].assignment = "rest", $slaves[$i].assignmentVisible = 1>>
+		is unhealthy, so she chooses to rest.
+		<<set $slaves[$i].assignment = "rest", $slaves[$i].assignmentVisible = 1>>
 	<</if>>
 
-<<elseif (($slaves[$i].devotion < 45) || ($slaves[$i].trust < 45)) && (($slaves[$i].sexualFlaw != "none") || ($slaves[$i].behavioralFlaw != "none")) && ($Attendant != 0)>>
+<<elseif (($slaves[$i].devotion < 45) || ($slaves[$i].trust < 45)) && (($slaves[$i].sexualFlaw != "none") || ($slaves[$i].behavioralFlaw != "none")) && ($Attendant != 0) && $universalRulesAssignsSelfFacility == 1>>
 	could use some counseling, so she chooses to visit $spaName.
 	<<assignJob $slaves[$i] "rest in the spa">>
 
 <<elseif ($slaves[$i].intelligenceImplant != 1)>>
-	<<if $schoolroom > 0>>
-	is uneducated, so she sits herself down in $schoolroomName.
-	<<assignJob $slaves[$i] "learn in the schoolroom">>
+	<<if $schoolroom > $schoolroomSlaves && $universalRulesAssignsSelfFacility == 1>>
+		is uneducated, so she sits herself down in $schoolroomName.
+		<<assignJob $slaves[$i] "learn in the schoolroom">>
 	<<else>>
-	is uneducated, so she sits herself down to learn.
-	<<set $slaves[$i].assignment = "take classes", $slaves[$i].assignmentVisible = 1>>
+		is uneducated, so she sits herself down to learn.
+		<<set $slaves[$i].assignment = "take classes", $slaves[$i].assignmentVisible = 1>>
 	<</if>>
 
-<<elseif ($slaves[$i].devotion <= 50) && canWalk($slaves[$i])>>
-	<<if $servantsQuarters > 0>>
-	is obedient but not devoted, so she chooses to work from $servantsQuartersName since it's the least sexually demanding job available.
-	<<assignJob $slaves[$i] "work as a servant">>
+<<elseif ($slaves[$i].devotion <= 50) && canWalk($slaves[$i]) && canSee($slaves[$i])>>
+	<<if $servantsQuarters > $servantsQuartersSlaves && $universalRulesAssignsSelfFacility == 1>>
+		is obedient but not devoted, so she chooses to work from $servantsQuartersName since it's the least sexually demanding job available.
+		<<assignJob $slaves[$i] "work as a servant">>
 	<<else>>
-	is obedient but not devoted, so she chooses to work as a servant since it's the least sexually demanding job available.
-	<<set $slaves[$i].assignment = "be a servant", $slaves[$i].assignmentVisible = 1>>
+		is obedient but not devoted, so she chooses to work as a servant since it's the least sexually demanding job available.
+		<<set $slaves[$i].assignment = "be a servant", $slaves[$i].assignmentVisible = 1>>
 	<</if>>
 
 <<elseif ($slaves[$i].relationship == -1)>>
 	relies on promiscuity to fulfill her emotional needs,
 	<<if ($cash > 10000)>>
-	and doesn't mind being a whore, so she prostitutes herself
-	<<if $brothel > 0>>
-		in $brothelName.
-		<<assignJob $slaves[$i] "work in the brothel">>
+		and doesn't mind being a whore, so she prostitutes herself
+		<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+			in $brothelName.
+			<<assignJob $slaves[$i] "work in the brothel">>
+		<<else>>
+			on the streets.
+			<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
 	<<else>>
-		on the streets.
-		<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<<else>>
-	so she eagerly decides to slut around
-	<<if $club > 0>>
-		in $clubName.
-		<<assignJob $slaves[$i] "serve in the club">>
-	<<else>>
-		on the streets.
-		<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
+		so she eagerly decides to slut around
+		<<if $club > $clubSlaves && $universalRulesAssignsSelfFacility == 1>>
+			in $clubName.
+			<<assignJob $slaves[$i] "serve in the club">>
+		<<else>>
+			on the streets.
+			<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
 	<</if>>
 
 <<elseif ($slaves[$i].relationship == -2)>>
 	is emotionally bonded to you,
 	<<if ($slaves[$i].behavioralQuirk == "insecure")>>
-	but insecure, so she chooses to make you money by prostituting herself
-	<<if $brothel > 0>>
-		in $brothelName.
-		<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-		on the streets.
-		<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
+		but insecure, so she chooses to make you money by prostituting herself
+		<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+			in $brothelName.
+			<<assignJob $slaves[$i] "work in the brothel">>
+		<<else>>
+			on the streets.
+			<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
 	<<elseif ($slaves[$i].behavioralQuirk == "advocate")>>
-	and an advocate for slavery, so she chooses to burnish your reputation by slutting it up
-	<<if $club > 0>>
-		in $clubName.
-		<<assignJob $slaves[$i] "serve in the club">>
-	<<else>>
-		on the streets.
-		<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
+		and an advocate for slavery, so she chooses to burnish your reputation by slutting it up
+		<<if $club > $clubSlaves && $universalRulesAssignsSelfFacility == 1>>
+			in $clubName.
+			<<assignJob $slaves[$i] "serve in the club">>
+		<<else>>
+			on the streets.
+			<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
 	<<elseif ($slaves[$i].energy > 60)>>
-	and she thinks of little but sex with you,
-	<<if $masterSuite > 0>>
-		so she heads straight to $masterSuiteName.
-		<<assignJob $slaves[$i] "serve in the master suite">>
+		and she thinks of little but sex with you,
+		<<if $masterSuite > $masterSuiteSlaves && $universalRulesAssignsSelfFacility == 1>>
+			so she heads straight to $masterSuiteName.
+			<<assignJob $slaves[$i] "serve in the master suite">>
+		<<else>>
+			so she cheerfully designates herself one of your fucktoys.
+			<<set $slaves[$i].assignment = "please you", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif canSee($slaves[$i]) && canWalk($slaves[$i])>>
+		so she chooses to work
+		<<if $servantsQuarters > $servantsQuartersSlaves && $universalRulesAssignsSelfFacility == 1>>
+			from $servantsQuartersName
+			<<assignJob $slaves[$i] "work as a servant">>
+		<<else>>
+			as a servant
+			<<set $slaves[$i].assignment = "be a servant", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+		to make your penthouse as clean and homelike as possible.
 	<<else>>
-		so she cheerfully designates herself one of your fucktoys.
-		<<set $slaves[$i].assignment = "please you", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<<else>>
-	so she chooses to work
-	<<if $servantsQuarters > 0>>
-		from $servantsQuartersName
-		<<assignJob $slaves[$i] "work as a servant">>
-	<<else>>
-		as a servant
-		<<set $slaves[$i].assignment = "be a servant", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	to make your penthouse as clean and homelike as possible.
+		but unable to do much on her own,
+		<<if $masterSuite > $masterSuiteSlaves && $universalRulesAssignsSelfFacility == 1>>
+			so she heads straight to $masterSuiteName to await your caress.
+			<<assignJob $slaves[$i] "serve in the master suite">>
+		<<else>>
+			so she cheerfully designates herself one of your fucktoys to be close to you.
+			<<set $slaves[$i].assignment = "please you", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
 	<</if>>
 
 <<elseif ($slaves[$i].relationship == -3)>>
 	is married to you,
 	<<if ($slaves[$i].energy > 60)>>
-	and she thinks of little but sex with you,
-	<<if $masterSuite > 0>>
-		so she heads straight to $masterSuiteName.
-		<<assignJob $slaves[$i] "serve in the master suite">>
+		and she thinks of little but sex with you,
+		<<if $masterSuite > $masterSuiteSlaves && $universalRulesAssignsSelfFacility == 1>>
+			so she heads straight to $masterSuiteName.
+			<<assignJob $slaves[$i] "serve in the master suite">>
+		<<else>>
+			so she cheerfully designates herself one of your fucktoys.
+			<<set $slaves[$i].assignment = "please you", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif canSee($slaves[$i]) && canWalk($slaves[$i])>>
+		so she chooses to work
+		<<if $servantsQuarters > $servantsQuartersSlaves && $universalRulesAssignsSelfFacility == 1>>
+			from $servantsQuartersName
+			<<assignJob $slaves[$i] "work as a servant">>
+		<<else>>
+			as a servant
+			<<set $slaves[$i].assignment = "be a servant", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+		to make your penthouse as clean and homelike as possible.
 	<<else>>
-		so she cheerfully designates herself one of your fucktoys.
-		<<set $slaves[$i].assignment = "please you", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<<else>>
-	so she chooses to work
-	<<if $servantsQuarters > 0>>
-		from $servantsQuartersName
-		<<assignJob $slaves[$i] "work as a servant">>
-	<<else>>
-		as a servant
-		<<set $slaves[$i].assignment = "be a servant", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	to make your penthouse as clean and homelike as possible.
+		but unable to do much on her own
+		<<if $masterSuite > $masterSuiteSlaves && $universalRulesAssignsSelfFacility == 1>>
+			so she heads straight to $masterSuiteName to await your caress.
+			<<assignJob $slaves[$i] "serve in the master suite">>
+		<<else>>
+			so she cheerfully designates herself one of your fucktoys to be close to you.
+			<<set $slaves[$i].assignment = "please you", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
 	<</if>>
 
 <<elseif ($slaves[$i].fetishKnown == 1)>>
-	<<if ($slaves[$i].fetish == "submissive") && canWalk($slaves[$i])>>
-	<<if $servantsQuarters > 0>>
-		thinks she belongs at the bottom of the penthouse hierarchy, so she goes to live in $servantsQuartersName.
-		<<assignJob $slaves[$i] "work as a servant">>
-	<<else>>
-		thinks she belongs at the bottom of the penthouse hierarchy, so she decides she should be a servant.
-		<<set $slaves[$i].assignment = "be a servant", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-<<elseif ($slaves[$i].fetish == "dom") || ($slaves[$i].fetish == "sadist")>>
-	<<if $club > 0>>
-		is self-confident, so she decides to work in $clubName.
-		<<assignJob $slaves[$i] "serve in the club">>
-	<<else>>
-		is self-confident, so she decides to work as a public servant.
-		<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-<<elseif ($slaves[$i].fetish == "masochist")>>
-	<<if $brothel > 0>>
-		enjoys abuse, so she hurries down to $brothelName.
-		<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-		enjoys abuse, so she decides to become a whore.
-		<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-<<elseif ($slaves[$i].fetish == "cumslut")>>
-	<<if $brothel > 0>>
-		hurries down to $brothelName to suck cocks.
-		<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-		decides to become a whore, mostly to suck cock.
-		<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-<<elseif ($slaves[$i].fetish == "humiliation")>>
-	<<if $brothel > 0>>
-		chooses $brothelName, since it's even more embarrassing to be a whore than a club slut.
-		<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-		chooses to whore, since it's even more embarrassing to be a whore than to be a public servant.
-		<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-<<elseif ($slaves[$i].fetish == "buttslut")>>
-	<<if ($slaves[$i].balls > 0)>>
-	<<if ($dairy > 0) && ($dairyRestraintsSetting < 2)>>
-		chooses confinement in $dairyName, since all she'll be expected to do is make cum by orgasming to buttsex.
-		<<assignJob $slaves[$i] "work in the dairy">>
-	<<else>>
-		chooses to get milked, since all she'll be expected to do is make cum by orgasming to buttsex.
-		<<set $slaves[$i].assignment = "get milked", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<<else>>
-	<<if $brothel > 0>>
-		chooses $brothelName, since whores get buttfucked more than anyone else.
-		<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-		chooses to whore, since whores get buttfucked more than anyone else.
-		<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<</if>>
-<<elseif ($slaves[$i].fetish == "pregnancy")>>
-	<<if ($slaves[$i].lactation > 0)>>
-	<<if $dairy > 0>>
-		heads down to $dairyName to be around other lactating girls.
-		<<assignJob $slaves[$i] "work in the dairy">>
-	<<else>>
-		decides to get milked, since she's already lactating.
-		<<set $slaves[$i].assignment = "get milked" , $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<<elseif ($slaves[$i].preg > -2) && ($slaves[$i].preg < 1) && ($PC.dick == 1)>>
-	<<if $masterSuite > 0>>
-		heads straight to $masterSuiteName, in the hope you'll get her pregnant.
-		<<assignJob $slaves[$i] "serve in the master suite">>
-	<<else>>
-		chooses to be your fucktoy, in the hope you'll get her pregnant.
-		<<set $slaves[$i].assignment = "please you", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<<elseif ($slaves[$i].preg > 0)>>
-	<<if $masterSuite > 0>>
-		heads straight to $masterSuiteName to share the intimacy of her pregnant body with you.
-		<<set $slaves[$i].assignment = "serve in the master suite">>
-		<<set $slaves[$i].assignmentVisible = 0>>
-	<<else>>
-		chooses to be your fucktoy to share the intimacy of her pregnant body with you.
-		<<assignJob $slaves[$i] "serve in the master suite">>
-	<</if>>
-	<<else>>
-	<<if $brothel > 0>>
-		can't indulge her fetish by getting pregnant herself, so she just heads down to $brothelName.
-		<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-		can't indulge her fetish by getting pregnant herself, so she glumly decides to be a whore.
-		<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<</if>>
-<<elseif ($slaves[$i].fetish == "boobs")>>
-	<<if ($slaves[$i].lactation > 0)>>
-	<<if $dairy > 0>>
-		heads down to $dairyName for all the attention that'll be lavished on her nipples.
-		<<assignJob $slaves[$i] "work in the dairy">>
-	<<else>>
-		decides to get milked, since she loves getting off to it.
-		<<set $slaves[$i].assignment = "get milked", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<<else>>
-	<<if $club > 0>>
-		decides to work in $clubName so she can show off her bare breasts.
-		<<assignJob $slaves[$i] "serve in the club">>
-	<<else>>
-		decides to work as a public servant so she can show off her bare breasts.
-		<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<</if>>
-<<elseif ($slaves[$i].attrXX > 85)>>
-	<<if $club > 0>>
-		decides to work in $clubName so she can hit on hot girls.
-		<<assignJob $slaves[$i] "serve in the club">>
-	<<else>>
-		decides to work as a public servant so she can hit on hot girls.
-		<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-<<elseif ($slaves[$i].attrXY > 85)>>
-	<<if $club > 0>>
-		decides to work in $clubName so she can hit on cute boys.
-		<<assignJob $slaves[$i] "serve in the club">>
-	<<else>>
-		decides to work as a public servant so she can hit on cute boys.
-		<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-<<elseif ($slaves[$i].energy > 95)>>
-	<<if $brothel > 0>>
-		decides to help those of your girls who mind taking dick all day by working in $brothelName.
-		<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-		decides to help those of your girls who mind taking dick all day by working as a whore.
-		<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
+	<<if ($slaves[$i].fetish == "submissive") && canWalk($slaves[$i]) && canSee($slaves[$i])>>
+		<<if $servantsQuarters > $servantsQuartersSlaves && $universalRulesAssignsSelfFacility == 1>>
+			thinks she belongs at the bottom of the penthouse hierarchy, so she goes to live in $servantsQuartersName.
+			<<assignJob $slaves[$i] "work as a servant">>
+		<<else>>
+			thinks she belongs at the bottom of the penthouse hierarchy, so she decides she should be a servant.
+			<<set $slaves[$i].assignment = "be a servant", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif ($slaves[$i].fetish == "dom") || ($slaves[$i].fetish == "sadist")>>
+		<<if $club > $clubSlaves && $universalRulesAssignsSelfFacility == 1>>
+			is self-confident, so she decides to work in $clubName.
+			<<assignJob $slaves[$i] "serve in the club">>
+		<<else>>
+			is self-confident, so she decides to work as a public servant.
+			<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif ($slaves[$i].fetish == "masochist")>>
+		<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+			enjoys abuse, so she hurries down to $brothelName.
+			<<assignJob $slaves[$i] "work in the brothel">>
+		<<else>>
+			enjoys abuse, so she decides to become a whore.
+			<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif ($slaves[$i].fetish == "cumslut")>>
+		<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+			hurries down to $brothelName to suck cocks.
+			<<assignJob $slaves[$i] "work in the brothel">>
+		<<else>>
+			decides to become a whore, mostly to suck cock.
+			<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif ($slaves[$i].fetish == "humiliation")>>
+		<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+			chooses $brothelName, since it's even more embarrassing to be a whore than a club slut.
+			<<assignJob $slaves[$i] "work in the brothel">>
+		<<else>>
+			chooses to whore, since it's even more embarrassing to be a whore than to be a public servant.
+			<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif ($slaves[$i].fetish == "buttslut")>>
+		<<if ($slaves[$i].balls > 0)>>
+			<<if ($dairy > $dairySlaves) && ($dairyRestraintsSetting < 2) && $universalRulesAssignsSelfFacility == 1>>
+				chooses confinement in $dairyName, since all she'll be expected to do is make cum by orgasming to buttsex.
+				<<assignJob $slaves[$i] "work in the dairy">>
+			<<else>>
+				chooses to get milked, since all she'll be expected to do is make cum by orgasming to buttsex.
+				<<set $slaves[$i].assignment = "get milked", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<<else>>
+			<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+				chooses $brothelName, since whores get buttfucked more than anyone else.
+				<<assignJob $slaves[$i] "work in the brothel">>
+			<<else>>
+				chooses to whore, since whores get buttfucked more than anyone else.
+				<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<</if>>
+	<<elseif ($slaves[$i].fetish == "pregnancy")>>
+		<<if ($slaves[$i].lactation > 0)>>
+			<<if $dairy > $dairySlaves && $dairyRestraintsSetting < 2 && $universalRulesAssignsSelfFacility == 1>>
+				heads down to $dairyName to be around other lactating girls.
+				<<assignJob $slaves[$i] "work in the dairy">>
+			<<else>>
+				decides to get milked, since she's already lactating.
+				<<set $slaves[$i].assignment = "get milked" , $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<<elseif isFertile($slaves[$i]) && ($PC.dick == 1)>>
+			<<if $masterSuite > $masterSuiteSlaves && $universalRulesAssignsSelfFacility == 1>>
+				heads straight to $masterSuiteName, in the hope you'll get her pregnant.
+				<<assignJob $slaves[$i] "serve in the master suite">>
+			<<else>>
+				chooses to be your fucktoy, in the hope you'll get her pregnant.
+				<<set $slaves[$i].assignment = "please you", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<<elseif isFertile($slaves[$i]) && $dairy > $dairySlaves && $dairyPregSetting > 0 && $universalRulesAssignsSelfFacility == 1>>
+			<<if $dairyPregSetting > 1>>
+				eagerly rushes to $dairyName in the hopes that her womb will be packed full of children.
+				<<assignJob $slaves[$i] "work in the dairy">>
+			<<else>>
+				rushes to $dairyName in the hopes that her womb will be rented out.
+				<<assignJob $slaves[$i] "work in the dairy">>
+			<</if>>
+		<<elseif ($slaves[$i].preg > 0)>>
+			<<if $masterSuite > $masterSuiteSlaves && $universalRulesAssignsSelfFacility == 1>>
+				heads straight to $masterSuiteName to share the intimacy of her pregnant body with you.
+				<<assignJob $slaves[$i] "serve in the master suite">>
+			<<else>>
+				chooses to be your fucktoy to share the intimacy of her pregnant body with you.
+				<<set $slaves[$i].assignment = "please you", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<<else>>
+			<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+				can't indulge her fetish by getting pregnant herself, so she just heads down to $brothelName.
+				<<assignJob $slaves[$i] "work in the brothel">>
+			<<else>>
+				can't indulge her fetish by getting pregnant herself, so she glumly decides to be a whore.
+				<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<</if>>
+	<<elseif ($slaves[$i].fetish == "boobs")>>
+		<<if ($slaves[$i].lactation > 0)>>
+			<<if $dairy > $dairySlaves && $dairyRestraintsSetting < 2 && $universalRulesAssignsSelfFacility == 1>>
+				heads down to $dairyName for all the attention that'll be lavished on her nipples.
+				<<assignJob $slaves[$i] "work in the dairy">>
+			<<else>>
+				decides to get milked, since she loves getting off to it.
+				<<set $slaves[$i].assignment = "get milked", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<<else>>
+			<<if $club > $clubSlaves && $universalRulesAssignsSelfFacility == 1>>
+				decides to work in $clubName so she can show off her bare breasts.
+				<<assignJob $slaves[$i] "serve in the club">>
+			<<else>>
+				decides to work as a public servant so she can show off her bare breasts.
+				<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<</if>>
+	<<elseif ($slaves[$i].attrXX > 85)>>
+		<<if $club > $clubSlaves && $universalRulesAssignsSelfFacility == 1>>
+			decides to work in $clubName so she can hit on hot girls.
+			<<assignJob $slaves[$i] "serve in the club">>
+		<<else>>
+			decides to work as a public servant so she can hit on hot girls.
+			<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif ($slaves[$i].attrXY > 85)>>
+		<<if $club > $clubSlaves && $universalRulesAssignsSelfFacility == 1>>
+			decides to work in $clubName so she can hit on cute boys.
+			<<assignJob $slaves[$i] "serve in the club">>
+		<<else>>
+			decides to work as a public servant so she can hit on cute boys.
+			<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif ($slaves[$i].energy > 95)>>
+		<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+			decides to help those of your girls who mind taking dick all day by working in $brothelName.
+			<<assignJob $slaves[$i] "work in the brothel">>
+		<<else>>
+			decides to help those of your girls who mind taking dick all day by working as a whore.
+			<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
 
-<<elseif ($arcologies[0].FSChattelReligionist > 0)>>
-	<<if $brothel > 0>>
-	is a pure and faithful slave, so she sells her body in the holy brothel.
-	<<assignJob $slaves[$i] "work in the brothel">>
+	<<elseif ($arcologies[0].FSChattelReligionist > 0)>>
+		<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+			is a pure and faithful slave, so she sells her body in the holy brothel.
+			<<assignJob $slaves[$i] "work in the brothel">>
+		<<else>>
+			is a pure and faithful slave, so she sells her body as a holy prostitute.
+			<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif ($arcologies[0].FSEgyptianRevivalist > 0)>>
+		<<if $masterSuite > $masterSuiteSlaves && $universalRulesAssignsSelfFacility == 1>>
+			is a devoted slave, so she immediately joins your harem.
+			<<assignJob $slaves[$i] "serve in the master suite">>
+		<<else>>
+			is a devoted slave, so she immediately joins your harem.
+			<<set $slaves[$i].assignment = "please you", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif ($arcologies[0].FSRomanRevivalist > 0)>>
+		<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+			is a devoted slave, so she decides she can best serve the state by raising money for the treasury, by selling her body in $brothelName.
+			<<assignJob $slaves[$i] "work in the brothel">>
+		<<else>>
+			is a devoted slave, so she decides she can best serve the state by raising money for the treasury, by selling her body as a prostitute.
+			<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif ($arcologies[0].FSPaternalist > 0)>>
+		<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+			decides to work in $brothelName, a respectable position for a slave in this enlightened arcology.
+			<<assignJob $slaves[$i] "work in the brothel">>
+		<<else>>
+			decides to be a whore, a respectable position for a slave in this enlightened arcology.
+			<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+		<</if>>
+	<<elseif ($arcologies[0].FSPastoralist > 0)>>
+		<<if ($slaves[$i].lactation > 0)>>
+			<<if $dairy > $dairySlaves && $dairyRestraintsSetting < 2 && $universalRulesAssignsSelfFacility == 1>>
+				hurries to join your herd of dairy cows.
+				<<assignJob $slaves[$i] "work in the dairy">>
+			<<else>>
+				hurries to join your herd of cows.
+				<<set $slaves[$i].assignment = "get milked", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<<else>>
+			<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+				decides to work in $brothelName to help raise money to get more girls lactating properly.
+				<<assignJob $slaves[$i] "work in the brothel">>
+			<<else>>
+				decides to prostitute herself to help raise money to get more girls lactating properly.
+				<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<</if>>
 	<<else>>
-	is a pure and faithful slave, so she sells her body as a holy prostitute.
-	<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-<<elseif ($arcologies[0].FSEgyptianRevivalist > 0)>>
-	<<if $masterSuite > 0>>
-	is a devoted slave, so she immediately joins your harem.
-	<<assignJob $slaves[$i] "serve in the master suite">>
-	<<else>>
-	is a devoted slave, so she immediately joins your harem.
-	<<set $slaves[$i].assignment = "please you", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-<<elseif ($arcologies[0].FSRomanRevivalist > 0)>>
-	<<if $brothel > 0>>
-	is a devoted slave, so she decides she can best serve the state by raising money for the treasury, by selling her body in $brothelName.
-	<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-	is a devoted slave, so she decides she can best serve the state by raising money for the treasury, by selling her body as a prostitute.
-	<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-<<elseif ($arcologies[0].FSPaternalist > 0)>>
-	<<if $brothel > 0>>
-	decides to work in $brothelName, a respectable position for a slave in this enlightened arcology.
-	<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-	decides to be a whore, a respectable position for a slave in this enlightened arcology.
-	<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-<<elseif ($arcologies[0].FSPastoralist > 0)>>
-	<<if ($slaves[$i].lactation > 0)>>
-	<<if $dairy > 0>>
-		hurries to join your herd of dairy cows.
-		<<assignJob $slaves[$i] "work in the dairy">>
-	<<else>>
-		hurries to join your herd of cows.
-		<<set $slaves[$i].assignment = "get milked", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<<else>>
-	<<if $brothel > 0>>
-		decides to work in $brothelName to help raise money to get more girls lactating properly.
-	<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-		decides to prostitute herself to help raise money to get more girls lactating properly.
-		<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
+		<<if ($slaves[$i].whoreSkill > $slaves[$i].entertainSkill)>>
+			<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+				decides to work in $brothelName, since she thinks herself a better whore than a public slut.
+				<<assignJob $slaves[$i] "work in the brothel">>
+			<<else>>
+				decides to whore, since she thinks herself a better whore than a public slut.
+				<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<<elseif ($slaves[$i].entertainSkill >= $slaves[$i].whoreSkill)>>
+			<<if $club > $clubSlaves && $universalRulesAssignsSelfFacility == 1>>
+				decides to be a club girl, since she thinks herself a better public slut than a whore.
+				<<assignJob $slaves[$i] "serve in the club">>
+			<<else>>
+				decides to serve the public, since she thinks herself a better public slut than a whore.
+				<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<<else>>
+			<<if $brothel > $brothelSlaves && $universalRulesAssignsSelfFacility == 1>>
+				decides to join her sisters and work in $brothelName.
+				<<assignJob $slaves[$i] "work in the brothel">>
+			<<else>>
+				decides to prostitute herself to help you upgrade $arcologies[0].name and improve everyone's life.
+				<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
+			<</if>>
+		<</if>>
 	<</if>>
 <<else>>
-	<<if ($slaves[$i].whoreSkill > $slaves[$i].entertainSkill)>>
-	<<if $brothel > 0>>
-		decides to work in $brothelName, since she thinks herself a better whore than a public slut.
-	<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-		decides to whore, since she thinks herself a better whore than a public slut.
-		<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<<elseif ($slaves[$i].entertainSkill >= $slaves[$i].whoreSkill)>>
-	<<if $club > 0>>
-		decides to be a club girl, since she thinks herself a better public slut than a whore.
-	<<assignJob $slaves[$i] "serve in the club">>
-	<<else>>
-		decides to serve the public, since she thinks herself a better public slut than a whore.
-		<<set $slaves[$i].assignment = "serve the public", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<<else>>
-	<<if $brothel > 0>>
-		decides to join her sisters and work in $brothelName.
-	<<assignJob $slaves[$i] "work in the brothel">>
-	<<else>>
-		decides to prostitute herself to help you upgrade $arcologies[0].name and improve everyone's life.
-		<<set $slaves[$i].assignment = "whore", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
-	<</if>>
-<</if>>
-
-<</if>>
-
-<<if ($slaves[$i].assignment == "choose her own job")>>
-	<<if canWalk($slaves[$i])>>
-	<<if $servantsQuarters > 0>>
-		isn't strongly inclined towards any other assignment, so she goes to live in $servantsQuartersName.
-	<<assignJob $slaves[$i] "work as a servant">>
-	<<else>>
-		isn't strongly inclined towards any other assignment, so she decides to work as a servant.
+	<<if $club > $clubSlaves && $universalRulesAssignsSelfFacility == 1>>
+		decides to be a club girl, since partying is better than sitting around and failing to think of a job to do.
+		<<assignJob $slaves[$i] "serve in the club">>
+	<<elseif canWalk($slaves[$i]) && canSee($slaves[$i])>>
+		decides to tidy up the penthouse a little while she thinks.
 		<<set $slaves[$i].assignment = "be a servant", $slaves[$i].assignmentVisible = 1>>
-	<</if>>
 	<<else>>
-	isn't strongly inclined towards an assignment, and can't be a servant without arms and legs, so she just rests.
-	<<set $slaves[$i].assignment = "rest", $slaves[$i].assignmentVisible = 1>>
+		stays in bed, unable to come up with anything.
+		<<set $slaves[$i].assignment = "rest", $slaves[$i].assignmentVisible = 1>>
 	<</if>>
 <</if>>

--- a/src/uncategorized/universalRules.tw
+++ b/src/uncategorized/universalRules.tw
@@ -66,6 +66,15 @@ Future society names for new slaves are currently @@.cyan;APPLIED@@. [[Stop appl
 <</if>>
 <</if>>
 
+<<if $brothel+$club+$dairy+$servantsQuarters+$arcade+$schoolroom+$spa+$clinic+$masterSuite+$cellblock > 0>>
+<br><br>
+<<if $universalRulesAssignsSelfFacility == 1>>
+	Slaves ''are'' permitted to assign themselves to facilities when choosing their assignment. [[Deny self assignment to facilities|Universal Rules][$universalRulesAssignsSelfFacility = 0]]
+<<else>>
+	Slaves ''are not'' permitted to assign themselves to facilities when choosing their assignment. [[Permit self assignment to facilities|Universal Rules][$universalRulesAssignsSelfFacility = 1]]
+<</if>>
+<</if>>
+
 <br><br>
 
 <<if $universalRulesNewSlavesRA == 0>>


### PR DESCRIPTION
The old saChoosesOwnJob was completely overriden by the final code block in it.  That is no longer the case.
Also prevented slaves from just throwing themselves into facilities without a second thought and causing problems by overloading facilities.  Has a new universal rule attached to allowing them to assign themselves, if there are open spots, to facilities. Also made use of <<AssignJob>>.

As for saChoosesOwnClothes, there were some inconsistancies with mindbroken slaves and showing reactions to things like heels.  Cleaned that up and allowed them some variety in what they could choose.