### PR TITLE
Rules Assistant usability & assignment code improvements

### DIFF
--- a/devTools/tweeGo/targets/sugarcube-2/userlib.js
+++ b/devTools/tweeGo/targets/sugarcube-2/userlib.js
@@ -129,31 +129,59 @@ if (typeof SlaveStatsChecker == "undefined") {
 	window.SlaveStatsChecker = SlaveStatsChecker;
 };
 
+window.removeFromArray = function(arr, val) {
+	for (var i = 0; i < arr.length; i++) {
+		if (val == arr[i])
+			return arr.splice(i,1);
+	}
+	return null;
+};
+
 window.canGetPregnant = function(slave) {
 	if (!slave) {
 		return null;
-	} else if (slave.preg != 0) {
+	} else if (slave.preg == -1) { /* contraceptives check */
 		return false;
-	} else if (slave.ovaries != 1) {
+	} else if (isFertile(slave) == false) { /* check other fertility factors */
 		return false;
-	} else if (canDoVaginal(slave) == false) {
+	} else if ((slave.ovaries == 1) && (canDoVaginal(slave) == true)) {
+		return true;
+	} else {
+		return false;
+	}
+};
+
+/* assuming slave1 is fertile, could slave2 impregnate slave1? slave2 must have dick and balls; both slaves must not be in chastity; slave2 need not achieve erection */
+window.canImpreg = function(slave1, slave2) {
+	if (!slave1 || !slave2) {
+		return null;
+	} else if (slave2.dick < 1) {
+		return false;
+	} else if (slave2.balls < 1) {
+		return false;
+	} else if (slave2.dickAccessory == "chastity") {
+		return false;
+	} else if (slave2.dickAccessory == "combined chastity") {
+		return false;
+	} else if (canGetPregnant(slave1) == false) { /* includes chastity checks */
 		return false;
 	} else {
 		return true;
 	}
 };
 
+/* contraceptives (.preg == -1) do not negate this function */
 window.isFertile = function(slave) {
 	if (!slave) {
 		return null;
-	} else if (slave.preg > 0) {
+	} else if (slave.preg > 0) { /* currently pregnant */
 		return false;
-	} else if (slave.preg < -1) {
+	} else if (slave.preg < -1) { /* sterile */
 		return false;
-	} else if (slave.ovaries != 1) {
-		return false;
-	} else {
+	} else if (slave.ovaries == 1) {
 		return true;
+	} else {
+		return false;
 	}
 };
 
@@ -272,20 +300,20 @@ window.ruleApplied = function(slave, ID) {
 };
 
 window.ruleAssignment = function(applyAssignment, assignment) {
+	if (!applyAssignment)
+		return false;
 	return applyAssignment.includes(assignment);
 };
 
 window.ruleFacility = function(applyFacility, facility) {
+	if (!applyFacility)
+		return false;
 	return applyFacility.includes(facility);
 };
 
 window.ruleExcludeSlaveFacility = function(rule, slave) {
-	if (!slave) {
+	if (!slave || !rule || !rule.excludeFacility) {
 		return null;
-	}else if (!rule) {
-		return null;
-	}else if (!rule.excludeFacility) {
-		return false;
 	} else {
 		for(var d=0; d < rule.excludeFacility.length; ++d){
 			if(rule.excludeFacility[d] == "hgsuite"){
@@ -374,16 +402,13 @@ window.ruleExcludeSlaveFacility = function(rule, slave) {
 				}
 			}
 		}
+		return false;
 	}
 };
 
 window.ruleAppliedToSlaveFacility = function(rule, slave) {
-	if (!slave) {
+	if (!slave || !rule || !rule.facility) {
 		return null;
-	}else if (!rule) {
-		return null;
-	}else if (!rule.facility) {
-		return false;
 	} else {
 		for(var d=0; d < rule.facility.length; ++d){
 			if(rule.facility[d] == "hgsuite"){
@@ -494,11 +519,7 @@ window.ruleSlaveExcluded = function(slave, rule) {
 };
 
 window.hasSurgeryRule = function(slave, rules) {
-	if (!slave) {
-		return false;
-	}else if (!rules) {
-		return false;
-	}else if (!slave.currentRules) {
+	if (!slave || !rules || !slave.currentRules) {
 		return false;
 	}else {
 		for(var d=rules.length-1; d >= 0; --d){
@@ -514,63 +535,15 @@ window.hasSurgeryRule = function(slave, rules) {
 };
 
 window.hasHColorRule = function(slave, rules) {
-	if (!slave) {
-		return false;
-	}else if (!rules) {
-		return false;
-	}else if (!slave.currentRules) {
-		return false;
-	}else {
-		for(var d=rules.length-1; d >= 0;--d){
-			for(var e=0; e < slave.currentRules.length;++e){
-				if(slave.currentRules[e] == rules[d].ID){
-					if (rules[d].hColor != "no default setting"){
-						return true;
-					}
-				}
-			}
-		}return false;
-	}
+	return lastRuleFor(slave, rules, "hColor") ? true : false;
 };
 
 window.hasHStyleRule = function(slave, rules) {
-	if (!slave) {
-		return false;
-	}else if (!rules) {
-		return false;
-	}else if (!slave.currentRules) {
-		return false;
-	}else {
-		for(var d=rules.length-1; d >= 0;--d){
-			for(var e=0; e < slave.currentRules.length;++e){
-				if(slave.currentRules[e] == rules[d].ID){
-					if (rules[d].hStyle != "no default setting"){
-						return true;
-					}
-				}
-			}
-		}return false;
-	}
+	return lastRuleFor(slave, rules, "hStyle") ? true : false;
 };
 
 window.hasEyeColorRule = function(slave, rules) {
-	if (!slave) {
-		return false;
-	}else if (!rules) {
-		return false;
-	}else if (!slave.currentRules) {
-		return false;
-	}else {
-		for(var d=rules.length-1; d >= 0;--d){
-			for(var e=0; e < slave.currentRules.length;++e){
-				if(slave.currentRules[e] == rules[d].ID){
-					if (rules[d].hStyle != "no default setting"){
-						return true;
-					}
-				}
-			}
-		}return false;
-	}
+	return lastRuleFor(slave, rules, "eyeColor") ? true : false;
 };
 
 window.lastRuleFor = function(slave, rules, what) {
@@ -912,3 +885,4 @@ window.cumAmount = function(slave) {
 		return cum
 	}
 };
+

--- a/src/init/storyInit.tw
+++ b/src/init/storyInit.tw
@@ -458,7 +458,6 @@
 <<set $futaAddiction = 0>>
 
 <<set $IDNumber = 1>>
-<<set $RulesID = 3>>
 
 <<set $week = 1>>
 <<set $month = "January">>

--- a/src/uncategorized/BackwardsCompatibility.tw
+++ b/src/uncategorized/BackwardsCompatibility.tw
@@ -39,56 +39,51 @@
 	<<set $fixedRace = 0>>
 <</if>>
 
-<<if ndef $RulesID>>
-	<<set $RulesID to 3>>
-	<<include "Init Rules">>
-<<else>>
-	<<for _i to 0; _i < $defaultRules.length; _i++>>
-		<<if ndef $defaultRules[_i].standardReward>>
-			<<set $defaultRules[_i].standardReward to "no default setting">>
-		<</if>>
-		<<if ndef $defaultRules[_i].standardPunishment>>
-			<<set $defaultRules[_i].standardPunishment to "no default setting">>
-		<</if>>
-		<<if ndef $defaultRules[_i].aVirginAccessory>>
-			<<set $defaultRules[_i].aVirginAccessory to "no default setting">>
-		<</if>>
-		<<if ndef $defaultRules[_i].aVirginDickAccessory>>
-			<<set $defaultRules[_i].aVirginDickAccessory to "no default setting">>
-		<</if>>
-		<<if ndef $defaultRules[_i].aVirginButtplug>>
-			<<set $defaultRules[_i].aVirginButtplug to "no default setting">>
-		<</if>>
-		<<if ndef $defaultRules[_i].surgery>>
-			<<set $defaultRules[_i].surgery to {lactation: "no default setting", cosmetic: 0, accent: "no default setting", shoulders: "no default setting", shouldersImplant: "no default setting", boobs: "no default setting", hips: "no default setting", hipsImplant: "no default setting", butt: "no default setting", faceShape: "no default setting", lips: "no default setting", holes: 0}>>
-		<</if>>
-		<<if ndef $defaultRules[_i].dietMilk>>
-			<<set $defaultRules[_i].dietMilk = 0>>
-		<</if>>
-		<<if ndef $defaultRules[_i].dietCum>>
-			<<set $defaultRules[_i].dietCum = 0>>
-		<</if>>
-		<<if ndef $defaultRules[_i].clitSettingXY>>
-			<<set $defaultRules[_i].clitSettingXY = "no default setting">>
-		<</if>>
-		<<if ndef $defaultRules[_i].clitSettingXX>>
-			<<set $defaultRules[_i].clitSettingXX = "no default setting">>
-		<</if>>
-		<<if ndef $defaultRules[_i].clitSettingEnergy>>
-			<<set $defaultRules[_i].clitSettingEnergy = "no default setting">>
-		<</if>>
-		<<switch $defaultRules[_i].clitSetting>>
-		<<case "all">>
-			<<set $defaultRules[_i].clitSetting = "no default setting", $defaultRules[_i].clitSettingXY = 100, $defaultRules[_i].clitSettingXX = 100, $defaultRules[_i].clitSettingEnergy = 100>>
-		<<case "none">>
-			<<set $defaultRules[_i].clitSetting = "no default setting", $defaultRules[_i].clitSettingXY = 0, $defaultRules[_i].clitSettingXX = 0, $defaultRules[_i].clitSettingEnergy = 0>>
-		<<case "men">>
-			<<set $defaultRules[_i].clitSetting = "no default setting", $defaultRules[_i].clitSettingXY = 100>>
-		<<case "women">>
-			<<set $defaultRules[_i].clitSetting = "no default setting", $defaultRules[_i].clitSettingXX = 100>>
-		<</switch>>
-	<</for>>
-<</if>>
+<<for _i = 0; _i < $defaultRules.length; _i++>>
+	<<if ndef $defaultRules[_i].standardReward>>
+		<<set $defaultRules[_i].standardReward = "no default setting">>
+	<</if>>
+	<<if ndef $defaultRules[_i].standardPunishment>>
+		<<set $defaultRules[_i].standardPunishment = "no default setting">>
+	<</if>>
+	<<if ndef $defaultRules[_i].aVirginAccessory>>
+		<<set $defaultRules[_i].aVirginAccessory = "no default setting">>
+	<</if>>
+	<<if ndef $defaultRules[_i].aVirginDickAccessory>>
+		<<set $defaultRules[_i].aVirginDickAccessory = "no default setting">>
+	<</if>>
+	<<if ndef $defaultRules[_i].aVirginButtplug>>
+		<<set $defaultRules[_i].aVirginButtplug = "no default setting">>
+	<</if>>
+	<<if ndef $defaultRules[_i].surgery>>
+		<<set $defaultRules[_i].surgery = {lactation: "no default setting", cosmetic: 0, accent: "no default setting", shoulders: "no default setting", shouldersImplant: "no default setting", boobs: "no default setting", hips: "no default setting", hipsImplant: "no default setting", butt: "no default setting", faceShape: "no default setting", lips: "no default setting", holes: 0}>>
+	<</if>>
+	<<if ndef $defaultRules[_i].dietMilk>>
+		<<set $defaultRules[_i].dietMilk = 0>>
+	<</if>>
+	<<if ndef $defaultRules[_i].dietCum>>
+		<<set $defaultRules[_i].dietCum = 0>>
+	<</if>>
+	<<if ndef $defaultRules[_i].clitSettingXY>>
+		<<set $defaultRules[_i].clitSettingXY = "no default setting">>
+	<</if>>
+	<<if ndef $defaultRules[_i].clitSettingXX>>
+		<<set $defaultRules[_i].clitSettingXX = "no default setting">>
+	<</if>>
+	<<if ndef $defaultRules[_i].clitSettingEnergy>>
+		<<set $defaultRules[_i].clitSettingEnergy = "no default setting">>
+	<</if>>
+	<<switch $defaultRules[_i].clitSetting>>
+	<<case "all">>
+		<<set $defaultRules[_i].clitSetting = "no default setting", $defaultRules[_i].clitSettingXY = 100, $defaultRules[_i].clitSettingXX = 100, $defaultRules[_i].clitSettingEnergy = 100>>
+	<<case "none">>
+		<<set $defaultRules[_i].clitSetting = "no default setting", $defaultRules[_i].clitSettingXY = 0, $defaultRules[_i].clitSettingXX = 0, $defaultRules[_i].clitSettingEnergy = 0>>
+	<<case "men">>
+		<<set $defaultRules[_i].clitSetting = "no default setting", $defaultRules[_i].clitSettingXY = 100>>
+	<<case "women">>
+		<<set $defaultRules[_i].clitSetting = "no default setting", $defaultRules[_i].clitSettingXX = 100>>
+	<</switch>>
+<</for>>
 
 <<if ndef $month>>
 <<set $month to either("January","February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December")>>

--- a/src/uncategorized/arcadeReport.tw
+++ b/src/uncategorized/arcadeReport.tw
@@ -35,6 +35,9 @@
 	<</if>>
 	/% Onward bound as normal %/
 	<<set $oldCash = $cash, $i = _i>>
+
+	/* Perform facility based rule changes */
+	<<set $slaves[_i].clothes = "no clothing">>
 	<<if ($arcadeUpgradeInjectors == 1)>>
 		<<if ($slaves[_i].health < -60)>>
 			<<set $slaves[_i].health = -60>>
@@ -52,6 +55,7 @@
 		<</if>>
 		<<set $slaves[_i].trust -= 5>>
 	<</if>>
+
 	<<if $showEWD != 0>>
 		<br><br>
 		/* 000-250-006 */
@@ -177,3 +181,4 @@
 	<</if>>
 	<br><br>
 <</if>>
+

--- a/src/uncategorized/assign.tw
+++ b/src/uncategorized/assign.tw
@@ -5,59 +5,23 @@
 <<assignJob $activeSlave $returnTo>>
 
 <<switch $returnTo>>
-<<case "Arcade">>
-	<<set $activeSlave.clothes = "no clothing">>
-<<case "Master Suite">>
-	<<if $masterSuiteUpgradeLuxury > 1>>
-		<<set $activeSlave.livingRules = "luxurious">>
-	<<else>>
-		<<set $activeSlave.livingRules = "normal">>
-	<</if>>
-<<case "Dairy">>
-	<<if $dairyRestraintsSetting > 1>>
-		<<set $activeSlave.collar = "none", $activeSlave.clothes = "no clothing", $activeSlave.buttplug = "none", $activeSlave.vaginalAccessory = "none">>
-	<</if>>
 <<case "Pit">>
 	<<set $fighterIDs.push(_ID)>>
+
 <<case "Coursing Association">>
 	<<set $Lurcher = $activeSlave>>
+
+<<default>>
+	<<if ($showAssignToScenes != 1) || ($activeSlave.fetish == "mindbroken")>>
+		<<goto $returnTo>>
+	<<elseif ($returnTo == "Dairy") && (($dairyStimulatorsSetting >= 2) || ($dairyFeedersSetting >= 2) || ($dairyPregSetting >= 2))>>
+		<<goto "Industrial Dairy Assignment Scene">>
+	<<elseif ($returnTo == "Dairy") && ($dairyRestraintsSetting == 0 && $activeSlave.devotion > 0)>>
+		<<goto "Free Range Dairy Assignment Scene">>
+	<<elseif ($returnTo == "Brothel")>>
+		<<goto "Brothel Assignment Scene">>
+	<<else>>
+		<<goto $returnTo>>
+	<</if>>
+
 <</switch>>
-
-<<if ($returnTo != "Pit") && ($returnTo != "Coursing Association")>>
-
-<<if $returnTo != "Master Suite">>
-	<<set $activeSlave.livingRules = "spare">>
-<</if>>
-
-<<set $activeSlave.drugs = "no drugs", $activeSlave.releaseRules = "restrictive", $activeSlave.sentence = 0, $activeSlave.standardPunishment = "situational", $activeSlave.standardReward = "situational", $activeSlave.releaseRules = "restrictive">>
-
-<<if _ID == $HeadGirl.ID>><<set $HeadGirl = 0>><</if>>
-<<if _ID == $Recruiter.ID>><<set $Recruiter = 0>><</if>>
-<<if _ID == $Bodyguard.ID>><<set $Bodyguard = 0>><</if>>
-<<if _ID == $Madam.ID>><<set $Madam = 0>><</if>>
-<<if _ID == $DJ.ID>><<set $DJ = 0>><</if>>
-<<if _ID == $Milkmaid.ID>><<set $Milkmaid = 0>><</if>>
-<<if _ID == $Schoolteacher.ID>><<set $Schoolteacher = 0>><</if>>
-<<if _ID == $Attendant.ID>><<set $Attendant = 0>><</if>>
-<<if _ID == $Nurse.ID>><<set $Nurse = 0>><</if>>
-<<if _ID == $Collectrix.ID>><<set $Collectrix = 0>><</if>>
-<<if _ID == $Stewardess.ID>><<set $Stewardess = 0>><</if>>
-<<if _ID == $Wardeness.ID>><<set $Wardeness = 0>><</if>>
-<<if _ID == $Concubine.ID>><<set $Concubine = 0>><</if>>
-
-<<set $slaves[$i] = $activeSlave>>
-
-<<if ($showAssignToScenes != 1) || ($activeSlave.fetish == "mindbroken")>>
-	<<goto $returnTo>>
-<<elseif ($returnTo == "Dairy") && (($dairyStimulatorsSetting >= 2) || ($dairyFeedersSetting >= 2) || ($dairyPregSetting >= 2))>>
-	<<goto "Industrial Dairy Assignment Scene">>
-<<elseif ($returnTo == "Dairy") && ($dairyRestraintsSetting == 0 && $activeSlave.devotion > 0)>>
-	<<goto "Free Range Dairy Assignment Scene">>
-<<else>>
-  <<goto $returnTo>>
-<</if>>
-<<else>>
-  <<goto $returnTo>>
-<</if>>
-
-

--- a/src/uncategorized/dairyReport.tw
+++ b/src/uncategorized/dairyReport.tw
@@ -229,7 +229,9 @@
 	<<elseif ($slaves[_i].diet == "fattening") || ($dairyRestraintsSetting > 1)>>
 		<<set $slaves[_i].diet = "healthy">>
 	<</if>>
-
+	<<if $dairyRestraintsSetting > 1>>
+		<<set $slaves[_i].collar = "none", $slaves[_i].clothes = "no clothing", $slaves[_i].buttplug = "none", $slaves[_i].vaginalAccessory = "none">>
+	<</if>>
 	/* General End of Week effects */
 	<<if $showEWD != 0>>
 		<br><br>

--- a/src/uncategorized/importRule.tw
+++ b/src/uncategorized/importRule.tw
@@ -16,9 +16,14 @@
 
 		<<set $defaultRules.push($tempRule)>>
 
-		/* renumber rule IDs */
+		/* renumber rule IDs and update slaves' assigned rule IDs if needed */
 		<<for $r = 0; $r < $defaultRules.length; $r++>>
 			<<set $defaultRules[$r].ID = $r + 1>>
+		<</for>>
+		<<for _i = 0; _i < $slaves.length; _i++>>
+			<<silently>>
+				<<CheckAutoRulesActivate $slaves[_i]>>
+			<</silently>>
 		<</for>>
 
 		<<replace #import>>

--- a/src/uncategorized/importRule.tw
+++ b/src/uncategorized/importRule.tw
@@ -1,26 +1,26 @@
 :: Import Rule [nobr]
 
+<<set $nextButton = "Continue", $nextLink = "Rules Assistant">>
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "Rules Assistant">>
 //Paste the code into the text box and click Apply//
 <br><br>
 <span id = "import">
 </span>
+
 <<set $tempRule = "">>
 <<textbox "$tempRule" $tempRule>>
+
 <<link "Apply">>
 	<<if (def $tempRule) && ($tempRule !== "")>>
 		<<set $tempRule = eval('({' + $tempRule + '})')>>
 
-		<<if $defaultRules.length > 0>>
-			<<set $RulesID += 1>>
-		<<else>>
-			<<set $RulesID = 1>>
-		<</if>>
-
-		<<set $tempRule.ID = $RulesID>>
 		<<set $defaultRules.push($tempRule)>>
+
+		/* renumber rule IDs */
+		<<for $r = 0; $r < $defaultRules.length; $r++>>
+			<<set $defaultRules[$r].ID = $r + 1>>
+		<</for>>
+
 		<<replace #import>>
 			''Rule imported successfully!''
 			<br><br>
@@ -33,7 +33,9 @@
 	<</if>>
 	<<unset $tempRule>>
 <</link>>
+
 <br><br>
+
 <<link "Continue">>
 	<<goto "Rules Assistant">>
 <</link>>

--- a/src/uncategorized/masterSuiteReport.tw
+++ b/src/uncategorized/masterSuiteReport.tw
@@ -118,7 +118,10 @@ The level of sexual energy in the suite is
 	/* 000-250-006 */
 <<if ($slaves[_i].assignment != "be your Concubine")>>
 	<<if $verboseDescriptions == 1>>''__@@.pink;$slaves[_i].slaveName@@__'' sees to your pleasure in the master suite.<</if>>
+
+	/* Perform facility based rule changes */
 	<<if ($masterSuiteUpgradeLuxury == 1)>>
+	<<set $slaves[_i].livingRules = "luxurious">>
 	<<if ($slaves[_i].devotion <= 95)>>
 		<<set $slaves[_i].devotion += 2>>
 	<</if>>
@@ -129,6 +132,7 @@ The level of sexual energy in the suite is
 		<<set $slaves[_i].trust++>>
 	<</if>>
 	<<elseif ($masterSuiteUpgradeLuxury == 2)>>
+	<<set $slaves[_i].livingRules = "luxurious">>
 	<<if ($slaves[_i].energy > 90)>>
 		<<if ($slaves[_i].devotion <= 95)>>
 		<<set $slaves[_i].devotion += 2>>
@@ -145,6 +149,7 @@ The level of sexual energy in the suite is
 		<</if>>
 	<</if>>
 	<<else>>
+	<<set $slaves[_i].livingRules = "spare">>
 	<<if ($slaves[_i].devotion <= 20) && ($slaves[_i].trust > -20)>>
 		<<set $slaves[_i].devotion -= 2, $slaves[_i].trust -= 5>>
 	<<elseif ($slaves[_i].devotion <= 60)>>
@@ -156,6 +161,7 @@ The level of sexual energy in the suite is
 		<<set $slaves[_i].trust++>>
 	<</if>>
 	<</if>>
+
 <<else>>
 	<<set $Concubine = $slaves[_FLs]>>
 	<<if $verboseDescriptions == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>''Your concubine $Concubine.slaveName is serving you in $masterSuiteName.'' More than any other slave, her sexual brilliance and physical appeal are @@.green;critical@@ to your reputation.
@@ -173,9 +179,9 @@ The level of sexual energy in the suite is
 	<</if>>
 	<<if $slaves[_i].devotion <= 20>>
 	<<if $masterSuiteUpgradeLuxury > 0>>
-		<<set $slaves[_i].devotion += 4, $slaves[_i].trust += 4>>
+		<<set $slaves[_i].livingRules = "luxurious", $slaves[_i].devotion += 4, $slaves[_i].trust += 4>>
 	<<else>>
-		<<set $slaves[_i].devotion += 2, $slaves[_i].trust += 2>>
+		<<set $slaves[_i].livingRules = "normal", $slaves[_i].devotion += 2, $slaves[_i].trust += 2>>
 	<</if>>
 	<</if>>
 	<<if $masterSuiteDecoration != "standard">>
@@ -269,8 +275,8 @@ The level of sexual energy in the suite is
 
 <<if $masterSuiteUpgradePregnancy == 1>>
 	/* If they're not on fertility drugs and the toggle is active, stick them on (if they can take them). Otherwise take them off. */
-	<<if $slaves[_i].assignment == "serve in the master suite">>
-	<<if ($masterSuitePregnancyFertilityDrugs == 1) && ($slaves[_i].drugs != "fertility drugs") && ($slaves[_i].preg > -2) && ($slaves[_i].ovaries > 0)>>
+	<<if $slaves[_i].assignment == "serve in the master suite" || $slaves[_i].assignment == "be your Concubine">>
+	<<if ($masterSuitePregnancyFertilityDrugs == 1) && ($slaves[_i].drugs != "fertility drugs") && canGetPregnant($slaves[_i])>>
 		<<set $slaves[_i].drugs = "fertility drugs">>
 	<<elseif ($masterSuitePregnancyFertilityDrugs == 0) && ($slaves[_i].drugs == "fertility drugs")>>
 		<<set $slaves[_i].drugs = "no drugs">>

--- a/src/uncategorized/rulesAssistant.tw
+++ b/src/uncategorized/rulesAssistant.tw
@@ -3,32 +3,33 @@
 <<set $nextButton = "Back to Main", $nextLink = "Main", $returnTo = "Main">>
 <<set $showEncyclopedia = 1, $encyclopedia = "Personal Assistant">>
 
-<<if $defaultRules.length > 0>>
+<<set _length = $defaultRules.length>>
 
-	<<if ndef $currentRule>>                    <<set $currentRule = $defaultRules[0]>>     <</if>>
-	<<if ndef $currentRule.assignment>>         <<set $currentRule.assignment = []>>        <</if>>
-	<<if ndef $currentRule.excludeAssignment>>  <<set $currentRule.excludeAssignment = []>> <</if>>
-	<<if ndef $currentRule.excludedSlaves>>     <<set $currentRule.excludedSlaves = []>>    <</if>>
-	<<if ndef $currentRule.selectedSlaves>>     <<set $currentRule.selectedSlaves = []>>    <</if>>
-	<<if ndef $currentRule.facility>>           <<set $currentRule.facility = []>>          <</if>>
-	<<if ndef $currentRule.excludeFacility>>    <<set $currentRule.excludeFacility = []>>   <</if>>
+<<if _length > 0>>
 
-	<<for _r = 0; _r < $defaultRules.length; _r++>>
-		<<if $currentRule.ID == $defaultRules[_r].ID>>
-			<<set $r = _r+1>>
+	<<if ndef $currentRule || $currentRule == null>>  <<set $currentRule = $defaultRules[0]>>           <</if>>
+	<<if ndef $currentRule.assignment>>               <<set $currentRule.assignment = []>>              <</if>>
+	<<if ndef $currentRule.excludeAssignment>>        <<set $currentRule.excludeAssignment = []>>       <</if>>
+	<<if ndef $currentRule.excludedSlaves>>           <<set $currentRule.excludedSlaves = []>>          <</if>>
+	<<if ndef $currentRule.selectedSlaves>>           <<set $currentRule.selectedSlaves = []>>          <</if>>
+	<<if ndef $currentRule.facility>>                 <<set $currentRule.facility = []>>                <</if>>
+	<<if ndef $currentRule.excludeFacility>>          <<set $currentRule.excludeFacility = []>>         <</if>>
+
+	<<for $r = _length - 1; $r >= 0; $r-->>
+		<<if $defaultRules[$r] == null>>
+			<<set $defaultRules.deleteAt($r)>>
+			<<goto "Rules Assistant">>
+		<<elseif $currentRule.ID == $defaultRules[$r].ID>>
+			<<set $r = $r + 1>>
 			<<break>>
 		<</if>>
 	<</for>>
-	
 
-	
 	<center>
 		<<if $r > 1>>
 			@@.cyan;[Shift+←,Shift+Q] @@<span id="firstRule">
 			<strong>
 			<<link "First">>
-				<<set $currentRule.facility = _facility>>
-				<<set $currentRule.excludeFacility = _excludeFacility>>
 				<<set $currentRule = $defaultRules[0]>>
 				<<goto "Rules Assistant">>
 			<</link>>
@@ -38,9 +39,7 @@
 			@@.cyan;[←,Q] @@<span id="prevRule">
 			<strong>
 			<<link "Prev">>
-				<<set $currentRule.facility = _facility>>
-				<<set $currentRule.excludeFacility = _excludeFacility>>
-				<<set $currentRule = $defaultRules[_r-1]>>
+				<<set $currentRule = $defaultRules[$r-2]>>
 				<<goto "Rules Assistant">>
 			<</link>>
 			</strong>
@@ -49,15 +48,13 @@
 			[Shift+←,Shift+Q] First  |  [←,Q] Prev
 		<</if>>
 
-		&nbsp;&nbsp;&nbsp;&nbsp;''Viewing Rule $r of $defaultRules.length''&nbsp;&nbsp;&nbsp;&nbsp;
+		&nbsp;&nbsp;&nbsp;&nbsp;''Viewing Rule $r of _length''&nbsp;&nbsp;&nbsp;&nbsp;
 
-		<<if _r+1 < $defaultRules.length>>
+		<<if $r < _length>>
 			<span id="nextRule">
 			<strong>
 			<<link "Next">>
-				<<set $currentRule.facility = _facility>>
-				<<set $currentRule.excludeFacility = _excludeFacility>>
-				<<set $currentRule = $defaultRules[_r+1]>>
+				<<set $currentRule = $defaultRules[$r]>>
 				<<goto "Rules Assistant">>
 			<</link>>
 			</strong>
@@ -66,11 +63,11 @@
 			Next [E,→]  |  
 		<</if>>
 
-		<<if $r != $defaultRules.length && $defaultRules[$defaultRules.length-1]>>
+		<<if $r < _length>>
 			<span id="lastRule">
 			<strong>
 			<<link "Last">>
-				<<set $currentRule = $defaultRules[$defaultRules.length-1]>>
+				<<set $currentRule = $defaultRules[_length-1]>>
 				<<goto "Rules Assistant">>
 			<</link>>
 			</strong>
@@ -81,8 +78,8 @@
 	</center>
 
 	<center>
-		<<if _r > 0>>
-			<<print $defaultRules[_r-1].name+" &emsp; <- &emsp;&emsp;">>
+		<<if $r > 1>>
+			<<print $defaultRules[$r-2].name+" &emsp; <- &emsp;&emsp;">>
 		<<else>>
 			<<print "&emsp;&emsp;&emsp;&emsp;&emsp;">>
 		<</if>>
@@ -94,8 +91,8 @@
 		@@.yellow;$currentRule.name@@
 		</span>
 
-		<<if _r < $defaultRules.length-1>>
-			<<print "&emsp;&emsp; -> &emsp; "+$defaultRules[_r+1].name>>
+		<<if $r < _length>>
+			<<print "&emsp;&emsp; -> &emsp; "+$defaultRules[$r].name>>
 		<<else>>
 			<<print "&emsp;&emsp;&emsp;&emsp;&emsp;">>
 		<</if>>
@@ -103,15 +100,15 @@
 
 	<center>
 		<span id="ruleDown">
-			<<if _r > 0>>
-			<<link "Lower Priority">>
-			<<set _tmpRule = $defaultRules[_r]>>
-			<<set $defaultRules[_r] = $defaultRules[_r-1]>>
-			<<set $defaultRules[_r-1] = _tmpRule>>
-			<<goto "Rules Assistant">>
-			<</link>>
+			<<if $r > 1>>
+				<<link "Lower Priority">>
+					<<set _tmpRule = $defaultRules[$r-1]>>
+					<<set $defaultRules[$r-1] = $defaultRules[$r-2]>>
+					<<set $defaultRules[$r-2] = _tmpRule>>
+					<<goto "Rules Assistant">>
+				<</link>>
 			<<else>>
-			Lower Priority
+				Lower Priority
 			<</if>>
 		</span>
 			|
@@ -122,11 +119,11 @@
 		<</link>>
 			|
 		<span id="ruleUp">
-			<<if _r < $defaultRules.length-1>>
+			<<if $r < _length>>
 				<<link "Higher Priority">>
-					<<set _tmpRule = $defaultRules[_r]>>
-					<<set $defaultRules[_r] = $defaultRules[_r+1]>>
-					<<set $defaultRules[_r+1] = _tmpRule>>
+					<<set _tmpRule = $defaultRules[$r-1]>>
+					<<set $defaultRules[$r-1] = $defaultRules[$r]>>
+					<<set $defaultRules[$r] = _tmpRule>>
 					<<goto "Rules Assistant">>
 				<</link>> 
 			<<else>>
@@ -134,7 +131,7 @@
 			<</if>>
 		</span>
 	</center>
-<</if>> /* closes if $defaultRules.length > 0 */
+<</if>> /* closes if _length > 0 */
 
 <br>
 
@@ -142,7 +139,7 @@
 
 <br><br>
 
-<<if $defaultRules.length < 1>>
+<<if _length < 1>>
 ''No rules.''
 
 <<else>>
@@ -2371,7 +2368,7 @@ Relationship rules: ''$currentRule.relationshipRules.''
 <<link "Reset this rule to use FC Dev's preferred options">>
 	<<replace "#saveresult">>
 	//Rule reset.//
-	<<for _t = 0; _t < $defaultRules.length; _t++>>
+	<<for _t = 0; _t < _length; _t++>>
 
 		<<if $currentRule.ID == $defaultRules[_t].ID>>
 			<<if ($currentRule.ID == 1)>>
@@ -2629,9 +2626,9 @@ Relationship rules: ''$currentRule.relationshipRules.''
 <<set _text = "Remove rule " + $r>>
 <<link _text>>
 	<<set $defaultRules.deleteAt($r-1)>>
-	<<for _r = $defaultRules.length; _r >= 0; _r-->>
-		<<if def $defaultRules[_r]>>
-			<<set $currentRule = $defaultRules[_r]>>
+	<<for $r = $defaultRules.length; $r > 0; $r-->>
+		<<if def $defaultRules[$r-1]>>
+			<<set $currentRule = $defaultRules[$r-1]>>
 			<<break>>
 		<</if>>
 	<</for>>
@@ -2639,42 +2636,37 @@ Relationship rules: ''$currentRule.relationshipRules.''
 <</link>>
 </span>
 
-<</if>> /* closes if defaultRules.length > 0 */
+<</if>> /* closes if _length > 0 */
 
 <br><br>
 
-<<if $defaultRules.length < 10>>
+<<if _length < 10>>
 
 	<<link "Add a new rule">>
 
 		<<set _activeRule = {aphrodisiacs: "no default setting", activation: "none", thresholdLower: 4, thresholdUpper: "none", eqLower: true, eqUpper: true, releaseRules: "no default setting", clitSetting: "no default setting", clitSettingXY: "no default setting", clitSettingXX: "no default setting", clitSettingEnergy: "no default setting", speechRules: "no default setting", clothes: "no default setting", fuckdoll: 0, choosesOwnClothes: 0, collar: "no default setting", shoes: "no default setting", virginAccessory: "no default setting", aVirginAccessory: "no default setting", vaginalAccessory: "no default setting", aVirginDickAccessory: "no default setting", dickAccessory: "no default setting", cSec: 0, bellyAccessory: "no default setting", aVirginButtplug: "no default setting", buttplug: "no default setting", markings: "none", eyeColor: "no default setting", makeup: "no default setting", nails: "no default setting", hColor: "no default setting", hLength: "no default setting", hStyle: "no default setting", pubicHColor: "no default setting", pubicHStyle: "no default setting", nipplesPiercing: "no default setting", areolaePiercing: "no default setting", clitPiercing: "no default setting", vaginaLube: "no default setting", vaginaPiercing: "no default setting", analArea: 1, dickPiercing: "no default setting", anusPiercing: "no default setting", lipsPiercing: "no default setting", tonguePiercing: "no default setting", earPiercing: "no default setting", nosePiercing: "no default setting", eyebrowPiercing: "no default setting", navelPiercing: "no default setting", corsetPiercing: "no default setting", boobsTat: "no default setting", buttTat: "no default setting", vaginaTat: "no default setting", dickTat: "no default setting", lipsTat: "no default setting", anusTat: "no default setting", shouldersTat: "no default setting", armsTat: "no default setting", legsTat: "no default setting", backTat: "no default setting", stampTat: "no default setting", curatives: "no default setting", livingRules: "no default setting", relationshipRules: "no default setting", standardPunishment: "no default setting", standardReward: "no default setting", useRulesAssistant: 1, diet: "no default setting", dietCum: "no default setting", dietMilk: "no default setting", muscles: "no default setting", XY: "no default setting", XX: "no default setting", gelding: "no default setting", preg: "no default setting", growth: "no default setting", autoSurgery: 0, choosesOwnAssignment: 0, lactation: 0, autoBrand: 0, pornFameSpending: "no default setting", dietGrowthSupport: 0, eyewear: "no default setting", assignment: [], excludeAssignment: [], setAssignment: "none", facility: [], excludeFacility: [], assignFacility: "none", excludeSpecialSlaves: true, facilityRemove: false, removalAssignment: "rest", selectedSlaves: [], excludedSlaves: [], surgery: {lactation: "no default setting", cosmetic: 0, accent: "no default setting", shoulders: "no default setting", shouldersImplant: "no default setting", boobs: "no default setting", hips: "no default setting", hipsImplant: "no default setting", butt: "no default setting", faceShape: "no default setting", lips: "no default setting", holes: 0} }>>
 
-		<<if ndef _r>>
-			<<set _r = 0>>
-			<<set $r = 1>>
-		<</if>>
-
-		<<if $defaultRules.length > 0>>
-			<<set _length to ($defaultRules.length+1)>>
-			<<set $RulesID to $RulesID+1>>
-		<<else>>
-			<<set _length to 1>>
-			<<set $RulesID to 1>>
-		<</if>>
-
-		<<set _activeRule.name = "Rule " + _length>>
-		<<set _activeRule.ID = $RulesID>>
-
+		<<set _activeRule.name = "Rule " + (_length+1)>>
 		<<set $defaultRules.push(_activeRule)>>
 
-		<<set $currentRule = $defaultRules[$defaultRules.length-1]>>
+		/* renumber rule IDs and update slaves' assigned rule IDs if needed */
+		<<for $r = 0; $r < $defaultRules.length; $r++>>
+			<<set $defaultRules[$r].ID = $r + 1>>
+		<</for>>
+		<<for _i = 0; _i < $slaves.length; _i++>>
+			<<silently>>
+				<<CheckAutoRulesActivate $slaves[_i]>>
+			<</silently>>
+		<</for>>
+
+		<<set $currentRule = $defaultRules[_length]>>
 		<<goto "Rules Assistant">>
 		
 	<</link>> |
 
 <</if>>
 
-<<if $defaultRules.length > 0>>
+<<if _length > 0>>
 	<span id="apply">
 		<span id="applied"></span>
 		<span id="applyresult"></span>

--- a/src/uncategorized/rulesAssistant.tw
+++ b/src/uncategorized/rulesAssistant.tw
@@ -1,102 +1,152 @@
 :: Rules Assistant [nobr]
 
-<<set $nextButton = "Back to Main">>
-<<set $nextLink = "Main">>
-<<set $returnTo = "Main">>
+<<set $nextButton = "Back to Main", $nextLink = "Main", $returnTo = "Main">>
 <<set $showEncyclopedia = 1, $encyclopedia = "Personal Assistant">>
 
 <<if $defaultRules.length > 0>>
 
-<<for _r = 0; _r < $defaultRules.length; _r++>>
-<<if $currentRule.ID == $defaultRules[_r].ID >>
-<<set $r = _r+1>>
-<<break>>
-<</if>>
-<</for>>
-<center>
-<<if $r > 1>>
-	@@.cyan;[Shift+←,Shift+Q] @@<span id="firstRule">
-	<strong>
-	<<link "First">>
-		<<set $currentRule.facility = _facility>>
-		<<set $currentRule.excludeFacility = _excludeFacility>>
-		<<set $currentRule = $defaultRules[0]>>
-		<<goto "Rules Assistant">>
-	<</link>>
-	</strong>
-	</span>  |  
+	<<if ndef $currentRule>>                    <<set $currentRule = $defaultRules[0]>>     <</if>>
+	<<if ndef $currentRule.assignment>>         <<set $currentRule.assignment = []>>        <</if>>
+	<<if ndef $currentRule.excludeAssignment>>  <<set $currentRule.excludeAssignment = []>> <</if>>
+	<<if ndef $currentRule.excludedSlaves>>     <<set $currentRule.excludedSlaves = []>>    <</if>>
+	<<if ndef $currentRule.selectedSlaves>>     <<set $currentRule.selectedSlaves = []>>    <</if>>
+	<<if ndef $currentRule.facility>>           <<set $currentRule.facility = []>>          <</if>>
+	<<if ndef $currentRule.excludeFacility>>    <<set $currentRule.excludeFacility = []>>   <</if>>
 
-	@@.cyan;[←,Q] @@<span id="prevRule">
-	<strong>
-	<<link "Prev">>
-		<<set $currentRule.facility = _facility>>
-		<<set $currentRule.excludeFacility = _excludeFacility>>
-		<<set $currentRule = $defaultRules[_r-1]>>
-		<<goto "Rules Assistant">>
-	<</link>>
-	</strong>
-	</span>
-<<else>>
-[Shift+←,Shift+Q] First  |  [←,Q] Prev
-<</if>>
-&nbsp;&nbsp;&nbsp;&nbsp;''Viewing Rule $r of $defaultRules.length''&nbsp;&nbsp;&nbsp;&nbsp;
-<<if _r+1 < $defaultRules.length>>
-	<span id="nextRule">
-	<strong>
-	<<link "Next">>
-		<<set $currentRule.facility = _facility>>
-		<<set $currentRule.excludeFacility = _excludeFacility>>
-		<<set $currentRule = $defaultRules[_r+1]>>
-		<<goto "Rules Assistant">>
-	<</link>>
-	</strong>
-	</span>@@.cyan; [E,→]@@  |  
-<<else>>
-Next [E,→]  |  
-<</if>>
+	<<for _r = 0; _r < $defaultRules.length; _r++>>
+		<<if $currentRule.ID == $defaultRules[_r].ID>>
+			<<set $r = _r+1>>
+			<<break>>
+		<</if>>
+	<</for>>
+	
 
-<<if $r != $defaultRules.length && $defaultRules[$defaultRules.length-1]>>
-<span id="lastRule">
-	<strong>
-	<<link "Last">>
-		<<set $currentRule.facility = _facility>>
-		<<set $currentRule.excludeFacility = _excludeFacility>>
-		<<set $currentRule = $defaultRules[$defaultRules.length-1]>>
-		<<goto "Rules Assistant">>
-	<</link>>
-	</strong>
-	</span>@@.cyan; [Shift+E,Shift+→]@@
-<<else>>
-Last [Shift+E,Shift+→]
-<</if>>
-</center>
+	
+	<center>
+		<<if $r > 1>>
+			@@.cyan;[Shift+←,Shift+Q] @@<span id="firstRule">
+			<strong>
+			<<link "First">>
+				<<set $currentRule.facility = _facility>>
+				<<set $currentRule.excludeFacility = _excludeFacility>>
+				<<set $currentRule = $defaultRules[0]>>
+				<<goto "Rules Assistant">>
+			<</link>>
+			</strong>
+			</span>
+				|	
+			@@.cyan;[←,Q] @@<span id="prevRule">
+			<strong>
+			<<link "Prev">>
+				<<set $currentRule.facility = _facility>>
+				<<set $currentRule.excludeFacility = _excludeFacility>>
+				<<set $currentRule = $defaultRules[_r-1]>>
+				<<goto "Rules Assistant">>
+			<</link>>
+			</strong>
+			</span>
+		<<else>>
+			[Shift+←,Shift+Q] First  |  [←,Q] Prev
+		<</if>>
 
-<center>
-	<br><span id="rulename">
-	<<if ndef $currentRule.name>>
-		<<set $currentRule.name = "Rule " + $r>>
-	<</if>>
-	$currentRule.name |
-	</span>
-	<<link "Rename">>
-	<<replace "#rulename">>
-		<<textbox "$currentRule.name" $currentRule.name "Rules Assistant">>
-	<</replace>>
-	<</link>>
-</center>
-<</if>>
+		&nbsp;&nbsp;&nbsp;&nbsp;''Viewing Rule $r of $defaultRules.length''&nbsp;&nbsp;&nbsp;&nbsp;
+
+		<<if _r+1 < $defaultRules.length>>
+			<span id="nextRule">
+			<strong>
+			<<link "Next">>
+				<<set $currentRule.facility = _facility>>
+				<<set $currentRule.excludeFacility = _excludeFacility>>
+				<<set $currentRule = $defaultRules[_r+1]>>
+				<<goto "Rules Assistant">>
+			<</link>>
+			</strong>
+			</span>@@.cyan; [E,→]@@  |  
+		<<else>>
+			Next [E,→]  |  
+		<</if>>
+
+		<<if $r != $defaultRules.length && $defaultRules[$defaultRules.length-1]>>
+			<span id="lastRule">
+			<strong>
+			<<link "Last">>
+				<<set $currentRule = $defaultRules[$defaultRules.length-1]>>
+				<<goto "Rules Assistant">>
+			<</link>>
+			</strong>
+			</span>@@.cyan; [Shift+E,Shift+→]@@
+		<<else>>
+			Last [Shift+E,Shift+→]
+		<</if>>
+	</center>
+
+	<center>
+		<<if _r > 0>>
+			<<print $defaultRules[_r-1].name+" &emsp; <- &emsp;&emsp;">>
+		<<else>>
+			<<print "&emsp;&emsp;&emsp;&emsp;&emsp;">>
+		<</if>>
+
+		<span id="rulename">
+		<<if ndef $currentRule.name>>
+			<<set $currentRule.name = "Rule " + $r>>
+		<</if>>
+		@@.yellow;$currentRule.name@@
+		</span>
+
+		<<if _r < $defaultRules.length-1>>
+			<<print "&emsp;&emsp; -> &emsp; "+$defaultRules[_r+1].name>>
+		<<else>>
+			<<print "&emsp;&emsp;&emsp;&emsp;&emsp;">>
+		<</if>>
+	</center>
+
+	<center>
+		<span id="ruleDown">
+			<<if _r > 0>>
+			<<link "Lower Priority">>
+			<<set _tmpRule = $defaultRules[_r]>>
+			<<set $defaultRules[_r] = $defaultRules[_r-1]>>
+			<<set $defaultRules[_r-1] = _tmpRule>>
+			<<goto "Rules Assistant">>
+			<</link>>
+			<<else>>
+			Lower Priority
+			<</if>>
+		</span>
+			|
+		<<link "Rename">>
+			<<replace "#rulename">>
+				<<textbox "$currentRule.name" $currentRule.name "Rules Assistant">>
+			<</replace>>
+		<</link>>
+			|
+		<span id="ruleUp">
+			<<if _r < $defaultRules.length-1>>
+				<<link "Higher Priority">>
+					<<set _tmpRule = $defaultRules[_r]>>
+					<<set $defaultRules[_r] = $defaultRules[_r+1]>>
+					<<set $defaultRules[_r+1] = _tmpRule>>
+					<<goto "Rules Assistant">>
+				<</link>> 
+			<<else>>
+				Higher Priority
+			<</if>>
+		</span>
+	</center>
+<</if>> /* closes if $defaultRules.length > 0 */
 
 <br>
+
 //<<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Sir<<else>>Ma'am<</if>>, I will review your slaves and make changes that will have a beneficial effect. Apologies, sir, but this function is... not fully complete. It may have some serious limitations. Please use the 'no default setting' option to identify areas I should not address.//
 
 <br><br>
 
 <<if $defaultRules.length < 1>>
 ''No rules.''
+
 <<else>>
 
-<<set _facility = $currentRule.facility>>
-<<set _excludeFacility = $currentRule.excludeFacility>>
 __Rule $r Automatic Activation__
 <span id ="activation">
 </span>
@@ -169,19 +219,11 @@ __Rule $r Automatic Activation__
 <<RAChangeApplyAssignment>>
 <</timed>>
 
-<br>
-
 <span id = "excludeassignment">
 </span>
 <<timed 50ms>>
 <<RAChangeExcludeAssignment>>
 <</timed>>
-
-<<set _facility = $currentRule.facility>>
-
-<<if (ndef _facility)>>
-	<<set _facility = []>>
-<</if>>
 
 <span id = "applyfacility">
 </span>
@@ -189,22 +231,28 @@ __Rule $r Automatic Activation__
 <<RAChangeApplyFacility>>
 <</timed>>
 
-<<set _excludeFacility = $currentRule.excludeFacility>>
-
-<<if (ndef _excludeFacility)>>
-	<<set _excludeFacility = []>>
-<</if>>
-
 <span id = "excludefacility">
 </span>
 <<timed 50ms>>
 <<RAChangeExcludeFacility>>
 <</timed>>
 
-<br><br>
+<span id="specialslaves"></span>
+<<timed 50ms>>
+<<RASpecialSlaves>>
+<</timed>>
 
-<<if ndef $currentRule.setAssignment>>
-	<<set $currentRule.setAssignment = "none">>
+&nbsp;&nbsp;&nbsp;&nbsp;
+
+<<if $currentRule.selectedSlaves.length < 1 && $currentRule.excludedSlaves.length < 1>>
+  @@.gray;Specific slaves:@@
+	''Not limited to nor excluding any specific slaves'' | [[Choose specific slaves|Rules Slave Select][$currentRule.excludedSlaves = []]] | [[Exclude specific slaves|Rules Slave Exclude][$currentRule.selectedSlaves = []]]
+<<elseif $currentRule.selectedSlaves.length < 1 && $currentRule.excludedSlaves.length > 0>>
+  Exclude specific slaves:
+	[[Currently excluding specific slaves|Rules Slave Exclude]] | [[Don't exclude specific slaves|Rules Assistant][$currentRule.excludedSlaves = []]]
+<<else>>
+  Apply to specific slaves:
+	[[Currently limited to specific slaves|Rules Slave Select]] | [[Don't limit to specific slaves|Rules Assistant][$currentRule.selectedSlaves = [], $currentRule.excludedSlaves = []]]
 <</if>>
 
 <span id = "setassignment">
@@ -218,25 +266,6 @@ __Rule $r Automatic Activation__
 <<timed 50ms>>
 <<RAChangeAssignFacility>>
 <</timed>>
-
-<br><br>
-Apply to slaves:<br>
-<<if ((ndef $currentRule.selectedSlaves) || ($currentRule.selectedSlaves.length < 1)) && ((ndef $currentRule.excludedSlaves) || ($currentRule.excludedSlaves.length < 1))>>
-''Currently applied to all slaves'' | [[Choose specific slaves|Rules Slave Select]]
-<<elseif ((ndef $currentRule.selectedSlaves) || ($currentRule.selectedSlaves.length < 1)) && (def $currentRule.excludedSlaves) && ($currentRule.excludedSlaves.length > 0)>>
-''Currently applied to all slaves except excluded slaves'' | [[Choose specific slaves|Rules Slave Select]] | [[Apply to all slaves|Rules Assistant][$currentRule.selectedSlaves = [],$currentRule.excludedSlaves = []]]
-<<else>>
-[[Currently applied to specific slaves|Rules Slave Select]] | [[Apply to all slaves|Rules Assistant][$currentRule.selectedSlaves = [], $currentRule.excludedSlaves = []]]
-<</if>>
-<br>
-Exclude slaves:<br>
-<<if ndef $currentRule.excludedSlaves || $currentRule.excludedSlaves.length < 1>>
-''Not excluding any slaves'' |
-
-[[Exclude specific slaves|Rules Slave Exclude]]
-<<else>>
-[[Currently excluding specific slaves|Rules Slave Exclude]] | [[Don't exclude slaves|Rules Assistant][$currentRule.excludedSlaves = []]]
-<</if>>
 
 <br><br>
 
@@ -588,7 +617,7 @@ Collar: ''$currentRule.collar.''
 	<<RAChangeApply>>
 <</link>>
 |
-<<if $seeAge == 1>>
+<<if $seeAge != 0>>
 <<link "Cruel retirement">>
 	<<set $currentRule.collar = "cruel retirement counter">>
 	<<RAChangeCollar>>
@@ -651,7 +680,7 @@ Collar: ''$currentRule.collar.''
 	<<RAChangeApply>>
 <</link>>
 |
-<<if $seeAge == 1>>
+<<if $seeAge != 0>>
 <<link "Nice retirement">>
 	<<set $currentRule.collar = "nice retirement counter">>
 	<<RAChangeCollar>>
@@ -1118,11 +1147,7 @@ Buttplugs for other slaves: ''$currentRule.buttplug.''
 //Will permanently gape assholes//
 
 <br><br>
-[[Cosmetic Rules Assistant Settings]]
-<br>
-[[Body Mod Rules Assistant Settings]]
-<br>
-[[Autosurgery Settings]]
+[[Cosmetic Rules Assistant Settings]] | [[Body Mod Rules Assistant Settings]] | [[Autosurgery Settings]]
 
 <br><br>
 
@@ -2333,7 +2358,7 @@ Relationship rules: ''$currentRule.relationshipRules.''
 
 <</if>>
 
-<br>
+
 <span id="saveresult">
 </span>
 <<timed 50ms>>
@@ -2603,11 +2628,7 @@ Relationship rules: ''$currentRule.relationshipRules.''
 <span id="result">
 <<set _text = "Remove rule " + $r>>
 <<link _text>>
-	<<set $defaultRules[$r-1].activation = "none">>
-	<<for $s = 0; $s < $slaves.length; $s++>>
-	  <<CheckAutoRulesActivate $slaves[$s]>>
-	<</for>>
-	<<set $defaultRules.pluck([$r-1],[$r-1])>>
+	<<set $defaultRules.deleteAt($r-1)>>
 	<<for _r = $defaultRules.length; _r >= 0; _r-->>
 		<<if def $defaultRules[_r]>>
 			<<set $currentRule = $defaultRules[_r]>>
@@ -2617,83 +2638,55 @@ Relationship rules: ''$currentRule.relationshipRules.''
 	<<goto "Rules Assistant">>
 <</link>>
 </span>
-<</if>>
 
-<br>
+<</if>> /* closes if defaultRules.length > 0 */
 
-<span id="applied">
-</span>
+<br><br>
+
 <<if $defaultRules.length < 10>>
-<br>
+
 	<<link "Add a new rule">>
 
-	<<set _activeRule = {aphrodisiacs: "no default setting", activation: "none", thresholdLower: 4, thresholdUpper: "none", eqLower: true, eqUpper: true, releaseRules: "no default setting", clitSetting: "no default setting", clitSettingXY: "no default setting", clitSettingXX: "no default setting", clitSettingEnergy: "no default setting", speechRules: "no default setting", clothes: "no default setting", fuckdoll: 0, choosesOwnClothes: 0, collar: "no default setting", shoes: "no default setting", virginAccessory: "no default setting", aVirginAccessory: "no default setting", vaginalAccessory: "no default setting", aVirginDickAccessory: "no default setting", dickAccessory: "no default setting", cSec: 0, bellyAccessory: "no default setting", aVirginButtplug: "no default setting", buttplug: "no default setting", markings: "none", eyeColor: "no default setting", makeup: "no default setting", nails: "no default setting", hColor: "no default setting", hLength: "no default setting", hStyle: "no default setting", pubicHColor: "no default setting", pubicHStyle: "no default setting", nipplesPiercing: "no default setting", areolaePiercing: "no default setting", clitPiercing: "no default setting", vaginaLube: "no default setting", vaginaPiercing: "no default setting", analArea: 1, dickPiercing: "no default setting", anusPiercing: "no default setting", lipsPiercing: "no default setting", tonguePiercing: "no default setting", earPiercing: "no default setting", nosePiercing: "no default setting", eyebrowPiercing: "no default setting", navelPiercing: "no default setting", corsetPiercing: "no default setting", boobsTat: "no default setting", buttTat: "no default setting", vaginaTat: "no default setting", dickTat: "no default setting", lipsTat: "no default setting", anusTat: "no default setting", shouldersTat: "no default setting", armsTat: "no default setting", legsTat: "no default setting", backTat: "no default setting", stampTat: "no default setting", curatives: "no default setting", livingRules: "no default setting", relationshipRules: "no default setting", standardPunishment: "no default setting", standardReward: "no default setting", useRulesAssistant: 1, diet: "no default setting", dietCum: "no default setting", dietMilk: "no default setting", muscles: "no default setting", XY: "no default setting", XX: "no default setting", gelding: "no default setting", preg: "no default setting", growth: "no default setting", autoSurgery: 0, choosesOwnAssignment: 0, lactation: 0, autoBrand: 0, pornFameSpending: "no default setting", dietGrowthSupport: 0, eyewear: "no default setting", assignment: [], excludeAssignment: [], setAssignment: "none", facility: [], excludeFacility: [], assignFacility: "none", excludeSpecialSlaves: true, facilityRemove: false, removalAssignment: "rest", selectedSlaves: [], excludedSlaves: [], surgery: {lactation: "no default setting", cosmetic: 0, accent: "no default setting", shoulders: "no default setting", shouldersImplant: "no default setting", boobs: "no default setting", hips: "no default setting", hipsImplant: "no default setting", butt: "no default setting", faceShape: "no default setting", lips: "no default setting", holes: 0} }>>
+		<<set _activeRule = {aphrodisiacs: "no default setting", activation: "none", thresholdLower: 4, thresholdUpper: "none", eqLower: true, eqUpper: true, releaseRules: "no default setting", clitSetting: "no default setting", clitSettingXY: "no default setting", clitSettingXX: "no default setting", clitSettingEnergy: "no default setting", speechRules: "no default setting", clothes: "no default setting", fuckdoll: 0, choosesOwnClothes: 0, collar: "no default setting", shoes: "no default setting", virginAccessory: "no default setting", aVirginAccessory: "no default setting", vaginalAccessory: "no default setting", aVirginDickAccessory: "no default setting", dickAccessory: "no default setting", cSec: 0, bellyAccessory: "no default setting", aVirginButtplug: "no default setting", buttplug: "no default setting", markings: "none", eyeColor: "no default setting", makeup: "no default setting", nails: "no default setting", hColor: "no default setting", hLength: "no default setting", hStyle: "no default setting", pubicHColor: "no default setting", pubicHStyle: "no default setting", nipplesPiercing: "no default setting", areolaePiercing: "no default setting", clitPiercing: "no default setting", vaginaLube: "no default setting", vaginaPiercing: "no default setting", analArea: 1, dickPiercing: "no default setting", anusPiercing: "no default setting", lipsPiercing: "no default setting", tonguePiercing: "no default setting", earPiercing: "no default setting", nosePiercing: "no default setting", eyebrowPiercing: "no default setting", navelPiercing: "no default setting", corsetPiercing: "no default setting", boobsTat: "no default setting", buttTat: "no default setting", vaginaTat: "no default setting", dickTat: "no default setting", lipsTat: "no default setting", anusTat: "no default setting", shouldersTat: "no default setting", armsTat: "no default setting", legsTat: "no default setting", backTat: "no default setting", stampTat: "no default setting", curatives: "no default setting", livingRules: "no default setting", relationshipRules: "no default setting", standardPunishment: "no default setting", standardReward: "no default setting", useRulesAssistant: 1, diet: "no default setting", dietCum: "no default setting", dietMilk: "no default setting", muscles: "no default setting", XY: "no default setting", XX: "no default setting", gelding: "no default setting", preg: "no default setting", growth: "no default setting", autoSurgery: 0, choosesOwnAssignment: 0, lactation: 0, autoBrand: 0, pornFameSpending: "no default setting", dietGrowthSupport: 0, eyewear: "no default setting", assignment: [], excludeAssignment: [], setAssignment: "none", facility: [], excludeFacility: [], assignFacility: "none", excludeSpecialSlaves: true, facilityRemove: false, removalAssignment: "rest", selectedSlaves: [], excludedSlaves: [], surgery: {lactation: "no default setting", cosmetic: 0, accent: "no default setting", shoulders: "no default setting", shouldersImplant: "no default setting", boobs: "no default setting", hips: "no default setting", hipsImplant: "no default setting", butt: "no default setting", faceShape: "no default setting", lips: "no default setting", holes: 0} }>>
 
-	<<if ndef _r>>
-		<<set _r = 0>>
-		<<set $r = 1>>
-	<</if>>
+		<<if ndef _r>>
+			<<set _r = 0>>
+			<<set $r = 1>>
+		<</if>>
 
-	<<if $defaultRules.length > 0>>
-		<<set _length to ($defaultRules.length+1)>>
-		<<set $RulesID to $RulesID+1>>
-	<<else>>
-		<<set _length to 1>>
-		<<set $RulesID to 1>>
-	<</if>>
+		<<if $defaultRules.length > 0>>
+			<<set _length to ($defaultRules.length+1)>>
+			<<set $RulesID to $RulesID+1>>
+		<<else>>
+			<<set _length to 1>>
+			<<set $RulesID to 1>>
+		<</if>>
 
-	<<set _activeRule.name = "Rule " + _length>>
-	<<set _activeRule.ID = $RulesID>>
+		<<set _activeRule.name = "Rule " + _length>>
+		<<set _activeRule.ID = $RulesID>>
 
-	<<set $defaultRules.push(_activeRule)>>
+		<<set $defaultRules.push(_activeRule)>>
 
-	<<set $currentRule = $defaultRules[$defaultRules.length-1]>>
-	<<goto "Rules Assistant">>
-	<</link>>
+		<<set $currentRule = $defaultRules[$defaultRules.length-1]>>
+		<<goto "Rules Assistant">>
+		
+	<</link>> |
 
 <</if>>
+
 <<if $defaultRules.length > 0>>
-|
-<span id="apply">
-<span id="applyresult">
-<<link "Apply rules">>
-	<<replace "#applyresult">>
-	//Rules applied.//
-	<</replace>>
-	<<replace "#applied">>
-	<<for _t = 0; _t < $defaultRules.length; _t++>>
-		<<if $currentRule.ID == $defaultRules[_t].ID>>
-			<<set $currentRule.facility = _facility>>
-			<<set $currentRule.excludeFacility = _excludeFacility>>
-			<<if $currentRule.thresholdLower != "none">>
-				<<set $currentRule.thresholdLower = Number($currentRule.thresholdLower)>>
-			<</if>>
-			<<if $currentRule.thresholdUpper != "none">>
-				<<set $currentRule.thresholdUpper = Number($currentRule.thresholdUpper)>>
-			<</if>>
-			<<set $defaultRules[_t] = $currentRule>>
-		<</if>>
-	<</for>>
-	<<for $s = 0; $s < $slaves.length; $s++>>
-		<<if $slaves[$s].useRulesAssistant == 1>>
-			<<CheckAutoRulesActivate $slaves[$s]>>
-			<<DefaultRules $slaves[$s]>>
-		<</if>>
-	<</for>>
-	<<for _t = 0; _t < $defaultRules.length; _t++>>
-		<<set _r = $r-1>>
-		<<if $defaultRules[_t].ID == $defaultRules[_r].ID>>
-			<<set $currentRule = $defaultRules[_t]>>
-			<<set _facility = $currentRule.facility>>
-			<<set _excludeFacility = $currentRule.excludeFacility>>
-			<<break>>
-		<</if>>
-	<</for>>
-	<</replace>>
-<</link>>
-</span>
-</span>
-<br><br>
-[[Export this rule|Export Rule]]
+	<span id="apply">
+		<span id="applied"></span>
+		<span id="applyresult"></span>
+	</span>
+	<<timed 50ms>>
+	<<RAChangeApply>>
+	<</timed>>
+
+	<br><br>
+
+	[[Export this rule|Export Rule]]
 <</if>>
+
 | [[Import a rule|Import Rule]]
+

--- a/src/utility/assignWidgets.tw
+++ b/src/utility/assignWidgets.tw
@@ -3,7 +3,7 @@
 /%
 	Call as <<assignJob slaveObject $returnto | _currentRule.facilityRemove | "serve in the master suite"
 	$args[0] slave object. *MUST be present*
-	$args[1] Job to assign slave to. Will accept the $returnto vars and the _currentRule.assignFacility vars and the actual job assignments "serve in the master suite" etc.
+	$args[1] Job to assign slave to. Will accept the $returnTo vars and the _currentRule.assignFacility vars and the actual job assignments "serve in the master suite" etc.
 
 	This is basically a Widget version of assign but will work anywhere, and saves to the slaves[..] array, and changes your $args[0] var sent.
 %/
@@ -19,9 +19,9 @@
 	<<set _wi = $i>>
 <<else>>
 	<<for _wi = 0; _wi < _SL; _wi++>>
-	<<if _wID == $slaves[_wi].ID>>
-		<<break>>
-	<</if>>
+		<<if _wID == $slaves[_wi].ID>>
+			<<break>>
+		<</if>>
 	<</for>>
 <</if>>
 
@@ -66,7 +66,7 @@
 
 <<if $slaves[_wi].choosesOwnClothes == 1>><<include "SA chooses own clothes">><<set $args[0] = $slaves[_wi]>><</if>> /* update clothes, then update $args[0] */
 
-<</if>>
+<</if>> /* not Pit or Coursing Association */
 <</widget>>
 
 /%
@@ -79,7 +79,22 @@
 %/
 <<widget removeJob>>
 <<if ($args[1] != "Pit") && ($args[1] != "Coursing Association")>>
+
 <<set _wID = $args[0].ID, _SL = $slaves.length>>
+
+<<if _wID == $HeadGirl.ID>><<set $HeadGirl = 0>><</if>>
+<<if _wID == $Recruiter.ID>><<set $Recruiter = 0>><</if>>
+<<if _wID == $Bodyguard.ID>><<set $Bodyguard = 0>><</if>>
+<<if _wID == $Madam.ID>><<set $Madam = 0>><</if>>
+<<if _wID == $DJ.ID>><<set $DJ = 0>><</if>>
+<<if _wID == $Milkmaid.ID>><<set $Milkmaid = 0>><</if>>
+<<if _wID == $Schoolteacher.ID>><<set $Schoolteacher = 0>><</if>>
+<<if _wID == $Attendant.ID>><<set $Attendant = 0>><</if>>
+<<if _wID == $Nurse.ID>><<set $Nurse = 0>><</if>>
+<<if _wID == $Collectrix.ID>><<set $Collectrix = 0>><</if>>
+<<if _wID == $Stewardess.ID>><<set $Stewardess = 0>><</if>>
+<<if _wID == $Wardeness.ID>><<set $Wardeness = 0>><</if>>
+<<if _wID == $Concubine.ID>><<set $Concubine = 0>><</if>>
 
 /% use .toLowerCase() to get rid of a few dupe conditions. %/
 <<switch $args[1].toLowerCase()>>

--- a/src/utility/raWidgets.tw
+++ b/src/utility/raWidgets.tw
@@ -6,109 +6,116 @@
 <<widget "RAChangeActivation">>
 
 <<replace #activation>>
-__($currentRule.activation):__
-<br>
-<<if ($currentRule.activation != "none") && ($currentRule.activation != "always")>>
-<span id="lower">
-<<if ($currentRule.thresholdLower == "none")>>
-(no lower limit)
-<<else>>
-<<if $currentRule.eqLower>>
-When ''$currentRule.activation'' is
-<<textbox "$currentRule.thresholdLower" $currentRule.thresholdLower>> ''or more''
-<<else>>
-When ''$currentRule.activation'' is ''more than''
-<<textbox "$currentRule.thresholdLower" $currentRule.thresholdLower>>
-<</if>>
-<</if>>
-</span>
-      <<link ">">>
-<<set $currentRule.eqLower = false>>
-<<replace "#lower">>
-When ''$currentRule.activation'' is ''more than''
-<<textbox "$currentRule.thresholdLower" $currentRule.thresholdLower>>
-<</replace>>
-<</link>>
- |
-<<link ">=">>
-<<set $currentRule.eqLower = true>>
-<<replace "#lower">>
-When ''$currentRule.activation'' is
-<<textbox "$currentRule.thresholdLower" $currentRule.thresholdLower>> ''or more''
-<</replace>>
-<</link>>
- |
-<<link "No lower limit">>
-<<set $currentRule.thresholdLower = "none">>
-<<replace "#lower">>
-(no lower limit)
-<</replace>>
-<</link>>
-<br>and<br>
-<span id="upper">
-<<if ($currentRule.thresholdUpper == "none")>>
-(no upper limit)
-<<else>>
-<<if $currentRule.eqUpper>>
-When ''$currentRule.activation'' is
-<<textbox "$currentRule.thresholdUpper" $currentRule.thresholdUpper>> ''or less''
-<<else>>
-When ''$currentRule.activation'' is ''less than''
-<<textbox "$currentRule.thresholdUpper" $currentRule.thresholdUpper>>
-<</if>>
-<</if>>
-</span>
-      <<link "<">>
-<<set $currentRule.eqUpper = false>>
-<<replace "#upper">>
-When ''$currentRule.activation'' is ''less than''
-<<textbox "$currentRule.thresholdUpper" $currentRule.thresholdUpper>>
-<</replace>>
-<</link>>
- |
-<<link "<=">>
-<<set $currentRule.eqUpper = true>>
-<<replace "#upper">>
-When ''$currentRule.activation'' is
-<<textbox "$currentRule.thresholdUpper" $currentRule.thresholdUpper>> ''or less''
-<</replace>>
-<</link>>
-|
-<<link "No upper limit">>
-<<set $currentRule.thresholdUpper = "none">>
-<<replace "#upper">>
-(no upper limit)
-<</replace>>
-<</link>>
-<<if ($currentRule.thresholdLower == "none") && ( $currentRule.thresholdUpper == "none")>>
-	<<set $currentRule.activation = "always">>
-<<elseif ($currentRule.thresholdLower != "none") && ( $currentRule.thresholdUpper != "none")>>
-	<<if (def $currentRule.thresholdLower && $currentRule.thresholdLower > $currentRule.thresholdUpper)>>
-	<<set $currentRule.thresholdLower = $currentRule.thresholdUpper>>
+	<<print "($currentRule.activation):">>
+	<br>
+	<<if ($currentRule.activation != "none") && ($currentRule.activation != "always")>>
+		<span id="lower">
+			<<if ($currentRule.thresholdLower == "none")>>
+			(no lower limit)
+			<<else>>
+				<<if $currentRule.eqLower>>
+					When ''$currentRule.activation'' is
+					<<textbox "$currentRule.thresholdLower" $currentRule.thresholdLower>> ''or more''
+				<<else>>
+					When ''$currentRule.activation'' is ''more than''
+					<<textbox "$currentRule.thresholdLower" $currentRule.thresholdLower>>
+				<</if>>
+			<</if>>
+		</span>
+
+		<<link ">">>
+			<<set $currentRule.eqLower = false>>
+			<<replace "#lower">>
+				When ''$currentRule.activation'' is ''more than''
+				<<textbox "$currentRule.thresholdLower" $currentRule.thresholdLower>>
+			<</replace>>
+		<</link>>
+	 |
+		<<link ">=">>
+			<<set $currentRule.eqLower = true>>
+			<<replace "#lower">>
+				When ''$currentRule.activation'' is
+				<<textbox "$currentRule.thresholdLower" $currentRule.thresholdLower>> ''or more''
+			<</replace>>
+		<</link>>
+	 |
+		<<link "No lower limit">>
+			<<set $currentRule.thresholdLower = "none">>
+			<<replace "#lower">>
+				(no lower limit)
+			<</replace>>
+		<</link>>
+
+		<br>and<br>
+
+		<span id="upper">
+			<<if ($currentRule.thresholdUpper == "none")>>
+				(no upper limit)
+			<<else>>
+				<<if $currentRule.eqUpper>>
+					When ''$currentRule.activation'' is
+					<<textbox "$currentRule.thresholdUpper" $currentRule.thresholdUpper>> ''or less''
+				<<else>>
+					When ''$currentRule.activation'' is ''less than''
+					<<textbox "$currentRule.thresholdUpper" $currentRule.thresholdUpper>>
+				<</if>>
+			<</if>>
+		</span>
+
+		<<link "<">>
+			<<set $currentRule.eqUpper = false>>
+			<<replace "#upper">>
+				When ''$currentRule.activation'' is ''less than''
+				<<textbox "$currentRule.thresholdUpper" $currentRule.thresholdUpper>>
+			<</replace>>
+		<</link>>
+	 |
+		<<link "<=">>
+			<<set $currentRule.eqUpper = true>>
+			<<replace "#upper">>
+				When ''$currentRule.activation'' is
+				<<textbox "$currentRule.thresholdUpper" $currentRule.thresholdUpper>> ''or less''
+			<</replace>>
+		<</link>>
+	 |
+		<<link "No upper limit">>
+			<<set $currentRule.thresholdUpper = "none">>
+			<<replace "#upper">>
+				(no upper limit)
+			<</replace>>
+		<</link>>
+
+		<<if ($currentRule.thresholdLower == "none") && ($currentRule.thresholdUpper == "none")>>
+			<<set $currentRule.activation = "always">>
+		<<elseif ($currentRule.thresholdLower != "none") && ($currentRule.thresholdUpper != "none")>>
+			<<if (def $currentRule.thresholdLower) && ($currentRule.thresholdLower > $currentRule.thresholdUpper)>>
+				<<set $currentRule.thresholdLower = $currentRule.thresholdUpper>>
+			<</if>>
+			<<if (def $currentRule.thresholdUpper) && ($currentRule.thresholdUpper < $currentRule.thresholdLower)>>
+				<<set $currentRule.thresholdUpper = $currentRule.thresholdLower>>
+			<</if>>
+		<</if>>
 	<</if>>
-	<<if (def $currentRule.thresholdUpper && $currentRule.thresholdUpper < $currentRule.thresholdLower)>>
-	<<set $currentRule.thresholdUpper = $currentRule.thresholdLower>>
-	<</if>>
-<</if>>
-<</if>>
-<<switch $currentRule.activation>>
-<<case "none">>
-''None.''
-<<case "always">>
-''Always.''
-<<case "devotion">>
-<br>@@.darkviolet;Very hateful@@: under -95, @@.darkviolet;Hateful@@: -95 to under -50, @@.mediumorchid;Resistant@@: -50 to under -20,
-<br>@@.yellow;Ambivalent@@: -20 to 20, @@.hotpink;Accepting@@: over 20 to 50, @@.deeppink;Devoted@@: over 50 to 95, @@.magenta;Worshipful@@: over 95
-<<case "trust">>
-<br>@@.goldenrod;Extremely terrified@@: under -95, @@.goldenrod;Terrified@@: -95 to under -50, @@.gold;Frightened@@: -50 to under -20,
-<br>@@.yellow;Fearful@@: -20 to 20, @@.mediumaquamarine;Careful@@: over 40 to 50, @@.mediumseagreen;Trusting@@: 50 to 95, @@.seagreen;Total trust@@: over 95
-<<case "health">>
-<br>@@.red;Death@@: under -100, @@.red;Near death@@: -100 to less than -90, @@.red;Extremely unhealthy@@: -90 to less than -50, @@.red;Unhealthy@@: -50 to less than -20 @@.green;Healthy@@: -20 to 20, @@.green;Very healthy@@: 20 to 50, @@.green;Extremely healthy@@: over 50 to 90, @@.green;Unnaturally healthy@@: over 90
-<<case "sex drive">>
-<br>@@.red;Frigid@@: 20 or under, @@.red;Poor@@: 21 to 40, @@.yellow;Average@@: 41 to 60, @@.green;Powerful@@: 61 to 80, @@.green;Sex addict@@: 81 to 99, @@.green;Nympho@@: 100
-<<case "weight">>
-<br>@@.red;Emaciated@@: under -95, @@.red;Skinny@@: -95 to less than -30, Thin: -30 to less than -10 Average weight: -10 to 10, Plush: over 10 to 30, @@.red;Fat@@: over 30 to 95, @@.red;Overweight@@: over 95
-<</switch>>
+	<<switch $currentRule.activation>>
+		<<case "none">>
+		''None.''
+		<<case "always">>
+		''Always.''
+		<<case "devotion">>
+		<br>@@.darkviolet;Very hateful@@: under -95, @@.darkviolet;Hateful@@: -95 to under -50, @@.mediumorchid;Resistant@@: -50 to under -20,
+		<br>@@.yellow;Ambivalent@@: -20 to 20, @@.hotpink;Accepting@@: over 20 to 50, @@.deeppink;Devoted@@: over 50 to 95, @@.magenta;Worshipful@@: over 95
+		<<case "trust">>
+		<br>@@.goldenrod;Extremely terrified@@: under -95, @@.goldenrod;Terrified@@: -95 to under -50, @@.gold;Frightened@@: -50 to under -20,
+		<br>@@.yellow;Fearful@@: -20 to 20, @@.mediumaquamarine;Careful@@: over 40 to 50, @@.mediumseagreen;Trusting@@: 50 to 95, @@.seagreen;Total trust@@: over 95
+		<<case "health">>
+		<br>@@.red;Death@@: under -100, @@.red;Near death@@: -100 to less than -90, @@.red;Extremely unhealthy@@: -90 to less than -50, @@.red;Unhealthy@@: -50 to less than -20 @@.green;Healthy@@: -20 to 20, @@.green;Very healthy@@: 20 to 50, @@.green;Extremely healthy@@: over 50 to 90, @@.green;Unnaturally healthy@@: over 90
+		<<case "sex drive">>
+		<br>@@.red;Frigid@@: 20 or under, @@.red;Poor@@: 21 to 40, @@.yellow;Average@@: 41 to 60, @@.green;Powerful@@: 61 to 80, @@.green;Sex addict@@: 81 to 99, @@.green;Nympho@@: 100
+		<<case "weight">>
+		<br>@@.red;Emaciated@@: under -95, @@.red;Skinny@@: -95 to less than -30, Thin: -30 to less than -10 Average weight: -10 to 10, Plush: over 10 to 30, @@.red;Fat@@: over 30 to 95, @@.red;Overweight@@: over 95
+		<<case "lactation">>
+		<br>// 0 - none, 1 - natural, 2 - lactation implant. //
+	<</switch>>
 <</replace>>
 <</widget>>
 
@@ -117,11 +124,6 @@ When ''$currentRule.activation'' is
 %/
 <<widget "RAChangeApplyAssignment">>
 <<replace #applyassignment>>
-Apply to assignments:
-<br>
-<<if ndef $currentRule.assignment>>
-	<<set $currentRule.assignment = []>>
-<</if>>
 <<set _rest = false>>
 <<set _fucktoy = false>>
 <<set _servant = false>>
@@ -131,61 +133,70 @@ Apply to assignments:
 <<set _milked = false>>
 <<set _subordinate = false>>
 <<set _gloryhole = false>>
-
-<<for _a = $currentRule.assignment.length; _a >= 0; _a-->>
-<<if $currentRule.assignment[_a] == "rest">>
-	<<set _rest = true>>
+<<if def $currentRule.assignment>>
+	<<for _a = $currentRule.assignment.length; _a >= 0; _a-->>
+		<<if $currentRule.assignment[_a] == "rest">>
+			<<set _rest = true>>
+		<</if>>
+		<<if $currentRule.assignment[_a] == "please you">>
+			<<set _fucktoy = true>>
+		<</if>>
+		<<if $currentRule.assignment[_a] == "be a servant">>
+			<<set _servant = true>>
+		<</if>>
+		<<if $currentRule.assignment[_a] == "whore">>
+			<<set _whore = true>>
+		<</if>>
+		<<if $currentRule.assignment[_a] == "work a glory hole">>
+			<<set _gloryhole = true>>
+		<</if>>
+		<<if $currentRule.assignment[_a] == "get milked">>
+			<<set _milked = true>>
+		<</if>>
+		<<if $currentRule.assignment[_a] == "serve the public">>
+			<<set _public = true>>
+		<</if>>
+		<<if $currentRule.assignment[_a] == "be a subordinate slave">>
+			<<set _subordinate = true>>
+		<</if>>
+		<<if $currentRule.assignment[_a] == "stay confined">>
+			<<set _confined = true>>
+		<</if>>
+	<</for>>
 <</if>>
-<<if $currentRule.assignment[_a] == "please you">>
-	<<set _fucktoy = true>>
-<</if>>
-<<if $currentRule.assignment[_a] == "be a servant">>
-	<<set _servant = true>>
-<</if>>
-<<if $currentRule.assignment[_a] == "whore">>
-	<<set _whore = true>>
-<</if>>
-<<if $currentRule.assignment[_a] == "work a glory hole">>
-	<<set _gloryhole = true>>
-<</if>>
-<<if $currentRule.assignment[_a] == "get milked">>
-	<<set _milked = true>>
-<</if>>
-<<if $currentRule.assignment[_a] == "serve the public">>
-	<<set _public = true>>
-<</if>>
-<<if $currentRule.assignment[_a] == "be a subordinate slave">>
-	<<set _subordinate = true>>
-<</if>>
-<<if $currentRule.assignment[_a] == "stay confined">>
-	<<set _confined = true>>
-<</if>>
-<</for>>
 
 <<if _rest || _fucktoy || _servant || _confined || _whore || _public || _milked || _subordinate || _gloryhole>>
+  Apply to assignments:
 	<<link "All">>
 		<<set $currentRule.assignment = []>>
+		<<set $currentRule.excludeAssignment = []>>
+		<<set $currentRule.setAssignment = "none">>
 		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>> |
 <<else>>
+  @@.gray;Apply to assignments:@@
 	''All'' |
 <</if>>
 
 <<if !_rest>>
 	<<link "Rest">>
 		<<set $currentRule.assignment.push("rest")>>
+		<<set $currentRule.excludeAssignment = []>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Rest''
 	<<link Stop>>
-		<<set $currentRule.assignment.delete("rest")>>
+		<<set removeFromArray($currentRule.assignment, "rest")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -195,16 +206,18 @@ Apply to assignments:
 <<if !_fucktoy>>
 	<<link "Fucktoy">>
 		<<set $currentRule.assignment.push("please you")>>
+		<<set $currentRule.excludeAssignment = []>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Fucktoy''
 	<<link Stop>>
-		<<set $currentRule.assignment.delete("please you")>>
+		<<set removeFromArray($currentRule.assignment, "please you")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -214,16 +227,18 @@ Apply to assignments:
 <<if !_subordinate>>
 	<<link "Subordinate Slave">>
 		<<set $currentRule.assignment.push("be a subordinate slave")>>
+		<<set $currentRule.excludeAssignment = []>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Subordinate Slave''
 	<<link Stop>>
-		<<set $currentRule.assignment.delete("be a subordinate slave")>>
+		<<set removeFromArray($currentRule.assignment, "be a subordinate slave")>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
@@ -235,16 +250,18 @@ Apply to assignments:
 <<if !_servant>>
 	<<link "House Servant">>
 		<<set $currentRule.assignment.push("be a servant")>>
+		<<set $currentRule.excludeAssignment = []>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''House Servant''
 	<<link Stop>>
-		<<set $currentRule.assignment.delete("be a servant")>>
+		<<set removeFromArray($currentRule.assignment, "be a servant")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -254,16 +271,18 @@ Apply to assignments:
 <<if !_confined>>
 	<<link "Confined">>
 		<<set $currentRule.assignment.push("stay confined")>>
+		<<set $currentRule.excludeAssignment = []>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Confined''
 	<<link Stop>>
-		<<set $currentRule.assignment.delete("stay confined")>>
+		<<set removeFromArray($currentRule.assignment, "stay confined")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -273,16 +292,18 @@ Apply to assignments:
 <<if !_whore>>
 	<<link "Whore">>
 		<<set $currentRule.assignment.push("whore")>>
+		<<set $currentRule.excludeAssignment = []>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Whore''
 	<<link Stop>>
-		<<set $currentRule.assignment.delete("whore")>>
+		<<set removeFromArray($currentRule.assignment, "whore")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -292,16 +313,18 @@ Apply to assignments:
 <<if !_public>>
 	<<link "Public Servant">>
 		<<set $currentRule.assignment.push("serve the public")>>
+		<<set $currentRule.excludeAssignment = []>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Public Servant''
 	<<link Stop>>
-		<<set $currentRule.assignment.delete("serve the public")>>
+		<<set removeFromArray($currentRule.assignment, "serve the public")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -311,16 +334,18 @@ Apply to assignments:
 <<if !_milked>>
 	<<link "Milking">>
 		<<set $currentRule.assignment.push("get milked")>>
+		<<set $currentRule.excludeAssignment = []>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Milking''
 	<<link Stop>>
-		<<set $currentRule.assignment.delete("get milked")>>
+		<<set removeFromArray($currentRule.assignment, "get milked")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -330,16 +355,18 @@ Apply to assignments:
 <<if !_gloryhole>>
 	<<link "Gloryhole">>
 		<<set $currentRule.assignment.push("work a glory hole")>>
+		<<set $currentRule.excludeAssignment = []>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Gloryhole''
 	<<link Stop>>
-		<<set $currentRule.assignment.delete("work a glory hole")>>
+		<<set removeFromArray($currentRule.assignment, "work a glory hole")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -352,11 +379,7 @@ Apply to assignments:
 %/
 <<widget "RAChangeExcludeAssignment">>
 <<replace #excludeassignment>>
-Exclude assignments:
 <br>
-<<if ndef $currentRule.excludeAssignment>>
-	<<set $currentRule.excludeAssignment = []>>
-<</if>>
 <<set _rest = false>>
 <<set _fucktoy = false>>
 <<set _servant = false>>
@@ -366,58 +389,67 @@ Exclude assignments:
 <<set _milked = false>>
 <<set _subordinate = false>>
 <<set _gloryhole = false>>
-<<for _a = $currentRule.excludeAssignment.length; _a >= 0; _a-->>
-<<if $currentRule.excludeAssignment[_a] == "rest">>
-	<<set _rest = true>>
+<<if def $currentRule.excludeAssignment>>
+	<<for _a = $currentRule.excludeAssignment.length; _a >= 0; _a-->>
+		<<if $currentRule.excludeAssignment[_a] == "rest">>
+			<<set _rest = true>>
+		<</if>>
+		<<if $currentRule.excludeAssignment[_a] == "please you">>
+			<<set _fucktoy = true>>
+		<</if>>
+		<<if $currentRule.excludeAssignment[_a] == "be a servant">>
+			<<set _servant = true>>
+		<</if>>
+		<<if $currentRule.excludeAssignment[_a] == "whore">>
+			<<set _whore = true>>
+		<</if>>
+		<<if $currentRule.excludeAssignment[_a] == "work a glory hole">>
+			<<set _gloryhole = true>>
+		<</if>>
+		<<if $currentRule.excludeAssignment[_a] == "get milked">>
+			<<set _milked = true>>
+		<</if>>
+		<<if $currentRule.excludeAssignment[_a] == "serve the public">>
+			<<set _public = true>>
+		<</if>>
+		<<if $currentRule.excludeAssignment[_a] == "be a subordinate slave">>
+			<<set _subordinate = true>>
+		<</if>>
+		<<if $currentRule.excludeAssignment[_a] == "stay confined">>
+			<<set _confined = true>>
+		<</if>>
+	<</for>>
 <</if>>
-<<if $currentRule.excludeAssignment[_a] == "please you">>
-	<<set _fucktoy = true>>
-<</if>>
-<<if $currentRule.excludeAssignment[_a] == "be a servant">>
-	<<set _servant = true>>
-<</if>>
-<<if $currentRule.excludeAssignment[_a] == "whore">>
-	<<set _whore = true>>
-<</if>>
-<<if $currentRule.excludeAssignment[_a] == "work a glory hole">>
-	<<set _gloryhole = true>>
-<</if>>
-<<if $currentRule.excludeAssignment[_a] == "get milked">>
-	<<set _milked = true>>
-<</if>>
-<<if $currentRule.excludeAssignment[_a] == "serve the public">>
-	<<set _public = true>>
-<</if>>
-<<if $currentRule.excludeAssignment[_a] == "be a subordinate slave">>
-	<<set _subordinate = true>>
-<</if>>
-<<if $currentRule.excludeAssignment[_a] == "stay confined">>
-	<<set _confined = true>>
-<</if>>
-<</for>>
 <<if _rest || _fucktoy || _servant || _confined || _whore || _public || _milked || _subordinate || _gloryhole>>
+  Include all assignments except:
 	<<link "None">>
 		<<set $currentRule.excludeAssignment = []>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>> |
+<<elseif (def $currentRule.assignment) && ($currentRule.assignment.length > 0)>>
+  @@.gray;Exclude assignments:@@
+	''None'' |
 <<else>>
+  Excluded assignments:
 	''None'' |
 <</if>>
 <<if !_rest>>
 	<<link "Rest">>
+		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("rest")>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
+		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Rest''
 	<<link Stop>>
-		<<set $currentRule.excludeAssignment.delete("rest")>>
+		<<set removeFromArray($currentRule.excludeAssignment, "rest")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -426,17 +458,19 @@ Exclude assignments:
 |
 <<if !_fucktoy>>
 	<<link "Fucktoy">>
+		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("please you")>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
+		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Fucktoy''
 	<<link Stop>>
-		<<set $currentRule.excludeAssignment.delete("please you")>>
+		<<set removeFromArray($currentRule.excludeAssignment, "please you")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -445,17 +479,19 @@ Exclude assignments:
 |
 <<if !_subordinate>>
 	<<link "Subordinate Slave">>
+		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("be a subordinate slave")>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
+		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Subordinate Slave''
 	<<link Stop>>
-		<<set $currentRule.excludeAssignment.delete("be a subordinate slave")>>
+		<<set removeFromArray($currentRule.excludeAssignment, "be a subordinate slave")>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
@@ -465,17 +501,19 @@ Exclude assignments:
 |
 <<if !_servant>>
 	<<link "House Servant">>
+		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("be a servant")>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
+		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''House Servant''
 	<<link Stop>>
-		<<set $currentRule.excludeAssignment.delete("be a servant")>>
+		<<set removeFromArray($currentRule.excludeAssignment, "be a servant")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -484,17 +522,19 @@ Exclude assignments:
 |
 <<if !_confined>>
 	<<link "Confined">>
+		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("stay confined")>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
+		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Confined''
 	<<link Stop>>
-		<<set $currentRule.excludeAssignment.delete("stay confined")>>
+		<<set removeFromArray($currentRule.excludeAssignment, "stay confined")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -503,17 +543,19 @@ Exclude assignments:
 |
 <<if !_whore>>
 	<<link "Whore">>
+		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("whore")>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
+		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Whore''
 	<<link Stop>>
-		<<set $currentRule.excludeAssignment.delete("whore")>>
+		<<set removeFromArray($currentRule.excludeAssignment, "whore")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -522,17 +564,19 @@ Exclude assignments:
 |
 <<if !_public>>
 	<<link "Public Servant">>
+		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("serve the public")>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
+		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Public Servant''
 	<<link Stop>>
-		<<set $currentRule.excludeAssignment.delete("serve the public")>>
+		<<set removeFromArray($currentRule.excludeAssignment, "serve the public")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -541,17 +585,19 @@ Exclude assignments:
 |
 <<if !_milked>>
 	<<link "Milking">>
+		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("get milked")>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
+		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Milking''
 	<<link Stop>>
-		<<set $currentRule.excludeAssignment.delete("get milked")>>
+		<<set removeFromArray($currentRule.excludeAssignment, "get milked")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -560,17 +606,19 @@ Exclude assignments:
 |
 <<if !_gloryhole>>
 	<<link "Gloryhole">>
+		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("work a glory hole")>>
 		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
+		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Gloryhole''
 	<<link Stop>>
-		<<set $currentRule.excludeAssignment.delete("work a glory hole")>>
+		<<set removeFromArray($currentRule.excludeAssignment, "work a glory hole")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -587,25 +635,33 @@ Exclude assignments:
 <<replace #applyfacility>>
 <<if ($HGSuite > 0) || ($brothel > 0) || ($club > 0) || ($arcade > 0) || ($dairy > 0) || ($servantsQuarters > 0) || ($masterSuite > 0) || ($schoolroom > 0) || ($spa > 0) || ($clinic > 0) || ($cellblock > 0)>>
 <br><br>
-Apply to facilities:
-<br>
-<<if (_facility.length > 0)>>
-	<<link "All">>
-		<<set _facility = []>>
+<<if (def $currentRule.facility) && ($currentRule.facility.length > 0)>>
+  Apply to facilities:
+	<<link "None">>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility = []>>
+		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
+		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
+  @@.gray;Apply to facilities:@@
 	''All''
 <</if>>
 <<if ($HGSuite > 0)>>
 |
-<<if !ruleFacility(_facility,"hgsuite")>>
+<<if !ruleFacility($currentRule.facility,"hgsuite")>>
 	<<link $HGSuiteNameCaps>>
-		<<set _facility.push("hgsuite")>>
+		<<set $currentRule.facility.push("hgsuite")>>
+		<<set $currentRule.excludeFacility = []>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -613,7 +669,7 @@ Apply to facilities:
 <<else>>
 	''$HGSuiteNameCaps''
 	<<link Stop>>
-		<<set _facility.delete("hgsuite")>>
+		<<set removeFromArray($currentRule.facility, "hgsuite")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -622,11 +678,14 @@ Apply to facilities:
 <</if>>
 <<if ($brothel > 0)>>
 |
-<<if !ruleFacility(_facility,"brothel")>>
+<<if !ruleFacility($currentRule.facility,"brothel")>>
 	<<link $brothelNameCaps>>
-		<<set _facility.push("brothel")>>
+		<<set $currentRule.facility.push("brothel")>>
+		<<set $currentRule.excludeFacility = []>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -634,7 +693,7 @@ Apply to facilities:
 <<else>>
 	''$brothelNameCaps''
 	<<link Stop>>
-		<<set _facility.delete("brothel")>>
+		<<set removeFromArray($currentRule.facility, "brothel")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -643,11 +702,14 @@ Apply to facilities:
 <</if>>
 <<if ($club > 0)>>
 |
-<<if !ruleFacility(_facility,"club")>>
+<<if !ruleFacility($currentRule.facility,"club")>>
 	<<link $clubNameCaps>>
-		<<set _facility.push("club")>>
+		<<set $currentRule.facility.push("club")>>
+		<<set $currentRule.excludeFacility = []>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -655,7 +717,7 @@ Apply to facilities:
 <<else>>
 	''$clubNameCaps''
 	<<link Stop>>
-		<<set _facility.delete("club")>>
+		<<set removeFromArray($currentRule.facility, "club")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -664,11 +726,14 @@ Apply to facilities:
 <</if>>
 <<if ($arcade > 0)>>
 |
-<<if !ruleFacility(_facility,"arcade")>>
+<<if !ruleFacility($currentRule.facility,"arcade")>>
 	<<link $arcadeNameCaps>>
-		<<set _facility.push("arcade")>>
+		<<set $currentRule.facility.push("arcade")>>
+		<<set $currentRule.excludeFacility = []>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -676,7 +741,7 @@ Apply to facilities:
 <<else>>
 	''$arcadeNameCaps''
 	<<link Stop>>
-		<<set _facility.delete("arcade")>>
+		<<set removeFromArray($currentRule.facility, "arcade")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -685,11 +750,14 @@ Apply to facilities:
 <</if>>
 <<if ($dairy > 0)>>
 |
-<<if !ruleFacility(_facility,"dairy")>>
+<<if !ruleFacility($currentRule.facility,"dairy")>>
 	<<link $dairyNameCaps>>
-		<<set _facility.push("dairy")>>
+		<<set $currentRule.facility.push("dairy")>>
+		<<set $currentRule.excludeFacility = []>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -697,7 +765,7 @@ Apply to facilities:
 <<else>>
 	''$dairyNameCaps''
 	<<link Stop>>
-		<<set _facility.delete("dairy")>>
+		<<set removeFromArray($currentRule.facility, "dairy")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -706,11 +774,14 @@ Apply to facilities:
 <</if>>
 <<if ($servantsQuarters > 0)>>
 |
-<<if !ruleFacility(_facility,"servantsquarters")>>
+<<if !ruleFacility($currentRule.facility,"servantsquarters")>>
 	<<link $servantsQuartersNameCaps>>
-		<<set _facility.push("servantsquarters")>>
+		<<set $currentRule.facility.push("servantsquarters")>>
+		<<set $currentRule.excludeFacility = []>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -718,7 +789,7 @@ Apply to facilities:
 <<else>>
 	''$servantsQuartersNameCaps''
 	<<link Stop>>
-		<<set _facility.delete("servantsquarters")>>
+		<<set removeFromArray($currentRule.facility, "servantsquarters")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -727,11 +798,14 @@ Apply to facilities:
 <</if>>
 <<if ($masterSuite > 0)>>
 |
-<<if !ruleFacility(_facility,"mastersuite")>>
+<<if !ruleFacility($currentRule.facility,"mastersuite")>>
 	<<link $masterSuiteNameCaps>>
-		<<set _facility.push("mastersuite")>>
+		<<set $currentRule.facility.push("mastersuite")>>
+		<<set $currentRule.excludeFacility = []>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -739,7 +813,7 @@ Apply to facilities:
 <<else>>
 	''$masterSuiteNameCaps''
 	<<link Stop>>
-		<<set _facility.delete("mastersuite")>>
+		<<set removeFromArray($currentRule.facility, "mastersuite")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -748,11 +822,14 @@ Apply to facilities:
 <</if>>
 <<if ($schoolroom > 0)>>
 |
-<<if !ruleFacility(_facility,"schoolroom")>>
+<<if !ruleFacility($currentRule.facility,"schoolroom")>>
 	<<link $schoolroomNameCaps>>
-		<<set _facility.push("schoolroom")>>
+		<<set $currentRule.facility.push("schoolroom")>>
+		<<set $currentRule.excludeFacility = []>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -760,7 +837,7 @@ Apply to facilities:
 <<else>>
 	''$schoolroomNameCaps''
 	<<link Stop>>
-		<<set _facility.delete("schoolroom")>>
+		<<set removeFromArray($currentRule.facility, "schoolroom")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -769,11 +846,14 @@ Apply to facilities:
 <</if>>
 <<if ($spa > 0)>>
 |
-<<if !ruleFacility(_facility,"spa")>>
+<<if !ruleFacility($currentRule.facility,"spa")>>
 	<<link $spaNameCaps>>
-		<<set _facility.push("spa")>>
+		<<set $currentRule.facility.push("spa")>>
+		<<set $currentRule.excludeFacility = []>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -781,7 +861,7 @@ Apply to facilities:
 <<else>>
 	''$spaNameCaps''
 	<<link Stop>>
-		<<set _facility.delete("spa")>>
+		<<set removeFromArray($currentRule.facility, "spa")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -790,11 +870,14 @@ Apply to facilities:
 <</if>>
 <<if ($clinic > 0)>>
 |
-<<if !ruleFacility(_facility,"clinic")>>
+<<if !ruleFacility($currentRule.facility,"clinic")>>
 	<<link $clinicNameCaps>>
-		<<set _facility.push("clinic")>>
+		<<set $currentRule.facility.push("clinic")>>
+		<<set $currentRule.excludeFacility = []>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -802,7 +885,7 @@ Apply to facilities:
 <<else>>
 ''$clinicNameCaps''
 	<<link Stop>>
-		<<set _facility.delete("clinic")>>
+		<<set removeFromArray($currentRule.facility, "clinic")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -811,11 +894,14 @@ Apply to facilities:
 <</if>>
 <<if ($cellblock > 0)>>
 |
-<<if !ruleFacility(_facility,"cellblock")>>
+<<if !ruleFacility($currentRule.facility,"cellblock")>>
 	<<link $cellblockNameCaps>>
-		<<set _facility.push("cellblock")>>
+		<<set $currentRule.facility.push("cellblock")>>
+		<<set $currentRule.excludeFacility = []>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyFacility>>
+		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -823,33 +909,12 @@ Apply to facilities:
 <<else>>
 	''$cellblockNameCaps''
 	<<link Stop>>
-		<<set _facility.delete("cellblock")>>
+		<<set removeFromArray($currentRule.facility, "cellblock")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <</if>>
-<</if>>
-<</if>>
-<<if (def _facility) && (_facility.length > 0)>>
-<br>
-  Exclude special slaves:
-<<if $currentRule.excludeSpecialSlaves>>
-	''True'' |
-	<<link False>>
-		<<set $currentRule.excludeSpecialSlaves = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
-	<</link>>
-<<else>>
-	''False'' |
-	<<link True>>
-		<<set $currentRule.excludeSpecialSlaves = true>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
-	<</link>>
 <</if>>
 <</if>>
 <</replace>>
@@ -861,24 +926,34 @@ Apply to facilities:
 <<replace #excludefacility>>
 <<if ($HGSuite > 0) || ($brothel > 0) || ($club > 0) || ($arcade > 0) || ($dairy > 0) || ($servantsQuarters > 0) || ($masterSuite > 0) || ($schoolroom > 0) || ($spa > 0) || ($clinic > 0) || ($cellblock > 0)>>
 <br>
-Exclude facilities:
-<br>
-<<if (_excludeFacility.length > 0)>>
+<<if (def $currentRule.excludeFacility) && ($currentRule.excludeFacility.length > 0)>>
+  Applying to all facilities except:
 	<<link "None">>
-		<<set _excludeFacility = []>>
+		<<set $currentRule.excludeFacility = []>>
+		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
+		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
+<<elseif (def $currentRule.facility) && ($currentRule.facility.length > 0)>>
+  @@.gray;Exclude facilities:@@
+	''None''
 <<else>>
+  Excluded facilities:
 	''None''
 <</if>>
 <<if ($HGSuite > 0)>>
 |
-<<if !ruleFacility(_excludeFacility,"hgsuite")>>
+<<if !ruleFacility($currentRule.excludeFacility,"hgsuite")>>
 	<<link $HGSuiteNameCaps>>
-		<<set _excludeFacility.push("hgsuite")>>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility.push("hgsuite")>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
@@ -887,7 +962,12 @@ Exclude facilities:
 <<else>>
 	''$HGSuiteNameCaps''
 	<<link Stop>>
-		<<set _excludeFacility.delete("hgsuite")>>
+		<<set removeFromArray($currentRule.excludeFacility, "hgsuite")>>
+		<<if $currentRule.assignFacility == "hgsuite">>
+			<<set $currentRule.assignFacility = "none">>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -896,10 +976,13 @@ Exclude facilities:
 <</if>>
 <<if ($brothel > 0)>>
 |
-<<if !ruleFacility(_excludeFacility,"brothel")>>
+<<if !ruleFacility($currentRule.excludeFacility,"brothel")>>
 	<<link $brothelNameCaps>>
-		<<set _excludeFacility.push("brothel")>>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility.push("brothel")>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
@@ -908,7 +991,12 @@ Exclude facilities:
 <<else>>
 	''$brothelNameCaps''
 	<<link Stop>>
-		<<set _excludeFacility.delete("brothel")>>
+		<<set removeFromArray($currentRule.excludeFacility, "brothel")>>
+		<<if $currentRule.assignFacility == "brothel">>
+			<<set $currentRule.assignFacility = "none">>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -917,10 +1005,13 @@ Exclude facilities:
 <</if>>
 <<if ($club > 0)>>
 |
-<<if !ruleFacility(_excludeFacility,"club")>>
+<<if !ruleFacility($currentRule.excludeFacility,"club")>>
 	<<link $clubNameCaps>>
-		<<set _excludeFacility.push("club")>>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility.push("club")>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
@@ -929,7 +1020,12 @@ Exclude facilities:
 <<else>>
 	''$clubNameCaps''
 	<<link Stop>>
-		<<set _excludeFacility.delete("club")>>
+		<<set removeFromArray($currentRule.excludeFacility, "club")>>
+		<<if $currentRule.assignFacility == "club">>
+			<<set $currentRule.assignFacility = "none">>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -938,10 +1034,13 @@ Exclude facilities:
 <</if>>
 <<if ($arcade > 0)>>
 |
-<<if !ruleFacility(_excludeFacility,"arcade")>>
+<<if !ruleFacility($currentRule.excludeFacility,"arcade")>>
 	<<link $arcadeNameCaps>>
-		<<set _excludeFacility.push("arcade")>>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility.push("arcade")>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
@@ -950,7 +1049,12 @@ Exclude facilities:
 <<else>>
 	''$arcadeNameCaps''
 	<<link Stop>>
-		<<set _excludeFacility.delete("arcade")>>
+		<<set removeFromArray($currentRule.excludeFacility, "arcade")>>
+		<<if $currentRule.assignFacility == "arcade">>
+			<<set $currentRule.assignFacility = "none">>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -959,10 +1063,13 @@ Exclude facilities:
 <</if>>
 <<if ($dairy > 0)>>
 |
-<<if !ruleFacility(_excludeFacility,"dairy")>>
+<<if !ruleFacility($currentRule.excludeFacility,"dairy")>>
 	<<link $dairyNameCaps>>
-		<<set _excludeFacility.push("dairy")>>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility.push("dairy")>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
@@ -971,7 +1078,12 @@ Exclude facilities:
 <<else>>
 	''$dairyNameCaps''
 	<<link Stop>>
-		<<set _excludeFacility.delete("dairy")>>
+		<<set removeFromArray($currentRule.excludeFacility, "dairy")>>
+		<<if $currentRule.assignFacility == "dairy">>
+			<<set $currentRule.assignFacility = "none">>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -980,10 +1092,13 @@ Exclude facilities:
 <</if>>
 <<if ($servantsQuarters > 0)>>
 |
-<<if !ruleFacility(_excludeFacility,"servantsquarters")>>
+<<if !ruleFacility($currentRule.excludeFacility,"servantsquarters")>>
 	<<link $servantsQuartersNameCaps>>
-		<<set _excludeFacility.push("servantsquarters")>>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility.push("servantsquarters")>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
@@ -992,7 +1107,12 @@ Exclude facilities:
 <<else>>
 	''$servantsQuartersNameCaps''
 	<<link Stop>>
-		<<set _excludeFacility.delete("servantsquarters")>>
+		<<set removeFromArray($currentRule.excludeFacility, "servantsquarters")>>
+		<<if $currentRule.assignFacility == "servantsquarters">>
+			<<set $currentRule.assignFacility = "none">>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -1001,10 +1121,13 @@ Exclude facilities:
 <</if>>
 <<if ($masterSuite > 0)>>
 |
-<<if !ruleFacility(_excludeFacility,"mastersuite")>>
+<<if !ruleFacility($currentRule.excludeFacility,"mastersuite")>>
 	<<link $masterSuiteNameCaps>>
-		<<set _excludeFacility.push("mastersuite")>>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility.push("mastersuite")>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
@@ -1013,7 +1136,12 @@ Exclude facilities:
 <<else>>
 	''$masterSuiteNameCaps''
 	<<link Stop>>
-		<<set _excludeFacility.delete("mastersuite")>>
+		<<set removeFromArray($currentRule.excludeFacility, "mastersuite")>>
+		<<if $currentRule.assignFacility == "mastersuite">>
+			<<set $currentRule.assignFacility = "none">>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -1022,10 +1150,13 @@ Exclude facilities:
 <</if>>
 <<if ($schoolroom > 0)>>
 |
-<<if !ruleFacility(_excludeFacility,"schoolroom")>>
+<<if !ruleFacility($currentRule.excludeFacility,"schoolroom")>>
 	<<link $schoolroomNameCaps>>
-		<<set _excludeFacility.push("schoolroom")>>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility.push("schoolroom")>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
@@ -1034,7 +1165,12 @@ Exclude facilities:
 <<else>>
 	''$schoolroomNameCaps''
 	<<link Stop>>
-		<<set _excludeFacility.delete("schoolroom")>>
+		<<set removeFromArray($currentRule.excludeFacility, "schoolroom")>>
+		<<if $currentRule.assignFacility == "schoolroom">>
+			<<set $currentRule.assignFacility = "none">>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -1043,10 +1179,13 @@ Exclude facilities:
 <</if>>
 <<if ($spa > 0)>>
 |
-<<if !ruleFacility(_excludeFacility,"spa")>>
+<<if !ruleFacility($currentRule.excludeFacility,"spa")>>
 	<<link $spaNameCaps>>
-		<<set _excludeFacility.push("spa")>>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility.push("spa")>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
@@ -1055,7 +1194,12 @@ Exclude facilities:
 <<else>>
 	''$spaNameCaps''
 	<<link Stop>>
-		<<set _excludeFacility.delete("spa")>>
+		<<set removeFromArray($currentRule.excludeFacility, "spa")>>
+		<<if $currentRule.assignFacility == "spa">>
+			<<set $currentRule.assignFacility = "none">>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -1064,10 +1208,13 @@ Exclude facilities:
 <</if>>
 <<if ($clinic > 0)>>
 |
-<<if !ruleFacility(_excludeFacility,"clinic")>>
+<<if !ruleFacility($currentRule.excludeFacility,"clinic")>>
 	<<link $clinicNameCaps>>
-		<<set _excludeFacility.push("clinic")>>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility.push("clinic")>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
@@ -1076,7 +1223,12 @@ Exclude facilities:
 <<else>>
 ''$clinicNameCaps''
 	<<link Stop>>
-		<<set _excludeFacility.delete("clinic")>>
+		<<set removeFromArray($currentRule.excludeFacility, "clinic")>>
+		<<if $currentRule.assignFacility == "clinic">>
+			<<set $currentRule.assignFacility = "none">>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -1085,10 +1237,13 @@ Exclude facilities:
 <</if>>
 <<if ($cellblock > 0)>>
 |
-<<if !ruleFacility(_excludeFacility,"cellblock")>>
+<<if !ruleFacility($currentRule.excludeFacility,"cellblock")>>
 	<<link $cellblockNameCaps>>
-		<<set _excludeFacility.push("cellblock")>>
+		<<set $currentRule.facility = []>>
+		<<set $currentRule.excludeFacility.push("cellblock")>>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
@@ -1097,7 +1252,12 @@ Exclude facilities:
 <<else>>
 	''$cellblockNameCaps''
 	<<link Stop>>
-		<<set _excludeFacility.delete("cellblock")>>
+		<<set removeFromArray($currentRule.excludeFacility, "cellblock")>>
+		<<if $currentRule.assignFacility == "cellblock">>
+			<<set $currentRule.assignFacility = "none">>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -1114,9 +1274,9 @@ Exclude facilities:
 <<widget "RAChangeSetAssignment">>
 
 <<replace #setassignment>>
+<br><br>
 <<if ($currentRule.setAssignment != "none")>>
-''Automatically set assignment:''
-<br>
+  Automatically set assignment:
 	<<link "None">>
 		<<set $currentRule.setAssignment = "none">>
 		<<RAChangeSetAssignment>>
@@ -1124,16 +1284,16 @@ Exclude facilities:
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
-Automatically set assignment:
-<br>
+  @@.gray;Automatically set assignment:@@
 	''None''
 <</if>>
 |
 <<if ($currentRule.setAssignment != "rest")>>
 	<<link "Rest">>
+		<<set removeFromArray($currentRule.assignment, "rest")>>
 		<<set $currentRule.setAssignment = "rest">>
 		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.assignment = []>>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
@@ -1146,9 +1306,10 @@ Automatically set assignment:
 |
 <<if ($currentRule.setAssignment != "please you")>>
 	<<link "Fucktoy">>
+		<<set removeFromArray($currentRule.assignment, "please you")>>
 		<<set $currentRule.setAssignment = "please you">>
 		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.assignment = []>>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
@@ -1161,9 +1322,10 @@ Automatically set assignment:
 |
 <<if ($currentRule.setAssignment != "be a servant")>>
 	<<link "House Servant">>
+		<<set removeFromArray($currentRule.assignment, "be a servant")>>
 		<<set $currentRule.setAssignment = "be a servant">>
 		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.assignment = []>>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
@@ -1176,9 +1338,10 @@ Automatically set assignment:
 |
 <<if ($currentRule.setAssignment != "stay confined")>>
 	<<link "Confined">>
+		<<set removeFromArray($currentRule.assignment, "stay confined")>>
 		<<set $currentRule.setAssignment = "stay confined">>
 		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.assignment = []>>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
@@ -1191,9 +1354,10 @@ Automatically set assignment:
 |
 <<if ($currentRule.setAssignment != "whore")>>
 	<<link "Whore">>
+		<<set removeFromArray($currentRule.assignment, "whore")>>
 		<<set $currentRule.setAssignment = "whore">>
 		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.assignment = []>>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
@@ -1206,9 +1370,10 @@ Automatically set assignment:
 |
 <<if ($currentRule.setAssignment != "serve the public")>>
 	<<link "Public Servant">>
+		<<set removeFromArray($currentRule.assignment, "serve the public")>>
 		<<set $currentRule.setAssignment = "serve the public">>
 		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.assignment = []>>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
@@ -1221,9 +1386,10 @@ Automatically set assignment:
 |
 <<if ($currentRule.setAssignment != "get milked")>>
 	<<link "Milking">>
+		<<set removeFromArray($currentRule.assignment, "get milked")>>
 		<<set $currentRule.setAssignment = "get milked">>
 		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.assignment = []>>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
@@ -1236,38 +1402,18 @@ Automatically set assignment:
 |
 <<if ($currentRule.setAssignment != "work a glory hole")>>
 	<<link "Gloryhole">>
+		<<set removeFromArray($currentRule.assignment, "work a glory hole")>>
 		<<set $currentRule.setAssignment = "work a glory hole">>
 		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.assignment = []>>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeApplyFacility>>
+		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
 	''Gloryhole''
-<</if>>
-<<if ($currentRule.setAssignment != "none")>>
-<br>
-  Exclude special slaves:
-<<if $currentRule.excludeSpecialSlaves>>
-	''True'' |
-	<<link False>>
-		<<set $currentRule.excludeSpecialSlaves = false>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
-	<</link>>
-<<else>>
-	''False'' |
-	<<link True>>
-		<<set $currentRule.excludeSpecialSlaves = true>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
-	<</link>>
-<</if>>
 <</if>>
 <</replace>>
 <</widget>>
@@ -1279,19 +1425,18 @@ Automatically set assignment:
 
 <<replace #assignfacility>>
 <<if ($HGSuite > 0) || ($brothel > 0) || ($club > 0) || ($arcade > 0) || ($dairy > 0) || ($servantsQuarters > 0) || ($masterSuite > 0) || ($schoolroom > 0) || ($spa > 0) || ($clinic > 0) || ($cellblock > 0)>>
-<br><br>
-<<if ($currentRule.assignFacility != "none")>>
-''Automatically assign slaves to facility:''
 <br>
+<<if ($currentRule.assignFacility != "none")>>
+  Automatically assign slaves to facility:
 	<<link "None">>
 		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
-Automatically assign slaves to facility:
-<br>
+  @@.gray;Automatically assign slaves to facility:@@
 	''None''
 <</if>>
 <<if ($HGSuite > 0)>>
@@ -1300,8 +1445,11 @@ Automatically assign slaves to facility:
 	<<link $HGSuiteNameCaps>>
 		<<set $currentRule.assignFacility = "hgsuite">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set $currentRule.facility = []>>
-		<<set _facility = []>>
+		<<set removeFromArray($currentRule.facility, "hgsuite")>>
+		<<if $currentRule.facility.length == 0>>
+			<<set $currentRule.excludeFacility.push("hgsuite")>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeApplyFacility>>
@@ -1318,8 +1466,11 @@ Automatically assign slaves to facility:
 	<<link $brothelNameCaps>>
 		<<set $currentRule.assignFacility = "brothel">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set $currentRule.facility = []>>
-		<<set _facility = []>>
+		<<set removeFromArray($currentRule.facility, "brothel")>>
+		<<if $currentRule.facility.length == 0>>
+			<<set $currentRule.excludeFacility.push("brothel")>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
@@ -1336,8 +1487,11 @@ Automatically assign slaves to facility:
 	<<link $clubNameCaps>>
 		<<set $currentRule.assignFacility = "club">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set $currentRule.facility = []>>
-		<<set _facility = []>>
+		<<set removeFromArray($currentRule.facility, "club")>>
+		<<if $currentRule.facility.length == 0>>
+			<<set $currentRule.excludeFacility.push("club")>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
@@ -1354,8 +1508,11 @@ Automatically assign slaves to facility:
 	<<link $arcadeNameCaps>>
 		<<set $currentRule.assignFacility = "arcade">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set $currentRule.facility = []>>
-		<<set _facility = []>>
+		<<set removeFromArray($currentRule.facility, "arcade")>>
+		<<if $currentRule.facility.length == 0>>
+			<<set $currentRule.excludeFacility.push("arcade")>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
@@ -1372,8 +1529,11 @@ Automatically assign slaves to facility:
 	<<link $dairyNameCaps>>
 		<<set $currentRule.assignFacility = "dairy">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set $currentRule.facility = []>>
-		<<set _facility = []>>
+		<<set removeFromArray($currentRule.facility, "dairy")>>
+		<<if $currentRule.facility.length == 0>>
+			<<set $currentRule.excludeFacility.push("dairy")>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
@@ -1390,8 +1550,11 @@ Automatically assign slaves to facility:
 	<<link $servantsQuartersNameCaps>>
 		<<set $currentRule.assignFacility = "servantsquarters">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set $currentRule.facility = []>>
-		<<set _facility = []>>
+		<<set removeFromArray($currentRule.facility, "servantsquarters")>>
+		<<if $currentRule.facility.length == 0>>
+			<<set $currentRule.excludeFacility.push("servantsquarters")>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
@@ -1408,8 +1571,11 @@ Automatically assign slaves to facility:
 	<<link $masterSuiteNameCaps>>
 		<<set $currentRule.assignFacility = "mastersuite">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set $currentRule.facility = []>>
-		<<set _facility = []>>
+		<<set removeFromArray($currentRule.facility, "mastersuite")>>
+		<<if $currentRule.facility.length == 0>>
+			<<set $currentRule.excludeFacility.push("mastersuite")>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
@@ -1426,8 +1592,11 @@ Automatically assign slaves to facility:
 	<<link $schoolroomNameCaps>>
 		<<set $currentRule.assignFacility = "schoolroom">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set $currentRule.facility = []>>
-		<<set _facility = []>>
+		<<set removeFromArray($currentRule.facility, "schoolroom")>>
+		<<if $currentRule.facility.length == 0>>
+			<<set $currentRule.excludeFacility.push("schoolroom")>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
@@ -1444,8 +1613,11 @@ Automatically assign slaves to facility:
 	<<link $spaNameCaps>>
 		<<set $currentRule.assignFacility = "spa">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set $currentRule.facility = []>>
-		<<set _facility = []>>
+		<<set removeFromArray($currentRule.facility, "spa")>>
+		<<if $currentRule.facility.length == 0>>
+			<<set $currentRule.excludeFacility.push("spa")>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
@@ -1462,8 +1634,11 @@ Automatically assign slaves to facility:
 	<<link $clinicNameCaps>>
 		<<set $currentRule.assignFacility = "clinic">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set $currentRule.facility = []>>
-		<<set _facility = []>>
+		<<set removeFromArray($currentRule.facility, "clinic")>>
+		<<if $currentRule.facility.length == 0>>
+			<<set $currentRule.excludeFacility.push("clinic")>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
@@ -1480,8 +1655,11 @@ Automatically assign slaves to facility:
 	<<link $cellblockNameCaps>>
 		<<set $currentRule.assignFacility = "cellblock">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set $currentRule.facility = []>>
-		<<set _facility = []>>
+		<<set removeFromArray($currentRule.facility, "cellblock")>>
+		<<if $currentRule.facility.length == 0>>
+			<<set $currentRule.excludeFacility.push("cellblock")>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
@@ -1492,28 +1670,9 @@ Automatically assign slaves to facility:
 	''$cellblockNameCaps''
 <</if>>
 <</if>>
-<<if ($currentRule.assignFacility != "none")>>
-<br>
-  Exclude special slaves:
-<<if $currentRule.excludeSpecialSlaves>>
-	''True'' |
-	<<link False>>
-		<<set $currentRule.excludeSpecialSlaves = false>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
-	<</link>>
-<<else>>
-	''False'' |
-	<<link True>>
-		<<set $currentRule.excludeSpecialSlaves = true>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
-	<</link>>
-<</if>>
-<br>
-  Automatically remove from facility:
+<<if $currentRule.assignFacility != "none">>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+Automatically remove from facility when rule no longer applies (only if it was applied before):
 <<if $currentRule.facilityRemove>>
 	''True'' |
 	<<link False>>
@@ -1531,9 +1690,8 @@ Automatically assign slaves to facility:
 		<<RAChangeApply>>
 	<</link>>
 <</if>>
-<br>
-  Assignment on removal:
-$currentRule.removalAssignment |
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+Assignment on removal: $currentRule.removalAssignment |
 <<if ($currentRule.removalAssignment != "rest")>>
 	<<link Rest>>
 		<<set $currentRule.removalAssignment = "rest">>
@@ -1541,8 +1699,6 @@ $currentRule.removalAssignment |
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>> |
-<<else>>
-''Rest'' |
 <</if>>
 <<if ($currentRule.removalAssignment != "please you")>>
 	<<link "Please you">>
@@ -1551,8 +1707,6 @@ $currentRule.removalAssignment |
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>> |
-<<else>>
-''Please you'' |
 <</if>>
 <<if ($currentRule.removalAssignment != "whore")>>
 	<<link Whore>>
@@ -1561,8 +1715,6 @@ $currentRule.removalAssignment |
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>> |
-<<else>>
-''Whore'' |
 <</if>>
 <<if ($currentRule.removalAssignment != "serve the public")>>
 	<<link "Public servant">>
@@ -1571,8 +1723,6 @@ $currentRule.removalAssignment |
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>> |
-<<else>>
-''Public servant'' |
 <</if>>
 <<if ($currentRule.removalAssignment != "get milked")>>
 	<<link "Get milked">>
@@ -1581,8 +1731,6 @@ $currentRule.removalAssignment |
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>> |
-<<else>>
-''Get milked'' |
 <</if>>
 <<if ($currentRule.removalAssignment != "stay confined")>>
 	<<link "Stay confined">>
@@ -1591,8 +1739,6 @@ $currentRule.removalAssignment |
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>> |
-<<else>>
-''Stay confined'' |
 <</if>>
 <<if ($currentRule.removalAssignment != "work a glory hole")>>
 	<<link "Glory hole">>
@@ -1601,10 +1747,36 @@ $currentRule.removalAssignment |
 		<<RAChangeSave>>
 		<<RAChangeApply>>
 	<</link>>
+<</if>>
+<</if>>
+<</if>>
+<</replace>>
+<</widget>>
+
+/%
+ Call as <<RASpecialSlaves>>
+%/
+<<widget "RASpecialSlaves">>
+<<replace #specialslaves>>
+<br><br>
+<<if $currentRule.excludeSpecialSlaves>>
+	Excluding special slaves:
+	''True'' |
+	<<link False>>
+		<<set $currentRule.excludeSpecialSlaves = false>>
+		<<RASpecialSlaves>>
+		<<RAChangeSave>>
+		<<RAChangeApply>>
+	<</link>>
 <<else>>
-''Glory hole''
-<</if>>
-<</if>>
+	@@.gray;Exclude special slaves:@@
+	''False'' |
+	<<link True>>
+		<<set $currentRule.excludeSpecialSlaves = true>>
+		<<RASpecialSlaves>>
+		<<RAChangeSave>>
+		<<RAChangeApply>>
+	<</link>>
 <</if>>
 <</replace>>
 <</widget>>
@@ -1874,7 +2046,8 @@ Slave diets:
 <</replace>>
 <<replace #dietsupport>>
 <<if $currentRule.diet !== "no default setting">>
-<br>&nbsp;&nbsp;&nbsp;&nbsp;Diet support for growth drugs:
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+Diet support for growth drugs:
 <<if $currentRule.dietGrowthSupport == 1>>
 	''on.''
 <<else>>
@@ -2147,7 +2320,7 @@ Relationship rules: ''$currentRule.relationshipRules.''
 	<<RAChangeFameSpending>>
 <</link>>
 <<else>>
-  Weekly porn publicity subsidy for excellent slaves: ''¤$currentRule.pornFameSpending.''
+  Weekly porn publicity subsidy for excellent slaves: ''�$currentRule.pornFameSpending.''
 <</if>>
 <</replace>>
 <</widget>>
@@ -2157,73 +2330,67 @@ Relationship rules: ''$currentRule.relationshipRules.''
 %/
 <<widget "RAChangeSave">>
 <<replace #saveresult>>
-<<link _text>>
-	<<replace "#saveresult">>
-	//Rule saved.//
-	<<for _t = 0; _t < $defaultRules.length; _t++>>
-		<<if $currentRule.ID == $defaultRules[_t].ID>>
-			<<if $currentRule.thresholdLower != "none">>
-				<<set $currentRule.thresholdLower = Number($currentRule.thresholdLower)>>
-			<</if>>
-			<<if $currentRule.thresholdUpper != "none">>
-				<<set $currentRule.thresholdUpper = Number($currentRule.thresholdUpper)>>
-			<</if>>
-			<<set $currentRule.facility = _facility>>
-			<<set $currentRule.excludeFacility = _excludeFacility>>
-			<<set $defaultRules[_t] = $currentRule>>
-			<<break>>
-		<</if>>
-	<</for>>
-	<</replace>>
-<</link>>
+	<br><br>
+	<<link _text>>
+		<<replace "#saveresult">>
+			<br><br>
+			<<for _t = 0; _t < $defaultRules.length; _t++>>
+				<<if $currentRule.ID == $defaultRules[_t].ID>>
+					<<if $currentRule.thresholdLower != "none">>
+						<<set $currentRule.thresholdLower = Number($currentRule.thresholdLower)>>
+					<</if>>
+					<<if $currentRule.thresholdUpper != "none">>
+						<<set $currentRule.thresholdUpper = Number($currentRule.thresholdUpper)>>
+					<</if>>
+					<<set $defaultRules[_t] = $currentRule>>
+					//Rule $r saved//
+					<<break>>
+				<</if>>
+			<</for>>
+		<</replace>>
+	<</link>>
 <</replace>>
 <</widget>>
 /%
  Call as <<RAChangeApply>>
-<<RAChangeApply>>
 %/
 <<widget "RAChangeApply">>
 <<replace #apply>>
-<span id="applyresult">
-<<link "Apply rules">>
-	<<replace "#applyresult">>
-	//Rules applied.//
-	<</replace>>
-	<<replace "#applied">>
-	<<for _t = 0; _t < $defaultRules.length; _t++>>
-		<<if $currentRule.ID == $defaultRules[_t].ID>>
-			<<set $currentRule.facility = _facility>>
-			<<set $currentRule.excludeFacility = _excludeFacility>>
-			<<if $currentRule.thresholdLower != "none">>
-				<<set $currentRule.thresholdLower = Number($currentRule.thresholdLower)>>
-			<</if>>
-			<<if $currentRule.thresholdUpper != "none">>
-				<<set $currentRule.thresholdUpper = Number($currentRule.thresholdUpper)>>
-			<</if>>
-			<<set $defaultRules[_t] = $currentRule>>
-		<</if>>
-	<</for>>
-	<<for $i = 0; $i < $slaves.length; $i++>>
-		  <<if $slaves[$i].useRulesAssistant == 1>>
-		  <<set $activeSlave = $slaves[$i]>>
-		  <<CheckAutoRulesActivate $activeSlave>>
-		  <<DefaultRules $activeSlave>>
-		  /*<<set $slaves[$i] = $activeSlave>>*/
-		  <</if>>
-	<</for>>
+	<span id="applyresult">
+	<<link "Apply rules">>
+		<<set State.variables._parseFailed = false>>
+		<<replace "#saveresult">>
+			<br><br>
+			<<for _t = 0; _t < $defaultRules.length; _t++>>
+				<<if $currentRule.ID == $defaultRules[_t].ID>>
+					<<if $currentRule.thresholdLower != "none">>
+						<<set $currentRule.thresholdLower = Number($currentRule.thresholdLower)>>
+					<</if>>
+					<<if $currentRule.thresholdUpper != "none">>
+						<<set $currentRule.thresholdUpper = Number($currentRule.thresholdUpper)>>
+					<</if>>
+					<<set $defaultRules[_t] = $currentRule>>
+					//Rule $r saved//
+					<<break>>
+				<</if>>
+			<</for>>
+		<</replace>>
+		<<replace "#applied">>
+			<<for $i = 0; $i < $slaves.length; $i++>>
+				<<if $slaves[$i].useRulesAssistant == 1>> /* skip RA-exempt slaves */
+				  <<set $activeSlave = $slaves[$i]>>
+				  <<CheckAutoRulesActivate $activeSlave>> /* does not use or modify $currentRule */
+				  <<DefaultRules $activeSlave>> /* does not use or modify $currentRule */
+				<</if>>
+			<</for>>
+		<</replace>>
+		<<replace "#applyresult">>
+			//Rules applied.//<br>
+		<</replace>>
 
-	<<for _t = 0; _t < $defaultRules.length; _t++>>
-		<<set _r = $r-1>>
-		<<if $defaultRules[_t].ID == $defaultRules[_r].ID>>
-			<<set $currentRule = $defaultRules[_t]>>
-			<<set _facility = $currentRule.facility>>
-			<<set _excludeFacility = $currentRule.excludeFacility>>
-			<<break>>
-		<</if>>
-	<</for>>
-	<</replace>>
-<</link>>
-</span>
+	<</link>>
+	</span>
+	<span id="applied"></span>
 <</replace>>
 <</widget>>
 
@@ -2930,19 +3097,23 @@ Your brand design is ''$brandDesign.''
 	<<for _s = 0; _s < $args[0].currentRules.length; _s++>>
 		<<if _currentRule.ID == $args[0].currentRules[_s]>>
 			<<set _dump = $args[0].currentRules.deleteAt(_s)>>
+			<br>//@@.tan;Rule _rule (_currentRule.name) is no longer applying to $args[0].slaveName, who is assigned to $args[0].assignment.@@//
+			<<if $args[0].assignmentVisible == 0>>
+				<<include "Rules Facility Remove">>
+			<</if>>
+			<<break>>
 		<</if>>
 	<</for>>
-	<br>Rule _rule (_currentRule.name) is no longer applying to $args[0].slaveName.
-	<<include "Rules Facility Remove">>
 <</widget>>
 
 /%
 	Call as <<DefaultRules SlaveObject>>
+	Does not use or modify $currentRule
 %/
 <<widget "DefaultRules">>
 <<for _r = 0; _r < $defaultRules.length; _r++>>
 <<set _currentRule = $defaultRules[_r]>>
-<<if !ruleApplied($args[0], _currentRule.ID) || (def _currentRule.facility && _currentRule.facility.length > 0 && !ruleAppliedToSlaveFacility(_currentRule, $args[0]))>><<continue>><</if>>
+<<if !ruleApplied($args[0], _currentRule.ID)>><<continue>><</if>>
 
 <<if $args[0].fuckdoll == 0>>
 
@@ -3362,16 +3533,20 @@ Your brand design is ''$brandDesign.''
 <<if canGetPregnant($args[0])>>
 <<if (_currentRule.preg !== "no default setting")>>
 <<if (_currentRule.preg == -1)>>
-	<<if $args[0].preg !== -1 || $args[0].drugs == "fertility drugs">>
-		<<set $args[0].preg = -1>>
-		<<set $args[0].drugs = "no drugs">>
+	<<if $args[0].preg !== -1>>
 		<br>$args[0].slaveName is a fertile female, so she has been put on the appropriate contraceptive regime.
+		<<set $args[0].preg = -1>>
+	<</if>>
+	<<if $args[0].drugs == "fertility drugs">>
+		<<set $args[0].drugs = "no drugs">>
 	<</if>>
 <<elseif (_currentRule.preg == 0)>>
-	<<if $args[0].preg !== 0 || $args[0].drugs == "fertility drugs">>
+	<<if $args[0].preg !== 0>>
+		<br>$args[0].slaveName is a fertile female, so she has been taken off contraceptives.
 		<<set $args[0].preg = 0>>
+	<</if>>
+	<<if $args[0].drugs == "fertility drugs">>
 		<<set $args[0].drugs = "no drugs">>
-		<br>$args[0].slaveName is a fertile female, so she has been put on the appropriate fertility regime.
 	<</if>>
 <<elseif (_currentRule.preg == 1)>>
 	<<if $args[0].preg !== 0 || $args[0].drugs !== "fertility drugs" || $args[0].hormones !== 0>>
@@ -4250,21 +4425,19 @@ consequences.
 <</if>>
 
 <<set _exclude = false>>
-<<if _currentRule.excludeSpecialSlaves>>
+<<if $args[0].assignment.includes("agent")>>
+	<<set _exclude = true>>
+<<elseif _currentRule.excludeSpecialSlaves>>
 	<<if (($HeadGirl != 0) && ($HeadGirl.ID == $args[0].ID)) || (($Bodyguard != 0) && ($Bodyguard.ID == $args[0].ID)) || (($Recruiter != 0) && ($Recruiter.ID == $args[0].ID)) || (($Concubine != 0) && ($Concubine.ID == $args[0].ID)) || (($Nurse != 0) && ($Nurse.ID == $args[0].ID)) || (($Attendant != 0) && ($Attendant.ID == $args[0].ID)) || (($Madam != 0) || ($Madam.ID == $args[0].ID)) || (($DJ != 0) && ($DJ.ID == $args[0].ID)) || (($Milkmaid != 0) && ($Milkmaid.ID == $args[0].ID)) || (($Stewardess != 0 ) && ($Stewardess.ID == $args[0].ID)) || (($Schoolteacher != 0) && ($Schoolteacher.ID == $args[0].ID)) || (($Wardeness != 0) && ($Wardeness.ID == $args[0].ID))>>
 		<<set _exclude = true>>
 	<</if>>
 <</if>>
 
-<<if $args[0].assignmentVisible != 1>>
-	<<set _exclude = true>>
-<</if>>
-
 <<if !_exclude>>
 <<switch _currentRule.assignFacility>>
 <<case "hgsuite">>
-	<<if ($args[0].indentureRestrictions <= 0) && ($args[0].assignment != "live with your Head Girl")>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+	<<if ($HGSuiteSlaves == 0) && ($args[0].indentureRestrictions <= 0) && ($args[0].assignment != "live with your Head Girl") && >>
+		<br>$args[0].slaveName has been automatically assigned to live in your Head Girl's private suite.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.
 		<</if>>
@@ -4272,7 +4445,7 @@ consequences.
 	<</if>>
 <<case "arcade">>
 	<<if ($arcade > $arcadeSlaves) && ($args[0].indentureRestrictions <= 0) && ($args[0].assignment != "be confined in the arcade")>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+		<br>$args[0].slaveName has been automatically assigned to be confined in $arcadeName.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.
 		<</if>>
@@ -4281,7 +4454,7 @@ consequences.
 <<case "mastersuite">>
 	<<if ($masterSuite > $masterSuiteSlaves) && ($args[0].devotion > 20) || (($args[0].devotion >= -50) && ($args[0].trust < -20)) || ($args[0].trust < -50)>>
 	<<if ($args[0].assignment != "serve in the master suite")>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+		<br>$args[0].slaveName has been automatically assigned to $masterSuiteName.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.
 		<</if>>
@@ -4295,7 +4468,7 @@ consequences.
 <<case "clinic">>
 	<<if ($clinic > $clinicSlaves) && ($args[0].health < 20) || (($Nurse != 0) && ($args[0].chem > 0) && ($clinicUpgradeFilters == 1))>>
 	<<if ($args[0].assignment != "get treatment in the clinic")>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+		<br>$args[0].slaveName has been automatically assigned to get treatment in $clinicName.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.
 		<</if>>
@@ -4309,7 +4482,7 @@ consequences.
 <<case "spa">>
 	<<if ($spa > $spaSlaves) && ($args[0].health < 20) || ($args[0].trust < 60) || ($args[0].devotion <= 60) || ($args[0].fetish == "mindbroken") && ($args[0].devotion >= -20)>>
 	<<if ($args[0].assignment != "rest in the spa")>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+		<br>$args[0].slaveName has been automatically assigned to rest in $spaName.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.
 		<</if>>
@@ -4323,7 +4496,7 @@ consequences.
 <<case "brothel">>
 	<<if ($brothel > $brothelSlaves) && ($args[0].devotion > 50) || (($args[0].devotion >= -50) && ($args[0].trust < -20)) || ($args[0].trust < -50) || ($args[0].trust > 50)>>
 	<<if ($args[0].assignment != "work in the brothel")>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+		<br>$args[0].slaveName has been automatically assigned to work in $brothelName.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.
 		<</if>>
@@ -4335,9 +4508,9 @@ consequences.
 		<</if>>
 	<</if>>
 <<case "club">>
-	<<if ($club > $clubSlaves)  && ($args[0].devotion > 50) || (($args[0].devotion >= -50) && ($args[0].trust < -20)) || ($args[0].trust < -50) || ($args[0].trust > 50)>>
+	<<if ($club > $clubSlaves) && ($args[0].devotion > 50) || (($args[0].devotion >= -50) && ($args[0].trust < -20)) || ($args[0].trust < -50) || ($args[0].trust > 50)>>
 	<<if ($args[0].assignment != "serve in the club")>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+		<br>$args[0].slaveName has been automatically assigned to serve in $clubName.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.
 		<</if>>
@@ -4351,14 +4524,14 @@ consequences.
 <<case "dairy">>
 	<<if ($dairy > $dairySlaves+$bioreactorsXY+$bioreactorsXX+$bioreactorsHerm+$bioreactorsBarren)>>
 	<<if ($args[0].indentureRestrictions > 0) && ($dairyRestraintsSetting > 1)>>
-	<<elseif ($args[0].indentureRestrictions > 1) && ($dairyRestraintsSetting > 0)>>
+	<<elseif (($args[0].indentureRestrictions > 1) && ($dairyRestraintsSetting > 0))>>
 	<<else>>
 		<<if ($args[0].lactation > 0) || ($args[0].balls > 0) || (($dairyFeedersUpgrade == 1) && ($dairyFeedersSetting > 0))>>
 		<<if ($args[0].devotion > 20) || (($args[0].devotion >= -50) && ($args[0].trust < -20)) || ($args[0].trust < -50) || ($args[0].amp == 1) || ($dairyRestraintsUpgrade == 1)>>
 		<<if ($dairyStimulatorsSetting < 2) || ($args[0].anus > 2) || ($dairyPrepUpgrade == 1)>>
 		<<if ($dairyPregSetting < 2) || ($args[0].vagina > 2) || ($args[0].ovaries == 0) || ($dairyPrepUpgrade == 1)>>
 	<<if ($args[0].assignment != "work in the dairy")>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+		<br>$args[0].slaveName has been automatically assigned to be milked in $dairyName.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.
 		<</if>>
@@ -4389,7 +4562,7 @@ consequences.
 <<case "servantsquarters">>
 	<<if ($servantsQuarters > $servantsQuartersSlaves) && ($args[0].devotion >= -20) || (($args[0].devotion >= -50) && ($args[0].trust <= 20)) || ($args[0].trust < -20)>>
 	<<if ($args[0].assignment != "work as a servant")>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+		<br>$args[0].slaveName has been automatically assigned to work in $servantsQuartersName.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.
 		<</if>>
@@ -4404,7 +4577,7 @@ consequences.
 	<<if ($schoolroom > $schoolroomSlaves) && ($args[0].fetish != "mindbroken") && ($args[0].devotion >= -20 || ($args[0].devotion >= -50 && $args[0].trust < -20) || $args[0].trust < -50)>>
 	<<if ($args[0].intelligenceImplant < 1) || ($args[0].voice != 0 && $args[0].accent+$schoolroomUpgradeLanguage > 2) || ($args[0].oralSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].whoreSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].entertainSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].analSkill < 10+$schoolroomUpgradeSkills*20) || (($args[0].vagina >= 0) && ($args[0].vaginalSkill < 10+$schoolroomUpgradeSkills*20))>>
 	<<if ($args[0].assignment != "learn in the schoolroom")>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+		<br>$args[0].slaveName has been automatically assigned to study in $schoolroomName.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.
 		<</if>>
@@ -4423,7 +4596,7 @@ consequences.
 <<case "cellblock">>
 	<<if ($cellblock > $cellblockSlaves ) && (($args[0].devotion < -20) && ($args[0].trust >= -20)) || (($args[0].devotion < -50) && ($args[0].trust >= -50))>>
 	<<if ($args[0].assignment != "be confined in the cellblock")>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+		<br>$args[0].slaveName has been automatically assigned to be confined in $cellblockName.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.
 		<</if>>
@@ -4438,10 +4611,10 @@ consequences.
 <</if>>
 
 <<if !_exclude>>
-<<if def _currentRule.setAssignment && _currentRule.setAssignment !== "none">>
+<<if _currentRule.setAssignment !== "none">>
 	<<if ($args[0].assignment !== _currentRule.setAssignment)>>
-		<<set $args[0].assignment = _currentRule.setAssignment>>
-		<br>$args[0].slaveName has automatically been assigned to $args[0].assignment.
+		<br>$args[0].slaveName has been automatically assigned to _currentRule.setAssignment.
+		<<assignJob $args[0] _currentRule.setAssignment>>
 	<</if>>
 <</if>>
 <</if>>
@@ -4451,138 +4624,82 @@ consequences.
 
 /%
 	Call as <<CheckAutoRulesActivate SlaveObject>>
+	Does not use or modify $currentRule
 %/
 <<widget "CheckAutoRulesActivate">>
-<<if (ndef $args[0].currentRules) || ($args[0].currentRules.length < 1)>>
-	<<set $args[0].currentRules = []>>
-<</if>>
+	<<if (ndef $args[0].currentRules) || ($args[0].currentRules.length < 1)>>
+		<<set $args[0].currentRules = []>>
+	<</if>>
 
-<<for _r = 0; _r < $defaultRules.length; _r++>>
-<<set _currentRule = $defaultRules[_r]>>
-<<set _rule = _r+1>>
+	<<for _r = 0; _r < $defaultRules.length; _r++>>
+		<<set _currentRule = $defaultRules[_r], _rule = _r+1, _ruleAppliesToThisSlave = true>> /* starting assumption, to be tested below */
 
-<<if ruleApplied($args[0], _currentRule.ID)>>
-	<<if (def _currentRule.excludedSlaves) && (_currentRule.excludedSlaves.length > 0) && ruleSlaveExcluded($args[0], _currentRule)>>
-		<<RARemoveRule $args[0]>>
-		<<continue>>
-	<<elseif (def _currentRule.selectedSlaves) && (_currentRule.selectedSlaves.length > 0) && !ruleSlaveSelected($args[0], _currentRule)>>
-		<<RARemoveRule $args[0]>>
-		<<continue>>
-	<</if>>
-	<<if $args[0].assignmentVisible == 0>>
-		<<if (def _currentRule.excludeFacility) && (_currentRule.excludeFacility.length > 0) && ruleExcludeSlaveFacility(_currentRule, $args[0])>>
-			<<RARemoveRule $args[0]>>
-			<<continue>>
-		<<elseif (def _currentRule.facility) && (_currentRule.facility.length > 0) && !ruleAppliedToSlaveFacility(_currentRule, $args[0])>>
-			<<RARemoveRule $args[0]>>
-			<<continue>>
-		<</if>>
-	<<else>>
-		<<if (def _currentRule.excludeAssignment) && (_currentRule.excludeAssignment.length > 0) && ruleAssignment(_currentRule.excludeAssignment, $args[0].assignment)>>
-			<<RARemoveRule $args[0]>>
-			<<continue>>
-		<<elseif (def _currentRule.assignment) && (_currentRule.assignment.length > 0) && !ruleAssignment(_currentRule.assignment, $args[0].assignment)>>
-			<<RARemoveRule $args[0]>>
-			<<continue>>
-		<</if>>
-	<</if>>
-<</if>>
+		<<switch _currentRule.activation>> /* check activation conditions */
 
-<<switch _currentRule.activation>>
-<<case "always">>
-	<<if !ruleApplied($args[0], _currentRule.ID)>>
-		<<set $args[0].currentRules.push(_currentRule.ID)>>
-		<br>Rule _rule (_currentRule.name) is now applying to $args[0].slaveName.
-	<</if>>
-<<case "none">>
-	<<if ruleApplied($args[0], _currentRule.ID)>>
-		<<RARemoveRule $args[0]>>
-	<</if>>
-<<case "devotion">>
-	<<if checkThresholds($args[0].devotion, _currentRule)>>
-		<<if !ruleApplied($args[0], _currentRule.ID)>>
-			<<set $args[0].currentRules.push(_currentRule.ID)>>
-			<br>Rule _rule (_currentRule.name) is now applying to $args[0].slaveName.
-		<</if>>
-	<<else>>
-		<<if ruleApplied($args[0], _currentRule.ID)>>
-			<<RARemoveRule $args[0]>>
-		<</if>>
-	<</if>>
-<<case "trust">>
-	<<if checkThresholds($args[0].trust, _currentRule)>>
-		<<if !ruleApplied($args[0], _currentRule.ID)>>
-			<<set $args[0].currentRules.push(_currentRule.ID)>>
-			<br>Rule _rule (_currentRule.name) is now applying to $args[0].slaveName.
-		<</if>>
-	<<else>>
-		<<if ruleApplied($args[0], _currentRule.ID)>>
-			<<RARemoveRule $args[0]>>
-		<</if>>
-	<</if>>
-<<case "health">>
-	<<if ($args[0].assignment == "live with your Head Girl") && ($args[0].health <= 100)>>
-		<<if checkThresholds($args[0].health, _currentRule)>>
-			<<if !ruleApplied($args[0], _currentRule.ID)>>
-			<<set $args[0].currentRules.push(_currentRule.ID)>>
-				<br>Rule _rule (_currentRule.name) is now applying to $args[0].slaveName.
-			<</if>>
-		<<else>>
-			<<if ruleApplied($args[0], _currentRule.ID)>>
-				<<RARemoveRule $args[0]>>
-			<</if>>
-		<</if>>
-	<<elseif $args[0].health <= 90>>
-		<<if checkThresholds($args[0].health, _currentRule)>>
-			<<if !ruleApplied($args[0], _currentRule.ID)>>
-			<<set $args[0].currentRules.push(_currentRule.ID)>>
-				<br>Rule _rule (_currentRule.name) is now applying to $args[0].slaveName.
-			<</if>>
-		<<else>>
-			<<if ruleApplied($args[0], _currentRule.ID)>>
-				<<RARemoveRule $args[0]>>
-			<</if>>
-		<</if>>
-	<<else>>
-		<<if ruleApplied($args[0], _currentRule.ID)>>
-			<<RARemoveRule $args[0]>>
-		<</if>>
-	<</if>>
-<<case "sex drive">>
-	<<if checkThresholds($args[0].energy, _currentRule)>>
-		<<if ($args[0].attrKnown == 1) && (ruleApplied($args[0], _currentRule.ID) == false)>>
-			<<set $args[0].currentRules.push(_currentRule.ID)>>
-			<br>Rule _rule (_currentRule.name) is now applying to $args[0].slaveName.
-		<</if>>
-	<<else>>
-		<<if ruleApplied($args[0], _currentRule.ID)>>
-			<<RARemoveRule $args[0]>>
-		<</if>>
-	<</if>>
-<<case "age">>
-	<<if checkThresholds($args[0].age, _currentRule)>>
-		<<if !ruleApplied($args[0], _currentRule.ID)>>
-			<<set $args[0].currentRules.push(_currentRule.ID)>>
-			<br>Rule _rule (_currentRule.name) is now applying to $args[0].slaveName.
-		<</if>>
-	<<else>>
-		<<if ruleApplied($args[0], _currentRule.ID)>>
-			<<RARemoveRule $args[0]>>
-		<</if>>
-	<</if>>
-<<case "weight">>
-	<<if checkThresholds($args[0].weight, _currentRule)>>
-		<<if !ruleApplied($args[0], _currentRule.ID)>>
-			<<set $args[0].currentRules.push(_currentRule.ID)>>
-			<br>Rule _rule (_currentRule.name) is now applying to $args[0].slaveName.
-		<</if>>
-	<<else>>
-		<<if ruleApplied($args[0], _currentRule.ID)>>
-			<<RARemoveRule $args[0]>>
-		<</if>>
-	<</if>>
-<</switch>>
-<</for>>
+			<<case "always">>
+				/* _ruleAppliesToThisSlave remains true, but still need to pass inclusion/exclusion checks below */
+			<<case "none">>
+					<<set _ruleAppliesToThisSlave = false>>
+			<<case "devotion">>
+				<<if !checkThresholds($args[0].devotion, _currentRule)>>
+					<<set _ruleAppliesToThisSlave = false>>
+				<</if>>
+			<<case "trust">>
+				<<if !checkThresholds($args[0].trust, _currentRule)>>
+					<<set _ruleAppliesToThisSlave = false>>
+				<</if>>
+			<<case "health">>
+				<<if !checkThresholds($args[0].health, _currentRule)>>
+					<<set _ruleAppliesToThisSlave = false>>
+				<</if>>
+			<<case "sex drive">> /* rule can only be applied if slave's sexuality is known */
+				<<if ($args[0].attrKnown == 0) || !checkThresholds($args[0].energy, _currentRule)>>
+					<<set _ruleAppliesToThisSlave = false>>
+				<</if>>
+			<<case "age">>
+				<<if !checkThresholds($args[0].age, _currentRule)>>
+					<<set _ruleAppliesToThisSlave = false>>
+				<</if>>
+			<<case "weight">>
+				<<if !checkThresholds($args[0].weight, _currentRule)>>
+					<<set _ruleAppliesToThisSlave = false>>
+				<</if>>
+			<<case "lactation">>
+				<<if !checkThresholds($args[0].lactation, _currentRule)>>
+					<<set _ruleAppliesToThisSlave = false>>
+				<</if>>
+		<</switch>> /* closes activation condition checks */
 
-<<set $args[0].currentRules = $args[0].currentRules.sort(function(a, b) { return a-b; });>>
+		<<if _ruleAppliesToThisSlave == true>> /* passed activation conditions check - next check inclusion/exclusion rules */
+			<<if   (def _currentRule.excludedSlaves && _currentRule.excludedSlaves.length > 0 && ruleSlaveExcluded($args[0], _currentRule))
+				|| (def _currentRule.selectedSlaves && _currentRule.selectedSlaves.length > 0 && !ruleSlaveSelected($args[0], _currentRule))>>
+					<<set _ruleAppliesToThisSlave = false>>
+			<<elseif $args[0].assignmentVisible == 0>> /* assignment is not visible, so check facilities assignments */
+				<<if   (def _currentRule.excludeFacility && _currentRule.excludeFacility.length > 0 && ruleExcludeSlaveFacility(_currentRule, $args[0]))
+					|| (def _currentRule.facility        && _currentRule.facility.length > 0        && !ruleAppliedToSlaveFacility(_currentRule, $args[0]))>>
+						<<set _ruleAppliesToThisSlave = false>>
+				<</if>>
+			<<else>> /* assignment is visible, so check non-facilities assignments */
+				<<if   (def _currentRule.excludeAssignment && _currentRule.excludeAssignment.length > 0 && ruleAssignment(_currentRule.excludeAssignment, $args[0].assignment))
+					|| (def _currentRule.assignment        && _currentRule.assignment.length > 0        && !ruleAssignment(_currentRule.assignment, $args[0].assignment))>>
+						<<set _ruleAppliesToThisSlave = false>>
+				<</if>>
+			<</if>>
+		<</if>> /* done with all checks for this rule */
+
+		<<if _ruleAppliesToThisSlave == true>>
+			<<if !ruleApplied($args[0], _currentRule.ID)>> /* rule applies now, but did not apply before */
+				<<set $args[0].currentRules.push(_currentRule.ID)>>
+				<br>//@@.tan;Rule _rule (_currentRule.name) is now applying to $args[0].slaveName (current assignment: $args[0].assignment).@@//
+			<</if>>
+			/* this rule has been applied to this slave now (or was already), so we are done with this rule */
+		<<elseif ruleApplied($args[0], _currentRule.ID)>> /* rule does not apply now, but did before */
+			<<RARemoveRule $args[0]>> /* RARemoveRule prints message and includes Rules Facilities Remove check, so we are done with this rule */
+		<</if>>
+	<</for>> /* done with this rule - continue looping through all the rules defined in the rules assistant */
+
+	/* done checking/applying/removing rules - sort this slave's updated applied rules to match the current priority order in the rules assistant */
+	<<set $args[0].currentRules = $args[0].currentRules.sort(function(a, b) { return a-b; });>> /* sort this slave's applied rules to match the current priority order in the rules assistant */
+
 <</widget>>
+


### PR DESCRIPTION
more fixes for (re-)assignment code, including moving on-assighnment facilities rule changes into the respective facilities' weekly code; more Rules Assistant fixes and improvements, including enabling the until-now-disabled feature of the RA that allows it to re-assign slaves that are in facilities, a condensed and (hopefully) more understandable activation conditions section, and mutual exclusion of incompatible conditions; added the ability to change the priority level of existing rules; various bug fixes, including defensive code to deal with nulls in the $defaultRules array; and last but not least, adding or importing rules re-numbers all rules' internal IDs to avoid some glitches that occur when multiple rules end up with the same ID; and some incidental cleanup in userlib.js to support all of this