### PR TITLE
Bugfixes for buildingWidgets.tw

### DIFF
--- a/src/uncategorized/buildingWidgets.tw
+++ b/src/uncategorized/buildingWidgets.tw
@@ -93,7 +93,7 @@ Yes, I am aware this is horrible. If anyone can figure out how to get widgets to
 		<td></td>
 		<td id="Penthouse" colspan="4">
 			<<link "Penthouse">><<set $nextButton = "Back", $nextLink = _Pass>><<goto "Manage Penthouse">><</link>>
-			<<if $servantsQuarters||$spa||$clinic||$schoolroom||$cellblock>>
+			<<if $masterSuite||$servantsQuarters||$spa||$clinic||$schoolroom||$cellblock||$HGSuite>>
 				<br>
 				<<if $masterSuite>>[[Suite|Master Suite]] ($masterSuiteSlaves/$masterSuite<<if $Concubine>>, C<</if>>)<</if>>
 				<<if $servantsQuarters>>[[Quarters|Servants' Quarters]] ($servantsQuartersSlaves/$servantsQuarters<<if $Stewardess>>, L<</if>>)<</if>>
@@ -101,7 +101,7 @@ Yes, I am aware this is horrible. If anyone can figure out how to get widgets to
 				<<if $clinic>>[[Clinic]] ($clinicSlaves/$clinic<<if $Nurse>>, L<</if>>)<</if>>
 				<<if $schoolroom>>[[Schoolroom]] ($schoolroomSlaves/$schoolroom<<if $Schoolteacher>>, L<</if>>)<</if>>
 				<<if $cellblock>>[[Cellblock]] ($cellblockSlaves/$cellblock<<if $Wardeness>>, L<</if>>)<</if>>
-				<<if $HGSuite>>[HG Suite|Head Girl Suite]] ($HGSuiteSlaves)<</if>>
+				<<if $HGSuite>>[[HG Suite|Head Girl Suite]] ($HGSuiteSlaves)<</if>>
 			<</if>>
 		</td>
 		<td></td>


### PR DESCRIPTION
Adds the Master and Head Girl suites to the triggers for the second line, you'd have to build one of the other five for them to show otherwise.  
Fixes Missing [ on the Head Girl suite.