### PR TITLE
Fix duplicate slaves in facilities & backwards compatibility update option & misc fixes

### DIFF
--- a/devTools/tweeGo/targets/sugarcube-2/userlib.js
+++ b/devTools/tweeGo/targets/sugarcube-2/userlib.js
@@ -519,8 +519,8 @@ window.hasSurgeryRule = function(slave, rules) {
 	if (!slave || !rules || !slave.currentRules) {
 		return false;
 	}else {
-		for(var d=rules.length-1; d >= 0; --d){
-			for(var e=0; e < slave.currentRules.length;++e){
+		for(var d=rules.length-1; d >= 0; d--){
+			for(var e=0; e < slave.currentRules.length;e++){
 				if(slave.currentRules[e] == rules[d].ID){
 					if (rules[d].autoSurgery > 0){
 						return true;
@@ -547,7 +547,7 @@ window.lastRuleFor = function(slave, rules, what) {
 	if (!slave  || !rules || !slave.currentRules)
 		return null;
 
-	for (var d = rules.length-1; d >= 0; --d) {
+	for (var d = rules.length-1; d >= 0; d--) {
 		if (ruleApplied(slave, rules[d].ID)) {
 			if (rules[d][what] !== "no default setting") {
 				return rules[d];
@@ -564,7 +564,7 @@ window.lastPregRule = function(slave, rules) {
 	if (!slave.currentRules)
 		return false;
 
-	for (var d = rules.length-1; d >= 0; --d){
+	for (var d = rules.length-1; d >= 0; d--){
 		if (ruleApplied(slave, rules[d].ID)) {
 			if (rules[d].preg == -1){
 				return rules[d];
@@ -723,7 +723,7 @@ window.lastSurgeryRuleFor = function(slave, rules, what) {
 	if (!slave || !rules || !slave.currentRules)
 		return null;
 
-	for (var d = rules.length-1; d >= 0; --d) {
+	for (var d = rules.length-1; d >= 0; d--) {
 		if (!rules[d].surgery)
 			return null;
 

--- a/src/npc/fFeelings.tw
+++ b/src/npc/fFeelings.tw
@@ -366,7 +366,7 @@ My favorite part of my body i<<s>>
 	<<elseif ($activeSlave.fetish == "pregnancy") && ($activeSlave.fetishStrength > 60)>>
 		<<if $PC.boobs == 1>>You, uh." She looks down, hesitating. "You have really ni<<c>>e breast<<s>>, <<Master>>.<</if>>
 	<<elseif ($activeSlave.fetish == "boobs") && ($activeSlave.fetishStrength > 60)>>
-		<<if $PC.boobs == 1>>Your brea<<s>>t<<s>> are incredible, <<Master>>," she <<say>>s	eagerly. "I love them.
+		<<if $PC.boobs == 1>>Your brea<<s>>t<<s>> are incredible, <<Master>>," she <<say>>s eagerly. "I love them.<</if>>
 	<<elseif ($activeSlave.attrKnown == 1) && ($activeSlave.attrXX > 80)>>
 		<<if $PC.boobs == 1>>You're, uh." She looks down, hesitating. "You're really hot, <<Master>>.<</if>>
 	<<elseif ($activeSlave.attrKnown == 1) && ($activeSlave.attrXY > 80)>>
@@ -449,14 +449,14 @@ My favorite part of my body i<<s>>
 		<<if $activeSlave.devotion > 75>>
 			I love you, <<Master>>,	<<s>>o I don't mind how the hormone<<s>> I'm on keep me <<s>>oft, if that'<<s>> how you want me.
 		<<else>>
-			I <<s>>ometime<<s>> wish the hormone<<s>> I'm on let me get hard.
+			I <<s>>ometime<<s>> wish the hormone<<s>> I'm on would let me get hard.
 		<</if>>
 	<</if>>
 	<<else>>
 		<<if $activeSlave.devotion > 75>>
 			I love you, <<Master>>,	<<s>>o I don't mind how the hormone<<s>> I'm on keep me <<s>>oft, if that'<<s>> how you want me.
 		<<else>>
-			I <<s>>ometime<<s>> wish the hormone<<s>> I'm on let me get hard.
+			I <<s>>ometime<<s>> wish the hormone<<s>> I'm on would let me get hard.
 		<</if>>
 	<</if>>
 <</if>> /* closes balls check */
@@ -541,7 +541,7 @@ My favorite part of my body i<<s>>
 		It'<<s>> great being a whore. I can't imagine being <<s>>ati<<s>>fied doing anything el<<s>>e.
 	<<elseif ($activeSlave.fetishStrength > 60) && ($activeSlave.fetish != "pregnancy")>>
 	<<switch $activeSlave.fetish>>
-	<<case "submissive">>-
+	<<case "submissive">>
 		It'<<s>> ni<<c>>e being a whore, I get treated like I de<<s>>erve.
 	<<case "dom">>
 		Being a whore i<<s>> okay, <<s>>ometime<<s>> <<s>>omebody want<<s>> to be dommed.
@@ -570,7 +570,7 @@ My favorite part of my body i<<s>>
 		It'<<s>> great being a public <<s>>lut. I can't imagine being <<s>>ati<<s>>fied doing anything el<<s>>e.
 	<<elseif ($activeSlave.fetishStrength > 60) && ($activeSlave.fetish != "pregnancy")>>
 	<<switch $activeSlave.fetish>>
-	<<case "submissive">>-
+	<<case "submissive">>
 		It'<<s>> ni<<c>>e being a public <<s>>lut, I get treated like I de<<s>>erve.
 	<<case "dom">>
 		Being a public <<s>>lut i<<s>> okay, <<s>>ometime<<s>> <<s>>omebody want<<s>> to be dommed.
@@ -708,13 +708,12 @@ My favorite part of my body i<<s>>
 
 <<if ($arcologies[0].FSSupremacistDecoration > 50) || ($arcologies[0].FSSubjugationistDecoration > 50) || ($arcologies[0].FSGenderRadicalistDecoration > 50) || ($arcologies[0].FSGenderFundamentalistDecoration > 50) || ($arcologies[0].FSPaternalistDecoration > 50) || ($arcologies[0].FSDegradationistDecoration > 50) || ($arcologies[0].FSBodyPuristDecoration > 50) || ($arcologies[0].FSTransformationFetishistDecoration > 50) || ($arcologies[0].FSSlimnessEnthusiastDecoration > 50) || ($arcologies[0].FSMaturityPreferentialistDecoration > 50) || ($arcologies[0].FSYouthPreferentialistDecoration > 50) || ($arcologies[0].FSAssetExpansionistDecoration > 50) || ($arcologies[0].FSPastoralistDecoration > 50) || ($arcologies[0].FSPhysicalIdealistDecoration > 50) || ($arcologies[0].FSChattelReligionistDecoration > 50) || ($arcologies[0].FSRomanRevivalistDecoration > 50) || ($arcologies[0].FSEgyptianRevivalistDecoration > 50)>>
 
-<<if ($activeSlave.devotion > 20)>>
+<<if ($activeSlave.devotion > 75)>>
 	I'll do everything I can to	<<s>>upport your vi<<s>>ion for the future.
 <<elseif ($activeSlave.devotion > 50)>>
 	I do my be<<s>>t to <<s>>upport your vi<<s>>ion for the future.
 <<else>>
 	I try to conform to your vi<<s>>ion for the future.
-	<</if>>
 <</if>>
 
 <<if $arcologies[0].FSRomanRevivalist >= 10>>
@@ -858,7 +857,7 @@ My favorite part of my body i<<s>>
 		I wish I could make milk for the arcology.
 	<</if>>
 <</if>>
-<</if>>
+<</if>> /* closes FS */
 
 <<if ($activeSlave.devotion > 75)>>
 <<if ($activeSlave.weekAcquired == 1) && ($week > 104)>>

--- a/src/npc/fucktoyWorkaround.tw
+++ b/src/npc/fucktoyWorkaround.tw
@@ -1,4 +1,6 @@
 :: Fucktoy Workaround [silently]
 
-<<set $slaves[$i].assignment = "please you", $slaves[$i].choosesOwnAssignment = 0>>
+<<assignJob $slaves[$i] "please you">>
+
 <<goto "Main">>
+

--- a/src/npc/removeActiveSlave.tw
+++ b/src/npc/removeActiveSlave.tw
@@ -11,6 +11,7 @@
 		<</if>>
 	<</for>>
 <</if>>
+
 <<if _x < _SL>>
 	<<for _y = 0; _y < _SL; _y++>>
 		<<if _ID == $slaves[_y].pregSource>>
@@ -26,6 +27,7 @@
 			<<set $slaves[_y].rivalry = 0, $slaves[_y].rivalryTarget = 0>>
 		<</if>>
 	<</for>>
+
 	<<if _ID == $Recruiter.ID>><<set $Recruiter = 0>><</if>>
 	<<if _ID == $HeadGirl.ID>><<set $HeadGirl = 0>><</if>>
 	<<if _ID == $Bodyguard.ID>><<set $Bodyguard = 0>><</if>>
@@ -43,23 +45,13 @@
 	<<if _ID == $Wardeness.ID>><<set $Wardeness = 0>><</if>>
 	<<if _ID == $Concubine.ID>><<set $Concubine = 0>><</if>>
 	<<if _ID == $personalAttention>><<set $personalAttention = "business">><</if>>
-	<<for _y = 0; _y < $fighterIDs.length; _y++>>
-		<<if _ID == $fighterIDs[_y]>>
-			<<set _dump = $fighterIDs.deleteAt(_y), _y-->>
-		<</if>>
-	<</for>>
-	/% Remove from facility array if assigned %/
-	<<switch $slaves[_x].assignment>>
-	<<case "learn in the schoolroom" "get treatment in the clinic" "rest in the spa" "work in the dairy" "be confined in the arcade" "live with your Head Girl" "be confined in the cellblock" "serve in the club" "serve in the master suite" "work as a servant" "work in the brothel">>
-		<<removeJob $activeSlave $activeSlave.assignment>>
-	<</switch>>
 
-	<<set _Tcount = $slavesOriginal.length>>
-	<<for _y = 0; _y < _Tcount; _y++>>
-		<<if $slavesOriginal[_y].ID == _ID>>
-			<<set _dump = $slavesOriginal.deleteAt(_y)>>
-			<<break>>
-		<</if>>
-	<</for>>
+	<<set $fighterIDs.delete(_ID)>>
+
+	/% Remove from facility array if assigned %/
+	<<removeJob $activeSlave $activeSlave.assignment>>
+
+	<<set $slavesOriginal.delete(_ID)>>
+
 	<<set _dump = $slaves.deleteAt(_x), _SL--, $activeSlave = 0>>
 <</if>>

--- a/src/npc/restWorkaround.tw
+++ b/src/npc/restWorkaround.tw
@@ -1,4 +1,6 @@
 :: Rest Workaround [silently]
 
-<<set $slaves[$i].assignment = "rest", $slaves[$i].choosesOwnAssignment = 0>>
+<<removeJob $slaves[$i] $slaves[$i].assignment>>
+
 <<goto "Main">>
+

--- a/src/npc/rgASDump.tw
+++ b/src/npc/rgASDump.tw
@@ -36,7 +36,7 @@
 	<<elseif $PC.career == "slaver">>
 		<<set $activeSlave.devotion += 10>>
 	<<elseif $PC.career == "medicine">>
-		<<set $activeSlave.boobs += 600, $activeSlave.boobsImplant += 600, $activeSlave.butt += 2, $activeSlave.buttImplant += 2, $activeSlave.lips += 10, $activeSlave.lipsImplant += 10, $activeSlave.waist = 55>>
+		<<set $activeSlave.boobs += 600, $activeSlave.boobsImplant += 600, $activeSlave.butt += 2, $activeSlave.buttImplant += 2, $activeSlave.lips += 10, $activeSlave.lipsImplant += 10, $activeSlave.waist = -55>>
 	<<elseif $PC.career == "celebrity">>
 		<<if $activeSlave.entertainSkill < 60>><<set $activeSlave.entertainSkill += 20>><</if>>
 	<<elseif $PC.career == "wealth">>

--- a/src/npc/servantWorkaround.tw
+++ b/src/npc/servantWorkaround.tw
@@ -1,4 +1,6 @@
 :: Servant Workaround [silently]
 
-<<set $slaves[$i].assignment = "be a servant", $slaves[$i].choosesOwnAssignment = 0>>
+<<assignJob $slaves[$i] "be a servant">>
+
 <<goto "Main">>
+

--- a/src/uncategorized/BackwardsCompatibility.tw
+++ b/src/uncategorized/BackwardsCompatibility.tw
@@ -39,6 +39,66 @@
 	<<set $fixedRace = 0>>
 <</if>>
 
+<<if ndef $arcologyUpgrade>>
+	<<set $arcologyUpgrade = {drones: 0, hydro: 0, apron: 0, grid: 0, spire: 0}>>
+	<<set $arcologyUpgrade.drones = ($AProsperityCap > 60)  ? 1 : 0>>
+	<<set $arcologyUpgrade.hydro  = ($AProsperityCap > 80)  ? 1 : 0>>
+	<<set $arcologyUpgrade.apron  = ($AProsperityCap > 100) ? 1 : 0>>
+	<<set $arcologyUpgrade.grid   = ($AProsperityCap > 120) ? 1 : 0>>
+	<<set $arcologyUpgrade.spire  = ($AProsperityCap > 240) ? 1 : 0>>
+<</if>>
+
+<<if def $AHelots>>
+	<<set $ASlaves += Math.trunc($AHelots / 2)>>
+	<<unset $AHelots>>
+<</if>>
+
+<<if ndef $seeBuilding>>
+	<<set $seeBuilding = $seeArcology>>
+<</if>>
+
+<<if ndef $sectors>>
+	<<set $sectors = []>>
+	<<set $AS = {type: "Penthouse", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Empty", ownership: 0}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Empty", ownership: 0}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Empty", ownership: 0}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Empty", ownership: 0}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Shops", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Shops", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Shops", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Apartments", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Markets", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Markets", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Markets", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Markets", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Markets", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Manufacturing", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Manufacturing", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Manufacturing", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Manufacturing", ownership: 1}>><<set $sectors.push($AS)>>
+	<<set $AS = {type: "Barracks", ownership: 1}>><<set $sectors.push($AS)>>
+	<<for _i = 0; _i < 12; _i++>>
+		<<set _j = random(5,28)>>
+		<<if $sectors[_j].ownership == 1>>
+			<<set $sectors[_j].ownership = 0>>
+		<<else>>
+			<<set _i-->>
+		<</if>>
+	<</for>>
+<</if>>
+
 <<for _i = 0; _i < $defaultRules.length; _i++>>
 	<<if ndef $defaultRules[_i].standardReward>>
 		<<set $defaultRules[_i].standardReward = "no default setting">>
@@ -1095,7 +1155,7 @@ Setting missing global variables:
 		<<set $seeDicks = 25>>
 	<</if>>
 <</if>>
-<<if ($ver.includes("0.6") == true) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true) ||  ($ver.includes("0.9") == true) && ($ver.includes("0.9.4") != true) && ($ver.includes("0.9.5") != true) && ($ver.includes("0.9.6") != true) && ($ver.includes("0.9.7") != true) && ($ver.includes("0.9.8") != true) && ($ver.includes("0.9.9") != true) && ($ver.includes("0.9.10") != true)>>
+<<if ($ver.includes("0.6") == true) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true) ||  ($ver.includes("0.9.4") != true) && ($ver.includes("0.9") == true) && ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true) ||  ($ver.includes("0.9.5") != true) && ($ver.includes("0.9.6") != true) && ($ver.includes("0.9.7") != true) && ($ver.includes("0.9.8") != true) && ($ver.includes("0.9.9") != true) && ($ver.includes("0.9.10") != true)>>
 	<<for _r to 0; _r < $defaultRules.length; _r++>>
 		<<if ndef $defaultRules[_r].aphrodisiacs>>
 			<<set $defaultRules[_r].aphrodisiacs = 0>>
@@ -1169,7 +1229,7 @@ Setting missing slave variables:
 	<<set _Slave.faceShape to "normal">>
 <</if>>
 
-<<if $releaseID > 1000>><<else>>
+<<if $releaseID < 1000>>
 	<<if _Slave.face == -3>>
 		<<set _Slave.face = -100>>
 	<<elseif _Slave.face == -2>>
@@ -1725,3 +1785,6 @@ Setting missing slave variables:
 <<if ndef $slavesOriginal>>
 	<<set $slavesOriginal = $slaves>>
 <</if>>
+
+Done!
+

--- a/src/uncategorized/apartments.tw
+++ b/src/uncategorized/apartments.tw
@@ -25,7 +25,7 @@ You control this part of the arcology and all these tenants pay you rent.
 
 <<if $sectors[$AS].type != "LuxuryApartments">>
 	<br>
-	[[Improve this sector of apartments occupancy by the Free Cities' wealthiest citizens|Manage Arcology][$cash -= Math.trunc(10000*$upgradeMultiplierArcology), $sectors[$AS].type = "LuxuryApartments"]]
+	[[Improve this sector of apartments for occupancy by the Free Cities' wealthiest citizens|Manage Arcology][$cash -= Math.trunc(10000*$upgradeMultiplierArcology), $sectors[$AS].type = "LuxuryApartments"]]
 	//Costs ¤<<print Math.trunc(10000*$upgradeMultiplierArcology)>>//
 <</if>>
 

--- a/src/uncategorized/arcade.tw
+++ b/src/uncategorized/arcade.tw
@@ -62,7 +62,7 @@ $arcadeNameCaps
 		<<set $arcade = 0, $arcadeUpgradeInjectors = 0, $arcadeUpgradeFuckdolls = 0, $arcadeUpgradeCollectors = 0>>
 		<<for _i = 0; _i < $sectors.length; _i++>>
 		<<if $sectors[_i].type == "Arcade">>
-			<<set $sectors[_i].type == "Markets">><<break>>
+			<<set $sectors[_i].type = "Markets">><<break>>
 		<</if>>
 		<</for>>
 		<<goto "Main">>

--- a/src/uncategorized/attendantWorkaround.tw
+++ b/src/uncategorized/attendantWorkaround.tw
@@ -3,28 +3,19 @@
 <<if $Attendant != 0>>
 	<<set _ID = $Attendant.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+			<<removeJob $slaves[_i] "be the Attendant">>
+			<<break>>
+		<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<if $slaves[$i].ID == $HeadGirl.ID>>
-		<<set $HeadGirl = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Recruiter.ID>>
-		<<set $Recruiter = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Bodyguard.ID>>
-		<<set $Bodyguard = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $personalAttention>>
-		<<set $personalAttention = "business">>
-	<</if>>
-	<<set $slaves[$i].assignment = "be the Attendant", $slaves[$i].assignmentVisible = 0, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0, $slaves[$i].livingRules = "luxurious">>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "be the Attendant">>
+	<<set $slaves[$i].livingRules = "luxurious">>
 	<<set $Attendant = $slaves[$i]>>
 <<else>>
 	<<set $Attendant = 0>>
 <</if>>
 
 <<goto "Spa">>
+

--- a/src/uncategorized/bodyguardWorkaround.tw
+++ b/src/uncategorized/bodyguardWorkaround.tw
@@ -3,13 +3,14 @@
 <<if $Bodyguard != 0>>
 	<<set _ID = $Bodyguard.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+			<<removeJob $slaves[_i] "guard you">>
+			<<break>>
+		<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<set $slaves[$i].assignment = "guard you", $slaves[$i].assignmentVisible = 1, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0>>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "guard you">>
 	<<set $Bodyguard = $slaves[$i]>>
 <<else>>
 	<<set $Bodyguard = 0>>

--- a/src/uncategorized/brothel.tw
+++ b/src/uncategorized/brothel.tw
@@ -115,7 +115,7 @@ $brothelNameCaps
 		<<set $brothel = 0, $brothelUpgradeDrugs = 0, $brothelDecoration = "standard">>
 		<<for _i = 0; _i < $sectors.length; _i++>>
 		<<if $sectors[_i].type == "Brothel">>
-			<<set $sectors[_i].type == "Shops">><<break>>
+			<<set $sectors[_i].type = "Shops">><<break>>
 		<</if>>
 		<</for>>
 		<<goto "Main">>

--- a/src/uncategorized/cellblock.tw
+++ b/src/uncategorized/cellblock.tw
@@ -91,7 +91,7 @@ $cellblockNameCaps
 	<br><br>''$cellblockNameCaps is full and cannot hold any more slaves''
 <<elseif ($slaves.length > $cellblockSlaves)>>
 	<br><br>''Send a resistant slave to be broken in the cellblock:''
-	<<set $Flag to 0>>
+	<<set $Flag = 0>>
 	<<include "Slave Summary">>
 <</if>>
 <<unset $Flag>>

--- a/src/uncategorized/cellblockReport.tw
+++ b/src/uncategorized/cellblockReport.tw
@@ -289,7 +289,7 @@
 		<br><br>&nbsp;&nbsp;&nbsp;
 	<</if>>
 	<<if (_softenedQuirks > 0)>>
-		$cellblockName's advanced compliance systems successfully softened
+		$cellblockNameCaps's advanced compliance systems successfully softened
 	<<if (_softenedQuirks == 1)>>
 		one slave's mental flaw into an @@.green;appealing quirk,@@ though the constant correction caused her @@.mediumorchid;considerable anguish.@@
 	<<else>>

--- a/src/uncategorized/classesWorkaround.tw
+++ b/src/uncategorized/classesWorkaround.tw
@@ -1,4 +1,6 @@
 :: Classes Workaround [silently]
 
-<<set $slaves[$i].assignment = "take classes", $slaves[$i].choosesOwnAssignment = 0>>
+<<assignJob $slaves[$i] "take classes">>
+
 <<goto "Main">>
+

--- a/src/uncategorized/club.tw
+++ b/src/uncategorized/club.tw
@@ -115,7 +115,7 @@ $clubNameCaps
 		<<set $club = 0, $clubDecoration = "standard", $clubUpgradePDAs = 0>>
 		<<for _i = 0; _i < $sectors.length; _i++>>
 		<<if $sectors[_i].type == "Club">>
-			<<set $sectors[_i].type == "Shops">><<break>>
+			<<set $sectors[_i].type = "Shops">><<break>>
 		<</if>>
 		<</for>>
 		<<goto "Main">>

--- a/src/uncategorized/concubineWorkaround.tw
+++ b/src/uncategorized/concubineWorkaround.tw
@@ -3,28 +3,19 @@
 <<if $Concubine != 0>>
 	<<set _ID = $Concubine.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+			<<removeJob $slaves[_i] "be your Concubine">>
+			<<break>>
+		<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<if $slaves[$i].ID == $HeadGirl.ID>>
-		<<set $HeadGirl = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Recruiter.ID>>
-		<<set $Recruiter = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Bodyguard.ID>>
-		<<set $Bodyguard = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $personalAttention>>
-		<<set $personalAttention = "business">>
-	<</if>>
-	<<set $slaves[$i].assignment = "be your Concubine", $slaves[$i].assignmentVisible = 0, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0, $slaves[$i].livingRules = "luxurious">>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "be your Concubine">>
+	<<set $slaves[$i].livingRules = "luxurious">>
 	<<set $Concubine = $slaves[$i]>>
 <<else>>
 	<<set $Concubine = 0>>
 <</if>>
 
 <<goto "Master Suite">>
+

--- a/src/uncategorized/confinementWorkaround.tw
+++ b/src/uncategorized/confinementWorkaround.tw
@@ -1,4 +1,6 @@
 :: Confinement Workaround [silently]
 
-<<set $slaves[$i].assignment = "stay confined", $slaves[$i].choosesOwnAssignment = 0>>
+<<assignJob $slaves[$i] "stay confined">>
+
 <<goto "Main">>
+

--- a/src/uncategorized/dairy.tw
+++ b/src/uncategorized/dairy.tw
@@ -33,8 +33,9 @@
 <<if ($Milkmaid != 0) && ($dairyRestraintsSetting == 2)>>
 <<for _i = 0; _i < _SL; _i++>>
 <<if $slaves[_i].assignment == "be the Milkmaid">>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1, $Milkmaid = 0>>
-	$slaves[_i].slaveName has been removed from her position as Milkmaid, since an industrialized dairy automates her duties.<br><br>
+	$slaves[_i].slaveName has been removed from her position as Milkmaid, since an industrialized dairy automates her duties.
+	<<removeJob $slaves[_i] "be the Milkmaid">>
+	<br><br>
 <</if>>
 <</for>>
 <</if>>
@@ -280,7 +281,7 @@ $dairyNameCaps
 		<<set $dairy = 0, $dairyFeedersUpgrade = 0, $dairyPregUpgrade = 0, $dairyStimulatorsUpgrade = 0, $dairyDecoration = "standard", $dairyFeedersSetting = 0, $dairyPregSetting = 0, $dairyStimulatorsSetting = 0>>
 		<<for _i = 0; _i < $sectors.length; _i++>>
 		<<if $sectors[_i].type == "Dairy">>
-			<<set $sectors[_i].type == "Manufacturing">><<break>>
+			<<set $sectors[_i].type = "Manufacturing">><<break>>
 		<</if>>
 		<</for>>
 		<<goto "Main">>

--- a/src/uncategorized/djWorkaround.tw
+++ b/src/uncategorized/djWorkaround.tw
@@ -3,28 +3,19 @@
 <<if $DJ != 0>>
 	<<set _ID = $DJ.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+		<<removeJob $slaves[_i] "be the DJ">>
+		<<break>>
+	<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<if $slaves[$i].ID == $HeadGirl.ID>>
-		<<set $HeadGirl = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Recruiter.ID>>
-		<<set $Recruiter = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Bodyguard.ID>>
-		<<set $Bodyguard = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $personalAttention>>
-		<<set $personalAttention = "business">>
-	<</if>>
-	<<set $slaves[$i].assignment = "be the DJ", $slaves[$i].assignmentVisible = 0, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0, $slaves[$i].livingRules = "luxurious">>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "be the DJ">>
+	<<set $slaves[$i].livingRules = "luxurious">>
 	<<set $DJ = $slaves[$i]>>
 <<else>>
 	<<set $DJ = 0>>
 <</if>>
 
 <<goto "Club">>
+

--- a/src/uncategorized/hgWorkaround.tw
+++ b/src/uncategorized/hgWorkaround.tw
@@ -3,20 +3,20 @@
 <<if $HeadGirl != 0>>
 	<<set _ID = $HeadGirl.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+			<<removeJob $slaves[_i] "be your Head Girl">>
+			<<break>>
+		<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<set $slaves[$i].assignment = "be your Head Girl", $slaves[$i].assignmentVisible = 1, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0>>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "be your Head Girl">>
 	<<set $HeadGirl = $slaves[$i]>>
 <<else>>
 	<<set $HeadGirl = 0>>
-	<<if $personalAttention == "HG">>
-		<<set $personalAttention = "business">>
-	<</if>>
 <</if>>
+
 <<set $HGTimeInGrade = 0>>
 
 <<goto "Main">>
+

--- a/src/uncategorized/holeWorkaround.tw
+++ b/src/uncategorized/holeWorkaround.tw
@@ -1,4 +1,6 @@
 :: Hole Workaround [silently]
 
-<<set $slaves[$i].assignment = "work a glory hole", $slaves[$i].choosesOwnAssignment = 0>>
+<<assignJob $slaves[$i] "work a glory hole">>
+
 <<goto "Main">>
+

--- a/src/uncategorized/madamWorkaround.tw
+++ b/src/uncategorized/madamWorkaround.tw
@@ -3,28 +3,19 @@
 <<if $Madam != 0>>
 	<<set _ID = $Madam.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+			<<removeJob $slaves[_i] "be the Madam">>
+			<<break>>
+		<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<if $slaves[$i].ID == $HeadGirl.ID>>
-		<<set $HeadGirl = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Recruiter.ID>>
-		<<set $Recruiter = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Bodyguard.ID>>
-		<<set $Bodyguard = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $personalAttention>>
-		<<set $personalAttention = "business">>
-	<</if>>
-	<<set $slaves[$i].assignment = "be the Madam", $slaves[$i].assignmentVisible = 0, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0, $slaves[$i].livingRules = "luxurious">>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "be the Madam">>
+	<<set $slaves[$i].livingRules = "luxurious">>
 	<<set $Madam = $slaves[$i]>>
 <<else>>
 	<<set $Madam = 0>>
 <</if>>
 
 <<goto "Brothel">>
+

--- a/src/uncategorized/milkingWorkaround.tw
+++ b/src/uncategorized/milkingWorkaround.tw
@@ -1,4 +1,6 @@
 :: Milking Workaround [silently]
 
-<<set $slaves[$i].assignment = "get milked", $slaves[$i].choosesOwnAssignment = 0>>
+<<assignJob $slaves[$i] "get milked">>
+
 <<goto "Main">>
+

--- a/src/uncategorized/milkmaidWorkaround.tw
+++ b/src/uncategorized/milkmaidWorkaround.tw
@@ -3,28 +3,19 @@
 <<if $Milkmaid != 0>>
 	<<set _ID = $Milkmaid.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+			<<removeJob $slaves[_i] "be the Milkmaid">>
+			<<break>>
+		<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<if $slaves[$i].ID == $HeadGirl.ID>>
-		<<set $HeadGirl = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Recruiter.ID>>
-		<<set $Recruiter = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Bodyguard.ID>>
-		<<set $Bodyguard = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $personalAttention>>
-		<<set $personalAttention = "business">>
-	<</if>>
-	<<set $slaves[$i].assignment = "be the Milkmaid", $slaves[$i].assignmentVisible = 0, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0, $slaves[$i].livingRules = "luxurious">>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "be the Milkmaid">>
+	<<set $slaves[$i].livingRules = "luxurious">>
 	<<set $Milkmaid = $slaves[$i]>>
 <<else>>
 	<<set $Milkmaid = 0>>
 <</if>>
 
 <<goto "Dairy">>
+

--- a/src/uncategorized/ngpWorkaround.tw
+++ b/src/uncategorized/ngpWorkaround.tw
@@ -1,8 +1,10 @@
 :: NGP Workaround [silently]
 
 <<if $slavesToImport == 1>>
-	<<set $slaves[$i].assignment = "be imported">>
+	<<assignJob $slaves[$i] "be imported">>
 <<else>>
-	<<set $slaves[$i].assignment = "rest">>
+	<<removeJob $slaves[$i] $slaves[$i].assignment>>
 <</if>>
+
 <<goto "New Game Plus">>
+

--- a/src/uncategorized/nurseWorkaround.tw
+++ b/src/uncategorized/nurseWorkaround.tw
@@ -3,28 +3,19 @@
 <<if $Nurse != 0>>
 	<<set _ID = $Nurse.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+			<<removeJob $slaves[_i] "be the Nurse">>
+			<<break>>
+		<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<if $slaves[$i].ID == $HeadGirl.ID>>
-		<<set $HeadGirl = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Recruiter.ID>>
-		<<set $Recruiter = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Bodyguard.ID>>
-		<<set $Bodyguard = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $personalAttention>>
-		<<set $personalAttention = "business">>
-	<</if>>
-	<<set $slaves[$i].assignment = "be the Nurse", $slaves[$i].assignmentVisible = 0, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0, $slaves[$i].livingRules = "luxurious">>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "be the Nurse">>
+	<<set $slaves[$i].livingRules = "luxurious">>
 	<<set $Nurse = $slaves[$i]>>
 <<else>>
 	<<set $Nurse = 0>>
 <</if>>
 
 <<goto "Clinic">>
+

--- a/src/uncategorized/options.tw
+++ b/src/uncategorized/options.tw
@@ -6,6 +6,9 @@
 This save was created using FC version $ver build $releaseID.
 
 <br><br>
+[[Apply Backwards Compatibility Update|Backwards Compatibility]]
+
+<br><br>
 
 <<if ($autosave == 0)>>
 End of week autosaving is currently @@.red;DISABLED@@. [[Enable|Options][$autosave = 1]]

--- a/src/uncategorized/pit.tw
+++ b/src/uncategorized/pit.tw
@@ -19,7 +19,7 @@ $pitNameCaps is clean and ready,
 		<<set $pit = 0>>
 		<<for _i = 0; _i < $sectors.length; _i++>>
 		<<if $sectors[_i].type == "Pit">>
-			<<set $sectors[_i].type == "Pit">><<break>>
+			<<set $sectors[_i].type = "Pit">><<break>>
 		<</if>>
 		<</for>>
 		<<goto "Main">>

--- a/src/uncategorized/publicServantWorkaround.tw
+++ b/src/uncategorized/publicServantWorkaround.tw
@@ -1,4 +1,6 @@
 :: Public Servant Workaround [silently]
 
-<<set $slaves[$i].assignment = "serve the public", $slaves[$i].choosesOwnAssignment = 0>>
+<<assignJob $slaves[$i] "serve the public">>
+
 <<goto "Main">>
+

--- a/src/uncategorized/reBusyArcadeWorkaround.tw
+++ b/src/uncategorized/reBusyArcadeWorkaround.tw
@@ -1,25 +1,17 @@
 :: RE busy arcade workaround
 
-<<nobr>>
+<<set $nextButton = "Continue", $nextLink = "AS Dump", $returnTo = "RIE Eligibility Check">>
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "AS Dump">>
-<<set $returnTo = "RIE Eligibility Check">>
-
-<</nobr>>\
-\
 Slaves in your arcade are not immured in the facility permanently, since holding them in one position at all times would negatively impact their health. They are released to exercise, eat, bathe, and sleep, though for nothing else. You occasionally inspect them when they do so, to see that their harsh lives are not inappropriately difficult for them. One day when you are doing so, <span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink = passage(), $eventDescription = 1]]">></span> flings herself on the ground in front of you the instant she sees you.
 
 Facing the ground, <<if canTalk($activeSlave) == false>>she gestures with shaking hands that she cannot take any more. She begs you abjectly to let her out of the arcade and promises to be a perfect sex slave if you do.<<elseif SlaveStatsChecker.checkForLisp($activeSlave)>>she lisps through tears, "M-mathter, pleathe. I can't take any more of thith. Pleathe let me out. I'll do anything, <<if def $PC.customTitleLisp>>$PC.customTitleLisp<<elseif $PC.title != 0>>Mathter<<else>>Mithtreth<</if>>. I'll love you forever, <<if def $PC.customTitleLisp>>$PC.customTitleLisp<<elseif $PC.title != 0>>Mathter<<else>>Mithtreth<</if>> - jutht don't make me go back inthide that wall."<<else>>she sobs, "M-master, please. I can't take any more of this. Please let me out. I'll do anything, <<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Master<<else>>Mistress<</if>>. I'll love you forever, <<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Master<<else>>Mistress<</if>> - just don't make me go back inside that wall."<</if>>
-\
+
 <span id="result">
 <<link "Accept her pledge">>
 	<<replace "#result">>
 	When you accept, $activeSlave.slaveName looks up at you in incomprehension, expecting you to correct yourself or reveal that this is a cruel trick. When you do neither, she scrabbles spastically to your feet, kisses them as she cries, and then clings to your knees, sobbing. She is so relieved by this reprieve that she is now on the cusp of @@.hotpink;devotion to you,@@ and will obey out of near-paralytic fear of being sent back to the arcade.
 	<<set $activeSlave.devotion = 45>>
-	<<set $activeSlave.assignment = "rest">>
-	<<set $activeSlave.assignmentVisible = 1>>
-<<set $activeSlave.choosesOwnAssignment = 0>>
+	<<removeJob $activeSlave "be confined in the arcade">>
 	<</replace>>
 <</link>>
 <<link "Refuse">>

--- a/src/uncategorized/reMalefactor.tw
+++ b/src/uncategorized/reMalefactor.tw
@@ -276,7 +276,7 @@
 	<<if $dairy > 0>>
 	<<if $dairyRestraintsSetting > 1>>
 	<br><<link "Enslave her and send her straight to the industrial dairy">>
-		<<set $activeSlave.assignment = "work in the dairy">>
+		<<assignJob $activeSlave "work in the dairy">>
 		<<AddSlave $activeSlave>>
 		<<set $cash -= $contractCost>>
 		<<replace "#result">>

--- a/src/uncategorized/reMalefactor.tw
+++ b/src/uncategorized/reMalefactor.tw
@@ -213,17 +213,16 @@
 		<<include "New Slave Intro">>
 		<</replace>>
 	<</link>>
-<</if>>
 	<br><<link "Sentence her to a day in the stocks, then enslave her">>
 		<<set $activeSlave.health -= 10>>
 		<<set $activeSlave.behavioralFlaw = "odd">>
 		<<set $activeSlave.sexualFlaw = "hates penetration">>
 		<<set $activeSlave.anus = 2>>
 		<<if $activeSlave.vagina > -1>>
-		<<set $activeSlave.vagina = 2>>
-		<<if random(1,100) > 60 && isFertile($activeSlave)>>
-			<<set $activeSlave.preg = 1>>
-		<</if>>
+			<<set $activeSlave.vagina = 2>>
+			<<if random(1,100) > 60 && isFertile($activeSlave)>>
+				<<set $activeSlave.preg = 1>>
+			<</if>>
 		<</if>>
 		<<AddSlave $activeSlave>>
 		<<set $cash -= $contractCost>>
@@ -298,7 +297,7 @@
 		<</replace>>
 	<</link>>
 	<</if>>
-	<</if>>
+	<</if>> /* closes dairy > 0 */
 	<<if $seeExtreme > 0>>
 	<br><<link "Punitively amputate her limbs, and then enslave her">>
 		<<set $activeSlave.health -= 20>>
@@ -340,10 +339,11 @@
 		<<set $arcologies[0].prosperity += 10>>
 		<</replace>>
 	<</link>>
-	<<else>>
+	<</if>>
+	<</if>> /* closes seeExtreme */
+<<else>>
 	//You lack the necessary funds to enslave her.//
-	<</if>>
-	<</if>>
+<</if>>
 <br><<link "Publicly flog the criminal">>
 	<<replace "#result">>
 	<<if $malefactor == "addict">>

--- a/src/uncategorized/reShelterInspection.tw
+++ b/src/uncategorized/reShelterInspection.tw
@@ -81,7 +81,7 @@ Not waiting to be greeted, the inspector looks up at the nearest camera and dema
 <</link>> //This will cost ¤$contractCost//
 <<if ($dairy > 0) && ($dairyRestraintsSetting > 1) && ($subSlave.assignment == "work in the dairy")>>\
 <<link "The slave is attached to a milking machine, and so will be the inspector">>
-	<<set $activeSlave.assignment = "work in the dairy">>
+	<<assignJob $activeSlave "work in the dairy">>
 	<<set $activeSlave.clothes = "no clothing">>
 	<<AddSlave $activeSlave>>
 	<<set $cash -= $contractCost/2>>

--- a/src/uncategorized/recruiterWorkaround.tw
+++ b/src/uncategorized/recruiterWorkaround.tw
@@ -3,16 +3,19 @@
 <<if $Recruiter != 0>>
 	<<set _ID = $Recruiter.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+			<<removeJob $slaves[_i] "recruit girls">>
+			<<break>>
+		<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<set $slaves[$i].assignment = "recruit girls", $slaves[$i].assignmentVisible = 1, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0>>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "recruit girls">>
+	<<set $slaves[$i].livingRules = "luxurious">>
 	<<set $Recruiter = $slaves[$i]>>
 <<else>>
 	<<set $Recruiter = 0>>
 <</if>>
 
 <<goto "Main">>
+

--- a/src/uncategorized/retrieve.tw
+++ b/src/uncategorized/retrieve.tw
@@ -1,41 +1,12 @@
 :: Retrieve [silently]
 
-<<set $activeSlave = $slaves[$i], _ID = $activeSlave.ID, _SL = $slaves.length>>
-
-<<removeJob $activeSlave $returnTo>>
-
 <<switch $returnTo>>
 <<case "Pit">>
-	<<for _i = 0; _i < $fighterIDs.length; _i++>>
-	<<if _ID == $fighterIDs[_i]>>
-		<<set _dump = $fighterIDs.pluck([_i], [_i]), _i-->>
-	<</if>>
-	<</for>>
+	<<set $fighterIDs.delete($slaves[$i].ID)>>
 <<case "Coursing Association">>
 	<<set $Lurcher = 0>>
-<<case "Arcade">>
-	<<set $activeSlave.assignment = "work a glory hole">>
-<<case "Master Suite">>
-	<<set $activeSlave.assignment = "please you">>
-<<case "Cellblock">>
-	<<set $activeSlave.assignment = "stay confined">>
-<<case "Schoolroom">>
-	<<set $activeSlave.assignment = "take classes">>
-<<case "Servants' Quarters">>
-	<<set $activeSlave.assignment = "be a servant">>
-<<case "Dairy">>
-	<<set $activeSlave.assignment = "get milked">>
-	<<if $dairyRestraintsSetting > 1>>
-		<<set $activeSlave.buttplug = "none", $activeSlave.clothes = "no clothing", $activeSlave.collar = "none", $activeSlave.vaginalAccessory = "none">>
-	<</if>>
-<<case "Brothel">>
-	<<set $activeSlave.assignment = "whore">>
-<<case "Club">>
-	<<set $activeSlave.assignment = "serve the public">>
+<<default>>
+	<<removeJob $slaves[$i] $slaves[$i].assignment>>
 <</switch>>
-
-<<if ($returnTo != "Pit") && ($returnTo != "Coursing Association")>>
-	<<set $slaves[$i] = $activeSlave>>
-<</if>>
 
 <<goto $returnTo>>

--- a/src/uncategorized/rulesFacilityRemove.tw
+++ b/src/uncategorized/rulesFacilityRemove.tw
@@ -6,97 +6,86 @@
 	<<case "brothel">>
 		<<if $activeSlave.assignment == "work in the brothel">>
 			<<if ($Madam == 0) || ($Madam.ID != $activeSlave.ID)>>
-				<<removeJob $activeSlave _currentRule.assignFacility>>
-				<<set $activeSlave.assignment = _currentRule.removalAssignment>>
-				<br>$activeSlave.slaveName has been removed from $brothelName and has been assigned to $activeSlave.assignment
+				<br>$activeSlave.slaveName has been removed from $brothelName and has been assigned to _currentRule.removalAssignment.
+				<<assignJob $activeSlave _currentRule.removalAssignment>>
 			<</if>>
 		<</if>>
 
 	<<case "club">>
 		<<if $activeSlave.assignment == "serve in the club">>
 			<<if ($DJ == 0) || ($DJ.ID != $activeSlave.ID)>>
-				<<removeJob $activeSlave _currentRule.assignFacility>>
-				<<set $activeSlave.assignment = _currentRule.removalAssignment>>
-				<br>$activeSlave.slaveName has been removed from $clubName and has been assigned to $activeSlave.assignment
+				<br>$activeSlave.slaveName has been removed from $clubName and has been assigned to _currentRule.removalAssignment.
+				<<assignJob $activeSlave _currentRule.removalAssignment>>
 			<</if>>
 		<</if>>
 
 	<<case "dairy">>
 		<<if $activeSlave.assignment == "work in the dairy">>
 			<<if ($Milkmaid == 0) || ($Milkmaid.ID != $activeSlave.ID)>>
-				<<removeJob $activeSlave _currentRule.assignFacility>>
-				<<set $activeSlave.assignment = _currentRule.removalAssignment>>
-				<br>$activeSlave.slaveName has been removed from $dairyName and has been assigned to $activeSlave.assignment
+				<br>$activeSlave.slaveName has been removed from $dairyName and has been assigned to _currentRule.removalAssignment.
+				<<assignJob $activeSlave _currentRule.removalAssignment>>
 			<</if>>
 		<</if>>
 
 	<<case "arcade">>
 		<<if $activeSlave.assignment == "be confined in the arcade">>
-				<<removeJob $activeSlave _currentRule.assignFacility>>
-			<<set $activeSlave.assignment = _currentRule.removalAssignment>>
-			<br>$activeSlave.slaveName has been removed from $arcadeName and has been assigned to $activeSlave.assignment
+			<br>$activeSlave.slaveName has been removed from $arcadeName and has been assigned to _currentRule.removalAssignment.
+			<<assignJob $activeSlave _currentRule.removalAssignment>>
 		<</if>>
 
 	<<case "spa">>
 		<<if $activeSlave.assignment == "rest in the spa">>
 			<<if ($Attendant == 0) || ($Attendant.ID != $activeSlave.ID)>>
-				<<removeJob $activeSlave _currentRule.assignFacility>>
-				<<set $activeSlave.assignment = _currentRule.removalAssignment>>
-				<br>$activeSlave.slaveName has been removed from $spaName and has been assigned to $activeSlave.assignment
+				<br>$activeSlave.slaveName has been removed from $spaName and has been assigned to _currentRule.removalAssignment.
+				<<assignJob $activeSlave _currentRule.removalAssignment>>
 			<</if>>
 		<</if>>
 
 	<<case "clinic">>
 		<<if $activeSlave.assignment == "get treatment in the clinic">>
 			<<if ($Nurse == 0) || ($Nurse.ID != $activeSlave.ID)>>
-				<<removeJob $activeSlave _currentRule.assignFacility>>
-				<<set $activeSlave.assignment = _currentRule.removalAssignment>>
-				<br>$activeSlave.slaveName has been removed from $clinicName and has been assigned to $activeSlave.assignment
+				<br>$activeSlave.slaveName has been removed from $clinicName and has been assigned to _currentRule.removalAssignment.
+				<<assignJob $activeSlave _currentRule.removalAssignment>>
 			<</if>>
 		<</if>>
 
 	<<case "mastersuite">>
 		<<if $activeSlave.assignment == "serve in the master suite">>
 			<<if ($Concubine == 0) || ($Concubine.ID != $activeSlave.ID)>>
-				<<removeJob $activeSlave _currentRule.assignFacility>>
-				<<set $activeSlave.assignment = _currentRule.removalAssignment>>
-				<br>$activeSlave.slaveName has been removed from $masterSuiteName and has been assigned to $activeSlave.assignment
+				<br>$activeSlave.slaveName has been removed from $masterSuiteName and has been assigned to _currentRule.removalAssignment.
+				<<assignJob $activeSlave _currentRule.removalAssignment>>
 			<</if>>
 		<</if>>
 
 	<<case "hgsuite">>
 		<<if $activeSlave.assignment == "live with your Head Girl">>
 			<<if ($HeadGirl == 0) || ($HeadGirl.ID != $activeSlave.ID)>>
-				<<removeJob $activeSlave _currentRule.assignFacility>>
-				<<set $activeSlave.assignment = _currentRule.removalAssignment>>
-				<br>$activeSlave.slaveName has been removed from $HGSuiteName and has been assigned to $activeSlave.assignment
+				<br>$activeSlave.slaveName has been removed from $HGSuiteName and has been assigned to _currentRule.removalAssignment.
+				<<assignJob $activeSlave _currentRule.removalAssignment>>
 			<</if>>
 		<</if>>
 
 	<<case "servantsquarters">>
 		<<if $activeSlave.assignment == "work as a servant">>
 			<<if ($Stewardess == 0) || ($Stewardess.ID != $activeSlave.ID)>>
-				<<removeJob $activeSlave _currentRule.assignFacility>>
-				<<set $activeSlave.assignment = _currentRule.removalAssignment>>
-				<br>$activeSlave.slaveName has been removed from $servantsQuartersName and has been assigned to $activeSlave.assignment
+				<br>$activeSlave.slaveName has been removed from $servantsQuartersName and has been assigned to _currentRule.removalAssignment.
+				<<assignJob $activeSlave _currentRule.removalAssignment>>
 			<</if>>
 		<</if>>
 
 	<<case "schoolroom">>
 		<<if $activeSlave.assignment == "learn in the schoolroom">>
 			<<if ($Schoolteacher == 0) || ($Schoolteacher.ID != $activeSlave.ID)>>
-				<<removeJob $activeSlave _currentRule.assignFacility>>
-				<<set $activeSlave.assignment = _currentRule.removalAssignment>>
-				<br>$activeSlave.slaveName has been removed from $schoolroomName and has been assigned to $activeSlave.assignment
+				<br>$activeSlave.slaveName has been removed from $schoolroomName and has been assigned to _currentRule.removalAssignment.
+				<<assignJob $activeSlave _currentRule.removalAssignment>>
 			<</if>>
 		<</if>>
 
 	<<case "cellblock">>
 		<<if $activeSlave.assignment == "be confined in the cellblock">>
 			<<if ($Wardeness == 0) || ($Wardeness.ID != $activeSlave.ID)>>
-				<<removeJob $activeSlave _currentRule.assignFacility>>
-				<<set $activeSlave.assignment = _currentRule.removalAssignment>>
-				<br>$activeSlave.slaveName has been removed from $cellblockName and has been assigned to $activeSlave.assignment
+				<br>$activeSlave.slaveName has been removed from $cellblockName and has been assigned to _currentRule.removalAssignment.
+				<<assignJob $activeSlave _currentRule.removalAssignment>>
 			<</if>>
 		<</if>>
 	<</switch>>

--- a/src/uncategorized/schoolteacherWorkaround.tw
+++ b/src/uncategorized/schoolteacherWorkaround.tw
@@ -3,28 +3,19 @@
 <<if $Schoolteacher != 0>>
 	<<set _ID = $Schoolteacher.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+			<<removeJob $slaves[_i] "be the Schoolteacher">>
+			<<break>>
+		<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<if $slaves[$i].ID == $HeadGirl.ID>>
-		<<set $HeadGirl = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Recruiter.ID>>
-		<<set $Recruiter = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Bodyguard.ID>>
-		<<set $Bodyguard = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $personalAttention>>
-		<<set $personalAttention = "business">>
-	<</if>>
-	<<set $slaves[$i].assignment = "be the Schoolteacher", $slaves[$i].assignmentVisible = 0, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0, $slaves[$i].livingRules = "luxurious">>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "be the Schoolteacher">>
+	<<set $slaves[$i].livingRules = "luxurious">>
 	<<set $Schoolteacher = $slaves[$i]>>
 <<else>>
 	<<set $Schoolteacher = 0>>
 <</if>>
 
 <<goto "Schoolroom">>
+

--- a/src/uncategorized/slaveAssignmentsReport.tw
+++ b/src/uncategorized/slaveAssignmentsReport.tw
@@ -74,7 +74,7 @@
 			<<set $HGCum = 2+Math.trunc(($HeadGirl.balls/5)+($HeadGirl.energy/95)+($HeadGirl.health/95)+($HeadGirl.devotion/95))>>
 		<</if>>
 	<<else>>
-		<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
+		<<removeJob $slaves[_i] "be your Head Girl">>
 	<</if>>
 <<case "live with your Head Girl">>
 	<<if random(-30,20) <= $slaves[_i].devotion>>
@@ -98,7 +98,7 @@
 		<<set $Recruiter = 0>>
 	<</if>>
 	<<if $Recruiter == 0>>
-		<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
+		<<removeJob $slaves[_i] "recruit girls">>
 	<</if>>
 <<case "be the Madam">>
 	<<set $Madam = $slaves[_i]>>
@@ -116,7 +116,7 @@
 		<<set $Madam = 0>>
 	<</if>>
 	<<if $Madam == 0>>
-		<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
+		<<removeJob $slaves[_i] "be the Madam">>
 	<</if>>
 <<case "be the DJ">>
 	<<set $DJ = $slaves[_i]>>
@@ -131,7 +131,7 @@
 		<<set $DJ = 0>>
 	<</if>>
 	<<if $DJ == 0>>
-		<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
+		<<removeJob $slaves[_i] "be the DJ">>
 	<</if>>
 <<case "be the Milkmaid">>
 	<<set $Milkmaid = $slaves[_i]>>
@@ -146,7 +146,7 @@
 		<<set $Milkmaid = 0>>
 	<</if>>
 	<<if $Milkmaid == 0>>
-		<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
+		<<removeJob $slaves[_i] "be the Milkmaid">>
 	<</if>>
 <<case "be the Stewardess">>
 	<<set $Stewardess = $slaves[_i]>>
@@ -164,7 +164,7 @@
 		<<set $Stewardess = 0>>
 	<</if>>
 	<<if $Stewardess == 0>>
-		<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
+		<<removeJob $slaves[_i] "be the Stewardess">>
 	<</if>>
 <<case "be the Schoolteacher">>
 	<<set $Schoolteacher = $slaves[_i]>>
@@ -179,7 +179,7 @@
 		<<set $Schoolteacher = 0>>
 	<</if>>
 	<<if $Schoolteacher == 0>>
-		<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
+		<<removeJob $slaves[_i] "be the Schoolteacher">>
 	<</if>>
 <<case "be the Wardeness">>
 	<<set $Wardeness = $slaves[_i]>>
@@ -191,7 +191,7 @@
 		<<set $Wardeness = 0>>
 	<</if>>
 	<<if $Wardeness == 0>>
-		<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
+		<<removeJob $slaves[_i] "be the Wardeness">>
 	<</if>>
 <<case "be the Attendant">>
 	<<set $Attendant = $slaves[_i]>>
@@ -203,7 +203,7 @@
 		<<set $Attendant = 0>>
 	<</if>>
 	<<if $Attendant == 0>>
-		<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
+		<<removeJob $slaves[_i] "be the Attendant">>
 	<</if>>
 <<case "be the Nurse">>
 	<<set $Nurse = $slaves[_i]>>
@@ -218,7 +218,7 @@
 		<<set $Nurse = 0>>
 	<</if>>
 	<<if $Nurse == 0>>
-		<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
+		<<removeJob $slaves[_i] "be the Nurse">>
 	<</if>>
 <<case "guard you">>
 	<<set $Bodyguard = $slaves[_i]>>
@@ -230,7 +230,7 @@
 		<<set $Bodyguard = 0>>
 	<</if>>
 	<<if $Bodyguard == 0>>
-		<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
+		<<removeJob $slaves[_i] "guard you">>
 	<</if>>
 <<case "be your Concubine">>
 	<<set $Concubine = $slaves[_i], $fuckSlaves++>>
@@ -251,12 +251,7 @@
 <<if $fighterIDs.includes($slaves[_i])>>
 	<<if canWalk($slaves[_i]) != true>>
 		''__@@.pink;$slaves[_i].slaveName@@__'' is no longer independently mobile @@.yellow;and cannot fight any more.@@ She has been removed from $pitName roster<br>.
-		<<for _k = 0; _k < $fighterIDs.length; _k++>>
-		<<if $slaves[_i].ID == $fighterIDs[_k]>>
-			<<set _dump = $fighterIDs.deleteAt(_k)>>
-			<<set _k-->>
-		<</if>>
-		<</for>>
+		<<set $fighterIDs.delete($slaves[_i].ID)>>
 	<</if>>
 <</if>>
 
@@ -344,21 +339,25 @@
 
 <<if $slavesVisible > 0>>
 <br>__''Penthouse Report''__<br>
-<<for $i = 0; $i < $slaves.length; $i++>>
+<<for $i = 0; $i < _SL; $i++>>
 <<if $slaves[$i].assignmentVisible == 1>>
 	<br>
 	<<include "Full Report">>
 	<<if ($slaves[$i].assignment == "be your Head Girl") && ($HGSuiteSlaves > 0)>>
 		<<set _iTemp = $i, $i = $HGSuiteiIDs[0].Index, _ID = $HGSuiteiIDs[0].ID>>
-		<<if $i >= $slaves.length || _ID != $slaves[$i].ID>>
+		<<if $i >= _SL || _ID != $slaves[$i].ID>>
 			/% Slaves.ID and $HGSuiteiIDs.ID's don't match-up so let's find her %/
-			<<for $i = 0; $i < $slaves.length; $i++>>
+			<<for $i = 0; $i < _SL; $i++>>
 			<<if _ID == $slaves[$i].ID>>
 				/% Correct the Index %/
 				<<set $HGSuiteiIDs[0].Index = $i>>
 				<<break>>
 			<</if>>
 			<</for>>
+		<</if>>
+		<<if $i < _SL && $slaves[$i].assignment != "live with your head girl">>
+			<br>@@.red;$slaves[$i].slaveName had been assigned to live with your Head Girl, but this week she was assigned to $slaves[$i].assignment. She has been released to your penthouse for reassignment.@@
+			<<removeJob $slaves[$i] "live with your head girl">>
 		<</if>>
 		/% Onward bound as normal %/
 		<<set $HGRelease = 1>>

--- a/src/uncategorized/slaveInteract.tw
+++ b/src/uncategorized/slaveInteract.tw
@@ -30,12 +30,6 @@
 	<<set $returnTo = "Clinic">>
 <</switch>>
 <</if>>
-<<if $activeSlave.amp == 1>>
-	<<switch $activeSlave.assignment>>
-	<<case "be the Madam" "be the DJ" "be the Milkmaid" "be the Attendant" "be the Schoolteacher" "be the Stewardess" "be the Wardeness" "be the Nurse">>
-		<<set $activeSlave.assignment = "rest">>
-	<</switch>>
-<</if>>
 
 <<set $encyclopedia = either("Drugs and Their Effects", "From Rebellious to Devoted", "Costs Summary", "Disease in the Free Cities", "Slave Couture", "Nymphomania", "Gender", "Independent Slaves", "Modern Anal")>>
 <<if $activeSlave.dick > 0>><<set $showEncyclopedia = 1, $encyclopedia = "Gender">><</if>>
@@ -258,16 +252,16 @@ __Rules Assistant__
 	//She is assigned to $activeSlave.assignment; bring her out of the facility to reassign her//
 <<else>>
 
-__Assignment__: <strong><span id="assign">$activeSlave.assignment</span>.</strong>
-<<link "Rest">><<set $activeSlave.assignment = "rest", $activeSlave.assignmentVisible = 1, $activeSlave.sentence = 0, $activeSlave.choosesOwnAssignment = 0>><<replace "#assign">>$activeSlave.assignment<</replace>><</link>>
-| <<link "Fucktoy">><<set $activeSlave.assignment = "please you", $activeSlave.assignmentVisible = 1, $activeSlave.sentence = 0, $activeSlave.choosesOwnAssignment = 0>><<replace "#assign">>$activeSlave.assignment<</replace>><</link>>
+__Assignment__: <strong><span id="assign">$activeSlave.assignment<<if $activeSlave.sentence>> ($activeSlave.sentence weeks)<</if>></span>.</strong>
+	  <<link "Rest">>                   <<removeJob $activeSlave $activeSlave.assignment>><<replace "#assign">>$activeSlave.assignment<</replace>><<SlaveInteractFucktoy>><</link>>
+	| <<link "Fucktoy">>                <<assignJob $activeSlave "please you">><<replace "#assign">>$activeSlave.assignment<</replace>><<SlaveInteractFucktoy>><</link>>
 <<if $activeSlave.fuckdoll == 0>>
 <<if (($activeSlave.devotion >= -20) || (($activeSlave.trust < -20) && ($activeSlave.devotion >= -50)) || ($activeSlave.trust < -50)) && canWalk($activeSlave)>>
-	| <<link "Subordinate slave">><<set $activeSlave.assignment = "be a subordinate slave", $activeSlave.assignmentVisible = 1, $activeSlave.sentence = 0, $activeSlave.choosesOwnAssignment = 0>><<goto "Subordinate Targeting">><</link>>
+	| <<link "Subordinate slave">>      <<assignJob $activeSlave "be a subordinate slave">><<goto "Subordinate Targeting">><</link>>
 	<<if ($activeSlave.eyes != -2)>>
-		| <<link "Servant">><<set $activeSlave.assignment = "be a servant", $activeSlave.assignmentVisible = 1, $activeSlave.sentence = 0, $activeSlave.choosesOwnAssignment = 0>><<replace "#assign">>$activeSlave.assignment<</replace>><</link>>
+	| <<link "Servant">>                <<assignJob $activeSlave "be a servant">><<replace "#assign">>$activeSlave.assignment<</replace>><<SlaveInteractFucktoy>><</link>>
 	<<else>>
-		/*| //Blind slaves cannot be servants// */
+	/*| //Blind slaves cannot be servants// */
 	<</if>>
 <</if>>
 <<if ($activeSlave.devotion >= -20) || (($activeSlave.devotion >= -50) && ($activeSlave.trust < -20)) || ($activeSlave.trust < -50)>>
@@ -324,7 +318,7 @@ __Assignment__: <strong><span id="assign">$activeSlave.assignment</span>.</stron
 	<<else>>Dairy<</if>>
 	<</if>>
 	<<if $servantsQuarters != 0>>|
-	<<if $servantsQuarters > $servantsQuartersSlaves && ($activeSlave.devotion >= -20) || (($activeSlave.devotion >= -50) && ($activeSlave.trust <= 20)) || ($activeSlave.trust < -20)>>
+	<<if $servantsQuarters > $servantsQuartersSlaves && canWalk($activeSlave) && canSee($activeSlave) && ($activeSlave.devotion >= -20 || ($activeSlave.devotion >= -50 && $activeSlave.trust <= 20) || $activeSlave.trust < -20)>>
 		[[Servants' Quarters|Assign][$slaves[_i] = $activeSlave, $returnTo = "Servants' Quarters", $i = _i]]
 	<<else>>Servants' Quarters<</if>>
 	<</if>>
@@ -334,7 +328,7 @@ __Assignment__: <strong><span id="assign">$activeSlave.assignment</span>.</stron
 	<<else>>Master Suite<</if>>
 	<</if>>
 	<<if $spa != 0>>|
-	<<if $spa > $spaSlaves && ($activeSlave.devotion >= -20 || $activeSlave.fetish == "mindbroken") && ($activeSlave.health < 20) || ($activeSlave.trust < 60) || ($activeSlave.devotion <= 60) || ($activeSlave.fetish == "mindbroken") || $activeSlave.sexualFlaw !== "none" || $activeSlave.behavioralFlaw !== "none">>
+	<<if $spa > $spaSlaves && ($activeSlave.devotion >= -20 || $activeSlave.fetish == "mindbroken") && ($activeSlave.health < 20 || $activeSlave.trust < 60 || $activeSlave.devotion <= 60 || $activeSlave.fetish == "mindbroken" || $activeSlave.sexualFlaw !== "none" || $activeSlave.behavioralFlaw !== "none")>>
 		[[Spa|Assign][$slaves[_i] = $activeSlave, $returnTo = "Spa", $i = _i]]
 	<<else>>Spa<</if>>
 	<</if>>
@@ -421,32 +415,14 @@ __Drugs__: <span id="drugs"><strong>$activeSlave.drugs</strong></span>.
 <br>
 
 __Health__: <span id="curatives"><strong><<if $activeSlave.curatives > 1>>curatives<<elseif $activeSlave.curatives > 0>>preventatives<<else>>none<</if>></strong></span>.
-<<if $activeSlave.curatives != 0>>
 	<<link "None">><<set $activeSlave.curatives = 0>><<replace "#curatives">><strong>none</strong><</replace>><</link>>
-<<else>>None<</if>>
-|
-<<if $activeSlave.curatives != 1>>
-	<<link "Preventatives">><<set $activeSlave.curatives = 1>><<replace "#curatives">><strong>preventatives</strong><</replace>><</link>>
-<<else>>Preventatives<</if>>
-|
-<<if $activeSlave.curatives != 2>>
-	<<link "Curatives">><<set $activeSlave.curatives = 2>><<replace "#curatives">><strong>curatives</strong><</replace>><</link>>
-<<else>>Curatives<</if>>
+	| <<link "Preventatives">><<set $activeSlave.curatives = 1>><<replace "#curatives">><strong>preventatives</strong><</replace>><</link>>
+	| <<link "Curatives">><<set $activeSlave.curatives = 2>><<replace "#curatives">><strong>curatives</strong><</replace>><</link>>
 
 __Aphrodisiacs__: <span id="aphrodisiacs"><strong><<if $activeSlave.aphrodisiacs > 1>>extreme<<elseif $activeSlave.aphrodisiacs > 0>>applied<<else>>none<</if>></strong></span>.
-<<if $activeSlave.aphrodisiacs != 0>>
 	<<link "None">><<set $activeSlave.aphrodisiacs = 0>><<replace "#aphrodisiacs">><strong>none</strong><</replace>><</link>>
-<<else>>None<</if>>
-|
-<<if $activeSlave.aphrodisiacs != 1>>
-	<<link "Apply">><<set $activeSlave.aphrodisiacs = 1>><<replace "#aphrodisiacs">><strong>applied</strong><</replace>><</link>>
-<<else>>Apply<</if>>
-|
-<<if $activeSlave.aphrodisiacs != 2>>
-	<<link "Extreme">><<set $activeSlave.aphrodisiacs = 2>><<replace "#aphrodisiacs">><strong>extreme</strong><</replace>><</link>>
-<<else>>Extreme<</if>>
-
-<</if>>
+	| <<link "Apply">><<set $activeSlave.aphrodisiacs = 1>><<replace "#aphrodisiacs">><strong>applied</strong><</replace>><</link>>
+	| <<link "Extreme">><<set $activeSlave.aphrodisiacs = 2>><<replace "#aphrodisiacs">><strong>extreme</strong><</replace>><</link>>
 
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
 <span id="fertilityblock">
@@ -488,12 +464,14 @@ __Hormones__: <strong><span id="hormones">
 <<link "Male">><<set $activeSlave.hormones = -1>><<replace "#hormones">>male<</replace>><</link>> |
 <<link "Male ++">><<set $activeSlave.hormones = -2>><<replace "#hormones">>intensive male<</replace>><</link>>
 
+<</if>> /* closes drugs (assignmentVisible == 0) */
+
 <br>__Diet__: <strong><span id="diet">$activeSlave.diet</span></strong>.
 <<link "Healthy">><<set $activeSlave.diet = "healthy">><<replace "#diet">>$activeSlave.diet<</replace>><</link>>
 <<if ($activeSlave.weight >= -95)>>
 | <<link "Lose weight">><<set $activeSlave.diet = "restricted">><<replace "#diet">>$activeSlave.diet<</replace>><</link>>
 <<else>>
-| //She is already thin//
+| //She is already underweight//
 <</if>>
 <<if $activeSlave.weight <= 95>>
 | <<link "Fatten">><<set $activeSlave.diet = "fattening">><<replace "#diet">>$activeSlave.diet<</replace>><</link>>
@@ -603,12 +581,12 @@ __Hormones__: <strong><span id="hormones">
 <</if>>
 
 <<if $activeSlave.clitPiercing == 3>>
-<br>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
 <<if $activeSlave.dick < 1>>Her smart clit piercing is set to
 <<else>>Her smart frenulum piercing is set to
 <</if>>
 <strong><span id="setting">$activeSlave.clitSetting</span></strong>.
-<br>&nbsp;&nbsp;&nbsp;&nbsp;<<link "Vanilla">><<set $activeSlave.clitSetting = "vanilla">><<replace "#setting">>$activeSlave.clitSetting<</replace>><</link>>
+&nbsp;&nbsp;&nbsp;&nbsp;<<link "Vanilla">><<set $activeSlave.clitSetting = "vanilla">><<replace "#setting">>$activeSlave.clitSetting<</replace>><</link>>
 | <<link "Oral">><<set $activeSlave.clitSetting = "oral">><<replace "#setting">>$activeSlave.clitSetting<</replace>><</link>>
 | <<link "Anal">><<set $activeSlave.clitSetting = "anal">><<replace "#setting">>$activeSlave.clitSetting<</replace>><</link>>
 | <<link "Boobs">><<set $activeSlave.clitSetting = "boobs">><<replace "#setting">>$activeSlave.clitSetting<</replace>><</link>>
@@ -693,7 +671,7 @@ __Hormones__: <strong><span id="hormones">
 <br>__Collar__: ''<span id="collar">$activeSlave.collar</span>.''
 <<link "None">><<set $activeSlave.collar = "none">><<replace "#collar">>$activeSlave.collar<</replace>><</link>>
 | <<link "Tight steel">><<set $activeSlave.collar = "tight steel">><<replace "#collar">>$activeSlave.collar<</replace>><</link>>
-<<if ($seeAge == 1)>>
+<<if ($seeAge != 0)>>
 	| <<link "Cruel retirement counter">><<set $activeSlave.collar = "cruel retirement counter">><<replace "#collar">>$activeSlave.collar<</replace>><</link>>
 <</if>>
 | <<link "Uncomfortable leather">><<set $activeSlave.collar = "uncomfortable leather">><<replace "#collar">>$activeSlave.collar<</replace>><</link>>
@@ -704,7 +682,7 @@ __Hormones__: <strong><span id="hormones">
 | <<link "Satin choker">><<set $activeSlave.collar = "satin choker">><<replace "#collar">>$activeSlave.collar<</replace>><</link>>
 | <<link "Heavy gold">><<set $activeSlave.collar = "heavy gold">><<replace "#collar">>$activeSlave.collar<</replace>><</link>>
 | <<link "Pretty jewelry">><<set $activeSlave.collar = "pretty jewelry">><<replace "#collar">>$activeSlave.collar<</replace>><</link>>
- <<if ($seeAge == 1)>>
+ <<if ($seeAge != 0)>>
 	| <<link "Nice retirement counter">><<set $activeSlave.collar = "nice retirement counter">><<replace "#collar">>$activeSlave.collar<</replace>><</link>>
 <</if>>
 | <<link "Leather with cowbell">><<set $activeSlave.collar = "leather with cowbell">><<replace "#collar">>$activeSlave.collar<</replace>><</link>>
@@ -728,7 +706,7 @@ __Hormones__: <strong><span id="hormones">
 <<link "None">><<set $activeSlave.bellyAccessory = "none">><<replace "#bellyAccessory">>$activeSlave.bellyAccessory<</replace>><</link>>
 | <<link "Tight corset">><<set $activeSlave.bellyAccessory = "a corset">><<replace "#bellyAccessory">>$activeSlave.bellyAccessory<</replace>><</link>>
 | <<link "Extreme corset">><<set $activeSlave.bellyAccessory = "an extreme corset">><<replace "#bellyAccessory">>$activeSlave.bellyAccessory<</replace>><</link>>
-<<if $clothesBoughtBelly == 1 || $cheatMode == 1>>
+<<if $clothesBoughtBelly == 1 || $cheatMode == 1 && $activeSlave.preg <= 10>>
 | <<link "1st Trimester">><<set $activeSlave.bellyAccessory = "a small empathy belly">><<replace "#bellyAccessory">>$activeSlave.bellyAccessory<</replace>><</link>>
 | <<link "2nd Trimester">><<set $activeSlave.bellyAccessory = "a medium empathy belly">><<replace "#bellyAccessory">>$activeSlave.bellyAccessory<</replace>><</link>>
 | <<link "3rd Trimester">><<set $activeSlave.bellyAccessory = "a large empathy belly">><<replace "#bellyAccessory">>$activeSlave.bellyAccessory<</replace>><</link>>
@@ -741,13 +719,14 @@ __Hormones__: <strong><span id="hormones">
 | <<link "Large">><<set $activeSlave.buttplug = "large plug">><<replace "#buttplug">>$activeSlave.buttplug<</replace>><</link>>
 <<if $activeSlave.anus >= 2>>| <<link "Huge">><<set $activeSlave.buttplug = "huge plug">><<replace "#buttplug">>$activeSlave.buttplug<</replace>><</link>><</if>>
 <<if $activeSlave.vagina > -1>>
-&nbsp;&nbsp;&nbsp;&nbsp;<<if $activeSlave.dick == 0>>__Accessory__<<else>>__Vaginal accessory__<</if>>: ''<span id="vaginalAccessory">$activeSlave.vaginalAccessory</span>.''
+<br><<if $activeSlave.dick == 0>>__Accessory__<<else>>__Vaginal accessory__<</if>>: ''<span id="vaginalAccessory">$activeSlave.vaginalAccessory</span>.''
 <<link "None">><<set $activeSlave.vaginalAccessory = "none">><<replace "#vaginalAccessory">>$activeSlave.vaginalAccessory<</replace>><<SlaveInteractImpreg>><<SlaveInteractFertility>><<SlaveInteractSexOption>><<SlaveInteractAnalSexOption>><<SlaveInteractGropeOption>><<SlaveInteractDickGropeOption>><<SlaveInteractAnalGropeOption>><</link>>
 | <<link "Dildo">><<set $activeSlave.vaginalAccessory = "dildo">><<replace "#vaginalAccessory">>$activeSlave.vaginalAccessory<</replace>><</link>>
 | <<link "Large dildo">><<set $activeSlave.vaginalAccessory = "large dildo">><<replace "#vaginalAccessory">>$activeSlave.vaginalAccessory<</replace>><</link>>
 <<if $activeSlave.vagina >= 2>>| <<link "Huge dildo">><<set $activeSlave.vaginalAccessory = "huge dildo">><<replace "#vaginalAccessory">>$activeSlave.vaginalAccessory<</replace>><</link>><</if>>
 | <<link "Chastity belt">><<set $activeSlave.vaginalAccessory = "chastity belt">><<replace "#vaginalAccessory">>$activeSlave.vaginalAccessory<</replace>><<SlaveInteractImpreg>><<SlaveInteractFertility>><<SlaveInteractSexOption>><<SlaveInteractAnalSexOption>><<SlaveInteractGropeOption>><<SlaveInteractDickGropeOption>><<SlaveInteractAnalGropeOption>><</link>>
 | <<link "Anal chastity belt">><<set $activeSlave.vaginalAccessory = "anal chastity">><<replace "#vaginalAccessory">>$activeSlave.vaginalAccessory<</replace>><<SlaveInteractSexOption>><<SlaveInteractAnalSexOption>><<SlaveInteractGropeOption>><<SlaveInteractDickGropeOption>><<SlaveInteractAnalGropeOption>><</link>>
+
 | <<link "Combined chastity belt">><<set $activeSlave.vaginalAccessory = "combined chastity">><<replace "#vaginalAccessory">>$activeSlave.vaginalAccessory<</replace>><<SlaveInteractImpreg>><<SlaveInteractFertility>><<SlaveInteractSexOption>><<SlaveInteractAnalSexOption>><<SlaveInteractGropeOption>><<SlaveInteractDickGropeOption>><<SlaveInteractAnalGropeOption>><</link>>
 <</if>>
 <<if $activeSlave.dick > 0>>
@@ -792,7 +771,7 @@ __Hormones__: <strong><span id="hormones">
 
 <<if (_SL > 1)>>
 	[[Sell her|Sell Slave][$cash -= 500]] //Listing her for sale will cost ¤500// |
-	<<if ($seeAge == 1) && ($activeSlave.indenture < 1)>>
+	<<if ($seeAge != 0) && ($activeSlave.indenture < 1)>>
 	<<if ($retiree == 0)>>
 		[[Retire her|Slave Interact][$retiree = $activeSlave, $manuallyRetired = 1]] |
 	<<else>>

--- a/src/uncategorized/slaveInteract.tw
+++ b/src/uncategorized/slaveInteract.tw
@@ -424,6 +424,8 @@ __Aphrodisiacs__: <span id="aphrodisiacs"><strong><<if $activeSlave.aphrodisiacs
 	| <<link "Apply">><<set $activeSlave.aphrodisiacs = 1>><<replace "#aphrodisiacs">><strong>applied</strong><</replace>><</link>>
 	| <<link "Extreme">><<set $activeSlave.aphrodisiacs = 2>><<replace "#aphrodisiacs">><strong>extreme</strong><</replace>><</link>>
 
+<</if>> /* closes drugs (assignmentVisible == 0) */
+
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
 <span id="fertilityblock">
 <<if ($activeSlave.preg < -1) || ($activeSlave.ovaries == 0)>>
@@ -463,8 +465,6 @@ __Hormones__: <strong><span id="hormones">
 <<link "None">><<set $activeSlave.hormones = 0>><<replace "#hormones">>none<</replace>><</link>> |
 <<link "Male">><<set $activeSlave.hormones = -1>><<replace "#hormones">>male<</replace>><</link>> |
 <<link "Male ++">><<set $activeSlave.hormones = -2>><<replace "#hormones">>intensive male<</replace>><</link>>
-
-<</if>> /* closes drugs (assignmentVisible == 0) */
 
 <br>__Diet__: <strong><span id="diet">$activeSlave.diet</span></strong>.
 <<link "Healthy">><<set $activeSlave.diet = "healthy">><<replace "#diet">>$activeSlave.diet<</replace>><</link>>

--- a/src/uncategorized/slaveSummary.tw
+++ b/src/uncategorized/slaveSummary.tw
@@ -24,25 +24,29 @@
 	<<print "[[_Slave.slaveName|Personal Attention Select][$personalAttention = $slaves["+_i+"].ID, $activeSlave = $slaves["+_i+"], $personalAttentionChanged = 1]]">>
 <<case "Agent Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.assignment != "guard you") && (_Slave.assignment != "recruit girls") && (_Slave.assignment != "be your Head Girl") && (_Slave.devotion >= 20) && (_Slave.intelligence > 0) && (_Slave.intelligenceImplant > 0) && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Agent Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Agent Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
 <<case "BG Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "guard you") && (_Slave.assignment != "recruit girls") && (_Slave.assignment != "be your Head Girl") && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Bodyguard Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Bodyguard Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
 <<case "Recruiter Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "guard you") && (_Slave.assignment != "recruit girls") && (_Slave.assignment != "be your Head Girl") && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Recruiter Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Recruiter Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
 <<case "HG Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "guard you") && (_Slave.assignment != "recruit girls") && (_Slave.assignment != "be your Head Girl") && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|HG Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|HG Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
@@ -50,7 +54,8 @@
 <<if _Slave.fuckdoll > 0>><<continue>><</if>>
 <<if $Flag == 0>>
 	<<if (_Slave.assignmentVisible == 1) && (_Slave.assignment != "be your Head Girl") && (_Slave.indentureRestrictions <= 0)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<<else>>
 		<<continue>>
 	<</if>>
@@ -58,12 +63,14 @@
 	<<if _Slave.assignment != "live with your Head Girl">>
 		<<continue>>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <</if>>
 <<case "Subordinate Targeting">>
 <<if (_Slave.devotion >= -20) && (_Slave.fuckdoll == 0) && ($activeSlave.ID != _Slave.ID)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Subordinate Targeting][$activeSlave.subTarget = $slaves["+_i+"].ID]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Subordinate Targeting][$activeSlave.subTarget = $slaves["+_i+"].ID]]">>
 <<else>>
 	<<continue>>
 <</if>>
@@ -73,7 +80,8 @@
 	<<if _Slave.assignment == "rest in the spa">><<continue>><</if>>
 	<<if (_Slave.health < 20) || (_Slave.trust < 60) || (_Slave.devotion <= 60) || (_Slave.fetish == "mindbroken") || _Slave.sexualFlaw !== "none" || _Slave.behavioralFlaw !== "none">>
 	<<if _Slave.devotion >= -20 || _Slave.fetish == "mindbroken">>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<<else>>
 		<br>//_Slave.slaveName cannot be trusted in the spa//
 		<<continue>>
@@ -86,7 +94,8 @@
 	<<if _Slave.assignment != "rest in the spa">>
 		<<continue>>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <<else>>
 	<<if _Slave.ID != $Attendant.ID>>
@@ -97,7 +106,8 @@
 <</if>>
 <<case "Attendant Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Attendant Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Attendant Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
@@ -106,7 +116,8 @@
 <<if $Flag == 0>>
 	<<if _Slave.assignment == "work in the brothel">><<continue>><</if>>
 	<<if (_Slave.devotion > 50) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) ||  (_Slave.trust < -50) || (_Slave.trust > 50)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt $slaves[_i] 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves[" + _i + "]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves[" + _i + "]]]">>
 	<<else>>
 		<br>//_Slave.slaveName must be either more fearful of you or devoted to you//
 		<<continue>>
@@ -115,7 +126,8 @@
 	<<if _Slave.assignment != "work in the brothel">>
 		<<continue>>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <<else>>
 	<<if _Slave.ID != $Madam.ID>>
@@ -126,7 +138,8 @@
 <</if>>
 <<case "Madam Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Madam Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Madam Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
@@ -135,7 +148,8 @@
 <<if $Flag == 0>>
 	<<if _Slave.assignment == "serve in the club">><<continue>><</if>>
 	<<if (_Slave.devotion > 50) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50) || (_Slave.trust > 50)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<<else>>
 		<br>//_Slave.slaveName must be either more fearful of you or devoted to you//
 		<<continue>>
@@ -144,18 +158,21 @@
 	<<if _Slave.assignment != "serve in the club">>
 		<<continue>>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <<else>>
 	<<if _Slave.ID != $DJ.ID>>
 		<<continue>>
 	<<else>>
-		<<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <</if>>
 <<case "DJ Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|DJ Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|DJ Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
@@ -164,7 +181,8 @@
 <<if $Flag == 0>>
 	<<if _Slave.assignment == "get treatment in the clinic">><<continue>><</if>>
 	<<if (_Slave.health < 20) || (($Nurse != 0) && (_Slave.chem > 0) && ($clinicUpgradeFilters == 1))>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<<else>>
 		<br>//_Slave.slaveName cannot benefit from the clinic//
 		<<continue>>
@@ -173,18 +191,21 @@
 	<<if _Slave.assignment != "get treatment in the clinic">>
 		<<continue>>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <<else>>
 	<<if _Slave.ID != $Nurse.ID>>
 		<<continue>>
 	<<else>>
-		<<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <</if>>
 <<case "Nurse Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Nurse Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Nurse Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
@@ -194,7 +215,8 @@
 	<<if _Slave.assignment == "learn in the schoolroom">><<continue>><</if>>
 	<<if (_Slave.devotion >= -20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50)>>
 		<<if (_Slave.intelligenceImplant < 1) || (_Slave.voice != 0 && _Slave.accent+$schoolroomUpgradeLanguage > 2) || (_Slave.oralSkill <= 10+$schoolroomUpgradeSkills*20) || (_Slave.whoreSkill <= 10+$schoolroomUpgradeSkills*20) || (_Slave.entertainSkill <= 10+$schoolroomUpgradeSkills*20) || (_Slave.analSkill < 10+$schoolroomUpgradeSkills*20) || ((_Slave.vagina >= 0) && (_Slave.vaginalSkill < 10+$schoolroomUpgradeSkills*20))>>
-			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 		<<else>>
 			<br>//_Slave.slaveName already has a basic education//
 			<<continue>>
@@ -207,18 +229,21 @@
 	<<if _Slave.assignment != "learn in the schoolroom">>
 		<<continue>>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <<else>>
 	<<if _Slave.ID != $Schoolteacher.ID>>
 		<<continue>>
 	<<else>>
-		<<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <</if>>
 <<case "Schoolteacher Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canTalk(_Slave) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Schoolteacher Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Schoolteacher Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
@@ -237,7 +262,8 @@
 			<<if (_Slave.devotion > 20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) ||  (_Slave.trust < -50) || (_Slave.amp == 1) || ($dairyRestraintsUpgrade == 1)>>
 				<<if ($dairyStimulatorsSetting < 2) || (_Slave.anus > 2) || ($dairyPrepUpgrade == 1)>>
 					<<if ($dairyPregSetting < 2) || (_Slave.vagina > 2) || (_Slave.ovaries == 0) || ($dairyPrepUpgrade == 1)>>
-						<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+						<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+						<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 						<<else>>
 							<br>//_Slave.slaveName's vagina cannot accommodate current machine settings//
 							<<continue>>
@@ -262,18 +288,21 @@
 	<<if _Slave.assignment != "work in the dairy">>
 		<<continue>>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <<else>>
 	<<if _Slave.ID != $Milkmaid.ID>>
 		<<continue>>
 	<<else>>
-		<<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <</if>>
 <<case "Milkmaid Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 20) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Milkmaid Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Milkmaid Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
@@ -282,7 +311,8 @@
 <<if $Flag == 0>>
 	<<if _Slave.assignment == "work as a servant">><<continue>><</if>>
 	<<if (_Slave.devotion >= -20) || ((_Slave.devotion >= -50) && (_Slave.trust <= 20)) || (_Slave.trust < -20)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<<else>>
 		<br>//_Slave.slaveName must be either more fearful of you or devoted to you//
 		<<continue>>
@@ -291,18 +321,21 @@
 	<<if _Slave.assignment != "work as a servant">>
 		<<continue>>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <<else>>
 	<<if _Slave.ID != $Stewardess.ID>>
 		<<continue>>
 	<<else>>
-		<<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <</if>>
 <<case "Stewardess Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Stewardess Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Stewardess Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
@@ -310,7 +343,8 @@
 <<if $Flag == 0>>
 	<<if _Slave.assignment == "serve in the master suite">><<continue>><</if>>
 	<<if (_Slave.devotion > 20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt $slaves[_i] 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves[" + _i + "]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves[" + _i + "]]]">>
 	<<else>>
 		<br>//_Slave.slaveName is not sufficiently broken for the master suite//
 		<<continue>>
@@ -326,12 +360,14 @@
 	<<if _Slave.ID != $Concubine.ID>>
 		<<continue>>
 	<<else>>
-		<<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <</if>>
 <<case "Concubine Select">>
 <<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Concubine Workaround][$i = "+_i+"]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Concubine Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
@@ -339,7 +375,8 @@
 <<if $Flag == 0>>
 	<<if _Slave.assignment == "be confined in the cellblock">><<continue>><</if>>
 	<<if (_Slave.assignment != "be confined in the cellblock") && ((_Slave.devotion < -20) && (_Slave.trust >= -20)) || ((_Slave.devotion < -50) && (_Slave.trust >= -50))>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<<else>>
 		<<continue>>
 	<</if>>
@@ -347,13 +384,15 @@
 	<<if _Slave.assignment != "be confined in the cellblock">>
 		<<continue>>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <<else>>
 	<<if _Slave.ID != $Wardeness.ID>>
 		<<continue>>
 	<<else>>
-		<<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <</if>>
 <<case "Wardeness Select">>
@@ -367,7 +406,8 @@
 <<if $Flag == 0>>
 	<<if (_Slave.assignmentVisible != 1) || (($arcade <= $arcadeSlaves) && ($arcadeUpgradeFuckdolls != 1))>><<continue>><</if>>
 	<<if (_Slave.indentureRestrictions <= 0)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<<else>>
 		<br>//_Slave.slaveName's indenture forbids arcade service.//
 		<<continue>>
@@ -376,7 +416,8 @@
 	<<if _Slave.assignment != "be confined in the arcade">>
 		<<continue>>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<</if>>
 <</if>>
 <<case "Pit">>
@@ -393,7 +434,8 @@
 			<<if ($fighterIDs.includes(_Slave.ID))>>
 				<<continue>>
 			<<else>>
-				<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Assign][$i = "+_i+"]]">>
+				<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+				<<print "[[_Slave.slaveName|Assign][$i = "+_i+"]]">>
 			<</if>>
 		<<else>>
 			<<continue>>
@@ -403,7 +445,8 @@
 	<</if>>
 <<else>>
 	<<if $fighterIDs.includes(_Slave.ID)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Retrieve][$i = "+_i+"]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Retrieve][$i = "+_i+"]]">>
 	<<else>>
 		<<continue>>
 	<</if>>
@@ -412,7 +455,8 @@
 <<if _Slave.fuckdoll > 0>><<continue>><</if>>
 <<if $Flag == 0>>
 	<<if canWalk(_Slave) && ($Lurcher.ID != _Slave.ID)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Assign][$i = "+_i+"]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Assign][$i = "+_i+"]]">>
 	<<else>>
 		<<continue>>
 	<</if>>
@@ -420,7 +464,8 @@
 	<<if $Lurcher.ID != _Slave.ID>>
 		<<continue>>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Retrieve][$i = "+_i+"]]">>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_Slave.slaveName|Retrieve][$i = "+_i+"]]">>
 	<</if>>
 <</if>>
 <<case "New Game Plus">>
@@ -441,14 +486,14 @@
 <<if $Flag == 0>>
 	<<if !ruleSlaveSelected(_Slave, $currentRule)>>
 		<br>__''
-		<<print "[[_Slave.slaveName|Rules Slave Select Workaround][$activeSlave = $slaves["+_i+"]]]">>
+		<<print "[[_Slave.slaveName|Rules Slave Select Workaround][$activeSlave = $slaves["+_i+"]]]">>''__
 	<<else>>
 		<<continue>>
 	<</if>>
 <<else>>
 	<<if ruleSlaveSelected(_Slave, $currentRule)>>
 		<br>__''
-		<<print "[[_Slave.slaveName|Rules Slave Deselect Workaround][$activeSlave = $slaves["+_i+"]]]">>
+		<<print "[[_Slave.slaveName|Rules Slave Deselect Workaround][$activeSlave = $slaves["+_i+"]]]">>''__
 	<<else>>
 		<<continue>>
 	<</if>>
@@ -457,22 +502,25 @@
 <<if $Flag == 0>>
 	<<if !ruleSlaveExcluded(_Slave, $currentRule)>>
 		<br>__''
-		<<print "[[_Slave.slaveName|Rules Slave Exclude Workaround][$activeSlave = $slaves["+_i+"]]]">>
+		<<print "[[_Slave.slaveName|Rules Slave Exclude Workaround][$activeSlave = $slaves["+_i+"]]]">>''__
 	<<else>>
 		<<continue>>
 	<</if>>
 <<else>>
 	<<if ruleSlaveExcluded(_Slave, $currentRule)>>
 		<br>__''
-		<<print "[[_Slave.slaveName|Rules Slave NoExclude Workaround][$activeSlave = $slaves["+_i+"]]]">>
+		<<print "[[_Slave.slaveName|Rules Slave NoExclude Workaround][$activeSlave = $slaves["+_i+"]]]">>''__
 	<<else>>
 		<<continue>>
 	<</if>>
 <</if>>
 <<case "Matchmaking">>
 	<<if ($slaves[_i].assignmentVisible != 1) || ($slaves[_i].devotion < 100) || ($slaves[_i].relationship != $activeSlave.relationship) || ($slaves[_i].ID == $activeSlave.ID)>><<continue>><</if>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
+	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+	<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 <</switch>>
+
+<<set _Slave.energy = Math.clamp(_Slave.energy, 0, 100)>>
 
 <<if _Slave.devotion > 100>>
 	<<if _Slave.trust < -95>>

--- a/src/uncategorized/stewardessWorkaround.tw
+++ b/src/uncategorized/stewardessWorkaround.tw
@@ -3,28 +3,19 @@
 <<if $Stewardess != 0>>
 	<<set _ID = $Stewardess.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+			<<removeJob $slaves[_i] "be the Stewardess">>
+			<<break>>
+		<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<if $slaves[$i].ID == $HeadGirl.ID>>
-		<<set $HeadGirl = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Recruiter.ID>>
-		<<set $Recruiter = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Bodyguard.ID>>
-		<<set $Bodyguard = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $personalAttention>>
-		<<set $personalAttention = "business">>
-	<</if>>
-	<<set $slaves[$i].assignment = "be the Stewardess", $slaves[$i].assignmentVisible = 0, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0, $slaves[$i].livingRules = "luxurious">>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "be the Stewardess">>
+	<<set $slaves[$i].livingRules = "luxurious">>
 	<<set $Stewardess = $slaves[$i]>>
 <<else>>
 	<<set $Stewardess = 0>>
 <</if>>
 
 <<goto "Servants' Quarters">>
+

--- a/src/uncategorized/subordinateTargeting.tw
+++ b/src/uncategorized/subordinateTargeting.tw
@@ -1,7 +1,6 @@
 :: Subordinate Targeting [nobr]
 
-<<set $nextButton = "Back">>
-<<set $nextLink = "Slave Interact">>
+<<set $nextButton = "Back", $nextLink = "Slave Interact">>
 
 <<set $displaySlave = $activeSlave>>
 
@@ -25,4 +24,5 @@
 <br><br>[[None|Subordinate Targeting][$activeSlave.subTarget = 0]]
 
 <<set $activeSlave = $displaySlave>>
-<<set $activeSlave.assignment = "be a subordinate slave">>
+<<assignJob $activeSlave "be a subordinate slave">>
+

--- a/src/uncategorized/wardenessWorkaround.tw
+++ b/src/uncategorized/wardenessWorkaround.tw
@@ -3,28 +3,19 @@
 <<if $Wardeness != 0>>
 	<<set _ID = $Wardeness.ID, _SL = $slaves.length>>
 	<<for _i = 0; _i < _SL; _i++>>
-		<<if (_ID == $slaves[_i].ID)>><<break>><</if>>
+		<<if (_ID == $slaves[_i].ID)>>
+			<<removeJob $slaves[_i] "be the Wardeness">>
+			<<break>>
+		<</if>>
 	<</for>>
-	<<set $slaves[_i].assignment = "rest", $slaves[_i].assignmentVisible = 1>>
 <</if>>
 <<if $i > -1>>
-	<<if $slaves[$i].ID == $HeadGirl.ID>>
-		<<set $HeadGirl = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Recruiter.ID>>
-		<<set $Recruiter = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $Bodyguard.ID>>
-		<<set $Bodyguard = 0>>
-	<</if>>
-	<<if $slaves[$i].ID == $personalAttention>>
-		<<set $personalAttention = "business">>
-	<</if>>
-	<<set $slaves[$i].assignment = "be the Wardeness", $slaves[$i].assignmentVisible = 0, $slaves[$i].choosesOwnAssignment = 0, $slaves[$i].sentence = 0, $slaves[$i].livingRules = "luxurious">>
-	<<if $slaves[$i].choosesOwnClothes == 1>><<include "SA chooses own clothes">><</if>>
+	<<assignJob $slaves[$i] "be the Wardeness">>
+	<<set $slaves[$i].livingRules = "luxurious">>
 	<<set $Wardeness = $slaves[$i]>>
 <<else>>
 	<<set $Wardeness = 0>>
 <</if>>
 
 <<goto "Cellblock">>
+

--- a/src/uncategorized/whoreWorkaround.tw
+++ b/src/uncategorized/whoreWorkaround.tw
@@ -1,4 +1,6 @@
 :: Whore Workaround [silently]
 
-<<set $slaves[$i].assignment = "whore", $slaves[$i].choosesOwnAssignment = 0>>
+<<assignJob $slaves[$i] "whore">>
+
 <<goto "Main">>
+

--- a/src/utility/assignWidgets.tw
+++ b/src/utility/assignWidgets.tw
@@ -10,196 +10,142 @@
 <<widget assignJob>>
 <<if ($args[1] != "Pit") && ($args[1] != "Coursing Association")>>
 
-<<removeJob $args[0] $args[0].assignment>>
+	<<removeJob $args[0] $args[0].assignment>>
 
-<<set _wID = $args[0].ID, _SL = $slaves.length>>
+	/% use .toLowerCase() to get rid of a few dupe conditions. %/
+	<<switch $args[1].toLowerCase()>>
+		<<case "be confined in the arcade" "arcade">>
+			<<set $args[0].assignment = "be confined in the arcade",    $args[0].assignmentVisible = 0, $arcadeSlaves++, $ArcadeiIDs.push({ID: _wID, Index: _wi})>>
+		<<case "work in the brothel" "brothel">>
+			<<set $args[0].assignment = "work in the brothel",          $args[0].assignmentVisible = 0, $brothelSlaves++, $BrothiIDs.push({ID: _wID, Index: _wi})>>
+		<<case "be confined in the cellblock" "cellblock">>
+			<<set $args[0].assignment = "be confined in the cellblock", $args[0].assignmentVisible = 0, $cellblockSlaves++, $CellBiIDs.push({ID: _wID, Index: _wi})>>
+		<<case "get treatment in the clinic" "clinic">>
+			<<set $args[0].assignment = "get treatment in the clinic",  $args[0].assignmentVisible = 0, $clinicSlaves++, $CliniciIDs.push({ID: _wID, Index: _wi})>>
+		<<case "serve in the club" "club">>
+			<<set $args[0].assignment = "serve in the club",            $args[0].assignmentVisible = 0, $clubSlaves++, $ClubiIDs.push({ID: _wID, Index: _wi})>>
+		<<case "work in the dairy" "dairy">>
+			<<set $args[0].assignment = "work in the dairy",            $args[0].assignmentVisible = 0, $dairySlaves++, $DairyiIDs.push({ID: _wID, Index: _wi})>>
+		<<case "live with your head girl" "head girl suite" "hgsuite">>
+			<<set $args[0].assignment = "live with your Head Girl",     $args[0].assignmentVisible = 0, $HGSuiteSlaves++, $HGSuiteiIDs.push({ID: _wID, Index: _wi})>>
+		<<case "serve in the master suite" "master suite" "mastersuite">>
+			<<set $args[0].assignment = "serve in the master suite",    $args[0].assignmentVisible = 0, $masterSuiteSlaves++, $MastSiIDs.push({ID: _wID, Index: _wi})>>
+		<<case "learn in the schoolroom" "schoolroom">>
+			<<set $args[0].assignment = "learn in the schoolroom",      $args[0].assignmentVisible = 0, $schoolroomSlaves++, $SchlRiIDs.push({ID: _wID, Index: _wi})>>
+		<<case "work as a servant" "servants' quarters" "servantsquarters">>
+			<<set $args[0].assignment = "work as a servant",            $args[0].assignmentVisible = 0, $servantsQuartersSlaves++, $ServQiIDs.push({ID: _wID, Index: _wi})>>
+		<<case "rest in the spa" "spa">>
+			<<set $args[0].assignment = "rest in the spa",              $args[0].assignmentVisible = 0, $spaSlaves++, $SpaiIDs.push({ID: _wID, Index: _wi})>>
+		<<case "be the attendant" "be your concubine" "be the dj" "be the madam" "be the milkmaid" "be the nurse" "be the schoolteacher" "be the stewardess" "be the wardeness" "be your agent" "live with your agent">>
+			<<set $args[0].assignment = $args[1],                       $args[0].assignmentVisible = 0>>     /* non-visible leadership roles */
+		<<case "choose her own job">>
+			<<set $args[0].assignment = $args[1],                       $args[0].choosesOwnAssignment = 1>>  /* removeJob already set assignmentVisible = 1 */
+		<<default>>
+			<<set $args[0].assignment = $args[1]>>                      /* removeJob already set assignmentVisible = 1 and choosesOwnAssignment = 0 */
+	<</switch>>
 
-/% Get slaves[_wi] index # %/
-<<if $i < _SL && _wID == $slaves[$i].ID>>
-	<<set _wi = $i>>
-<<else>>
-	<<for _wi = 0; _wi < _SL; _wi++>>
-		<<if _wID == $slaves[_wi].ID>>
-			<<break>>
-		<</if>>
-	<</for>>
-<</if>>
+	<<if _wID == $personalAttention>>
+		<<set $personalAttention = "business">>
+	<</if>>
 
-/% use .toLowerCase() to get rid of a few dupe conditions. %/
-<<switch $args[1].toLowerCase()>>
-<<case "clinic" "get treatment in the clinic">>
-	<<set $args[0].assignment = "get treatment in the clinic",  $args[0].assignmentVisible = 0, $clinicSlaves++, $CliniciIDs.push({ID: _wID, Index: _wi})>>
-<<case "schoolroom" "learn in the schoolroom">>
-	<<set $args[0].assignment = "learn in the schoolroom",      $args[0].assignmentVisible = 0, $schoolroomSlaves++, $SchlRiIDs.push({ID: _wID, Index: _wi})>>
-<<case "spa" "rest in the spa">>
-	<<set $args[0].assignment = "rest in the spa",              $args[0].assignmentVisible = 0, $spaSlaves++, $SpaiIDs.push({ID: _wID, Index: _wi})>>
-<<case "cellblock" "be confined in the cellblock">>
-	<<set $args[0].assignment = "be confined in the cellblock", $args[0].assignmentVisible = 0, $cellblockSlaves++, $CellBiIDs.push({ID: _wID, Index: _wi})>>
-<<case "arcade" "be confined in the arcade">>
-	<<set $args[0].assignment = "be confined in the arcade",    $args[0].assignmentVisible = 0, $arcadeSlaves++, $ArcadeiIDs.push({ID: _wID, Index: _wi})>>
-<<case "brothel" "work in the brothel">>
-	<<set $args[0].assignment = "work in the brothel",          $args[0].assignmentVisible = 0, $brothelSlaves++, $BrothiIDs.push({ID: _wID, Index: _wi})>>
-<<case "club" "serve in the club">>
-	<<set $args[0].assignment = "serve in the club",            $args[0].assignmentVisible = 0, $clubSlaves++, $ClubiIDs.push({ID: _wID, Index: _wi})>>
-<<case "dairy" "work in the dairy">>
-	<<set $args[0].assignment = "work in the dairy",            $args[0].assignmentVisible = 0, $dairySlaves++, $DairyiIDs.push({ID: _wID, Index: _wi})>>
-<<case "hgsuite" "head girl suite" "live with your head girl">>
-	<<set $args[0].assignment = "live with your Head Girl",     $args[0].assignmentVisible = 0, $HGSuiteSlaves++, $HGSuiteiIDs.push({ID: _wID, Index: _wi})>>
-<<case "servantsquarters" "servants' quarters" "work as a servant">>
-	<<set $args[0].assignment = "work as a servant",            $args[0].assignmentVisible = 0, $servantsQuartersSlaves++, $ServQiIDs.push({ID: _wID, Index: _wi})>>
-<<case "mastersuite" "master suite" "serve in the master suite">>
-	<<set $args[0].assignment = "serve in the master suite",    $args[0].assignmentVisible = 0, $masterSuiteSlaves++, $MastSiIDs.push({ID: _wID, Index: _wi})>>
-<<case "be your agent" "live with your agent">>
-	<<set $args[0].assignment = $args[1],                       $args[0].assignmentVisible = 0>>     /* removeJob already set choosesOwnAssignment = 0 */
-<<case "choose her own job">>
-	<<set $args[0].assignment = $args[1],                       $args[0].choosesOwnAssignment = 1>>  /* removeJob already set assignmentVisible = 1 */
-<<default>>
-	<<set $args[0].assignment = $args[1]>>                      /* removeJob already set assignmentVisible = 1 and choosesOwnAssignment = 0 */
-<</switch>>
+	/% Get slaves[_wi] index # %/
+	<<if $i < _SL && _wID == $slaves[$i].ID>>
+		<<set _wi = $i>>
+	<<else>>
+		<<for _wi = 0; _wi < _SL; _wi++>>
+			<<if _wID == $slaves[_wi].ID>>
+				<<break>>
+			<</if>>
+		<</for>>
+	<</if>>
 
-/% Stop creating Starving/overweight deaths?, Endless drug supply etc. %/
-<<set $args[0].diet = "healthy", $args[0].drugs = "no drugs", $args[0].curatives = 0, $args[0].hormones = 0, $args[0].aphrodisiacs = 0>>
+	<<set $slaves[_wi] = $args[0], $i = _wi>> /* save changes to slave array, and set $i in case we call "SA chooses own clothes" next, since it uses $slaves[$i] */
 
-<<if _wID == $personalAttention>><<set $personalAttention = "business">><</if>>
-
-<<set $slaves[_wi] = $args[0], $i = _wi>> /* save changes to slave array, and set $i in case we call "SA chooses own clothes" next, since it uses $slaves[$i] */
-
-<<if $slaves[_wi].choosesOwnClothes == 1>><<include "SA chooses own clothes">><<set $args[0] = $slaves[_wi]>><</if>> /* update clothes, then update $args[0] */
+	<<if $slaves[_wi].choosesOwnClothes == 1>><<include "SA chooses own clothes">><<set $args[0] = $slaves[_wi]>><</if>> /* update clothes, then update $args[0] */
 
 <</if>> /* not Pit or Coursing Association */
 <</widget>>
 
 /%
-	Call as <<removeJob slaveObject $returnto | _currentRule.facilityRemove | "serve in the master suite"
+	Call as <<removeJob slaveObject $returnTo | _currentRule.facilityRemove | "serve in the master suite">>
 	$args[0] slave object. *MUST be present*
-	$args[1] Job to remove slave from. Will accept the $returnto vars and the _currentRule.assignFacility vars and the actual job assignments "serve in the master suite" etc.
+	$args[1] Job to remove slave from. Will accept the $returnTo vars and the _currentRule.assignFacility vars and the actual job assignments "serve in the master suite" etc.
 
-	This is basically a Widget version of Retrieve but will work anywhere, And it changes the assignment to "rest", and saves to the slaves[..] array, and changes your $args[0] var sent.
+	This is basically a Widget version of Retrieve but will work anywhere. It changes the assignment and saves to the slaves[..] array, and changes your $args[0] var sent.
 	Retrieve overrides the 'rest' in most cases.
 %/
 <<widget removeJob>>
-<<if ($args[1] != "Pit") && ($args[1] != "Coursing Association")>>
-
 <<set _wID = $args[0].ID, _SL = $slaves.length>>
 
-<<if _wID == $HeadGirl.ID>><<set $HeadGirl = 0>><</if>>
-<<if _wID == $Recruiter.ID>><<set $Recruiter = 0>><</if>>
-<<if _wID == $Bodyguard.ID>><<set $Bodyguard = 0>><</if>>
-<<if _wID == $Madam.ID>><<set $Madam = 0>><</if>>
-<<if _wID == $DJ.ID>><<set $DJ = 0>><</if>>
-<<if _wID == $Milkmaid.ID>><<set $Milkmaid = 0>><</if>>
-<<if _wID == $Schoolteacher.ID>><<set $Schoolteacher = 0>><</if>>
-<<if _wID == $Attendant.ID>><<set $Attendant = 0>><</if>>
-<<if _wID == $Nurse.ID>><<set $Nurse = 0>><</if>>
-<<if _wID == $Collectrix.ID>><<set $Collectrix = 0>><</if>>
-<<if _wID == $Stewardess.ID>><<set $Stewardess = 0>><</if>>
-<<if _wID == $Wardeness.ID>><<set $Wardeness = 0>><</if>>
-<<if _wID == $Concubine.ID>><<set $Concubine = 0>><</if>>
+<<if ($args[1] == "Pit")>>
+	<<set $fighterIDs.delete({ID: _wID, Index: _wi})>>
 
-/% use .toLowerCase() to get rid of a few dupe conditions. %/
-<<switch $args[1].toLowerCase()>>
-<<case "clinic" "get treatment in the clinic">>
-	<<set _Tcount = $CliniciIDs.length>>
-	<<for _wi = 0; _wi < _Tcount; _wi++>>
-		<<if _wID == $CliniciIDs[_wi].ID>>
-			<<set _dump = $CliniciIDs.deleteAt(_wi), $clinicSlaves-->>
-			<<break>>
-		<</if>>
-	<</for>>
-<<case "schoolroom" "learn in the schoolroom">>
-	<<set _Tcount = $SchlRiIDs.length>>
-	<<for _wi = 0; _wi < _Tcount; _wi++>>
-		<<if _wID == $SchlRiIDs[_wi].ID>>
-			<<set _dump = $SchlRiIDs.deleteAt(_wi), $schoolroomSlaves-->>
-			<<break>>
-		<</if>>
-	<</for>>
-<<case "spa" "rest in the spa">>
-	<<set _Tcount = $SpaiIDs.length>>
-	<<for _wi = 0; _wi < _Tcount; _wi++>>
-		<<if _wID == $SpaiIDs[_wi].ID>>
-			<<set _dump = $SpaiIDs.deleteAt(_wi), $spaSlaves-->>
-			<<break>>
-		<</if>>
-	<</for>>
-<<case "cellblock" "be confined in the cellblock">>
-	<<set _Tcount = $CellBiIDs.length>>
-	<<for _wi = 0; _wi < _Tcount; _wi++>>
-		<<if _wID == $CellBiIDs[_wi].ID>>
-			<<set _dump = $CellBiIDs.deleteAt(_wi), $cellblockSlaves-->>
-			<<break>>
-		<</if>>
-	<</for>>
-<<case "arcade" "be confined in the arcade">>
-	<<set _Tcount = $ArcadeiIDs.length>>
-	<<for _wi = 0; _wi < _Tcount; _wi++>>
-		<<if _wID == $ArcadeiIDs[_wi].ID>>
-			<<set _dump = $ArcadeiIDs.deleteAt(_wi), $arcadeSlaves-->>
-			<<break>>
-		<</if>>
-	<</for>>
-<<case "brothel" "work in the brothel">>
-	<<set _Tcount = $BrothiIDs.length>>
-	<<for _wi = 0; _wi < _Tcount; _wi++>>
-		<<if _wID == $BrothiIDs[_wi].ID>>
-			<<set _dump = $BrothiIDs.deleteAt(_wi), $brothelSlaves-->>
-			<<break>>
-		<</if>>
-	<</for>>
-<<case "club" "serve in the club">>
-	<<set _Tcount = $ClubiIDs.length>>
-	<<for _wi = 0; _wi < _Tcount; _wi++>>
-		<<if _wID == $ClubiIDs[_wi].ID>>
-			<<set _dump = $ClubiIDs.deleteAt(_wi), $clubSlaves-->>
-			<<break>>
-		<</if>>
-	<</for>>
-<<case "dairy" "work in the dairy">>
-	<<set _Tcount = $DairyiIDs.length>>
-	<<for _wi = 0; _wi < _Tcount; _wi++>>
-		<<if _wID == $DairyiIDs[_wi].ID>>
-			<<set _dump = $DairyiIDs.deleteAt(_wi), $dairySlaves-->>
-			<<break>>
-		<</if>>
-	<</for>>
-<<case "hgsuite" "head girl suite" "live with your head girl">>
-	<<set _Tcount = $HGSuiteiIDs.length>>
-	<<for _wi = 0; _wi < _Tcount; _wi++>>
-		<<if _wID == $HGSuiteiIDs[_wi].ID>>
-			<<set _dump = $HGSuiteiIDs.deleteAt(_wi), $HGSuiteSlaves-->>
-			<<break>>
-		<</if>>
-	<</for>>
-<<case "servantsquarters" "servants' quarters" "work as a servant">>
-	<<set _Tcount = $ServQiIDs.length>>
-	<<for _wi = 0; _wi < _Tcount; _wi++>>
-		<<if _wID == $ServQiIDs[_wi].ID>>
-			<<set _dump = $ServQiIDs.deleteAt(_wi), $servantsQuartersSlaves-->>
-			<<break>>
-		<</if>>
-	<</for>>
-<<case "mastersuite" "master suite" "serve in the master suite">>
-	<<set _Tcount = $MastSiIDs.length>>
-	<<for _wi = 0; _wi < _Tcount; _wi++>>
-		<<if _wID == $MastSiIDs[_wi].ID>>
-			<<set _dump = $MastSiIDs.deleteAt(_wi), $masterSuiteSlaves-->>
-			<<break>>
-		<</if>>
-	<</for>>
-<</switch>>
+<<elseif ($args[1] == "Coursing Association")>>
+	<<set $Lurcher = 0>>
 
-<<set $args[0].assignmentVisible = 1, $args[0].assignment = "rest", $args[0].choosesOwnAssignment = 0, $args[0].sentence = 0>>
-
-<<if $i < _SL && _wID == $slaves[$i].ID>>
-	<<set $slaves[$i] = $args[0]>>
 <<else>>
-	<<for _wi = 0; _wi < _SL; _wi++>>
-	<<if _wID == $slaves[_wi].ID>>
-		<<set $slaves[_wi] = $args[0]>>
-		<<break>>
+
+	<<if _wID == $HeadGirl.ID>><<set $HeadGirl = 0>><</if>>
+	<<if _wID == $Recruiter.ID>><<set $Recruiter = 0>><</if>>
+	<<if _wID == $Bodyguard.ID>><<set $Bodyguard = 0>><</if>>
+	<<if _wID == $Madam.ID>><<set $Madam = 0>><</if>>
+	<<if _wID == $DJ.ID>><<set $DJ = 0>><</if>>
+	<<if _wID == $Milkmaid.ID>><<set $Milkmaid = 0>><</if>>
+	<<if _wID == $Schoolteacher.ID>><<set $Schoolteacher = 0>><</if>>
+	<<if _wID == $Attendant.ID>><<set $Attendant = 0>><</if>>
+	<<if _wID == $Nurse.ID>><<set $Nurse = 0>><</if>>
+	<<if _wID == $Collectrix.ID>><<set $Collectrix = 0>><</if>>
+	<<if _wID == $Stewardess.ID>><<set $Stewardess = 0>><</if>>
+	<<if _wID == $Wardeness.ID>><<set $Wardeness = 0>><</if>>
+	<<if _wID == $Concubine.ID>><<set $Concubine = 0>><</if>>
+
+	/% Get slaves[_wi] index # %/
+	<<if $i < _SL && _wID == $slaves[$i].ID>>
+		<<set _wi = $i>>
+	<<else>>
+		<<for _wi = 0; _wi < _SL; _wi++>>
+			<<if _wID == $slaves[_wi].ID>>
+				<<break>>
+			<</if>>
+		<</for>>
 	<</if>>
-	<</for>>
-<</if>>
+
+	/% use .toLowerCase() to get rid of a few dupe conditions. %/
+	<<switch $args[1].toLowerCase()>>
+		<<case "be confined in the arcade" "arcade">>
+			<<set $ArcadeiIDs = $ArcadeiIDs.delete({ID: _wID, Index: _wi}),     $arcadeSlaves--, $args[0].assignment = "work a glory hole">>
+		<<case "work in the brothel" "brothel">>
+			<<set $BrothiIDs = $BrothiIDs.delete({ID: _wID, Index: _wi}),       $brothelSlaves--, $args[0].assignment = "whore">>
+		<<case "be confined in the cellblock" "cellblock">>
+			<<set $CellBiIDs = $CellBiIDs.delete({ID: _wID, Index: _wi}),       $cellblockSlaves--, $args[0].assignment = "stay confined">>
+		<<case "get treatment in the clinic" "clinic">>
+			<<set $CliniciIDs = $CliniciIDs.delete({ID: _wID, Index: _wi}),     $clinicSlaves--, $args[0].assignment = "rest">>
+		<<case "serve in the club" "club">>
+			<<set $ClubiIDs = $ClubiIDs.delete({ID: _wID, Index: _wi}),         $clubSlaves--, $args[0].assignment = "serve the public">>
+		<<case "work in the dairy" "dairy">>
+			<<set $DairyiIDs = $DairyiIDs.delete({ID: _wID, Index: _wi}),       $dairySlaves--, $args[0].assignment = "get milked">>
+		<<case "live with your head girl" "head girl suite" "hgsuite">>
+			<<set $HGSuiteiIDs = $HGSuiteiIDs.delete({ID: _wID, Index: _wi}),   $HGSuiteSlaves--, $args[0].assignment = "rest">>
+		<<case "serve in the master suite" "master suite" "mastersuite">>
+			<<set $MastSiIDs = $MastSiIDs.delete({ID: _wID, Index: _wi}),       $masterSuiteSlaves--, $args[0].assignment = "please you">>
+		<<case "learn in the schoolroom" "schoolroom">>
+			<<set $SchlRiIDs = $SchlRiIDs.delete({ID: _wID, Index: _wi}),       $schoolroomSlaves--, $args[0].assignment = "take classes">>
+		<<case "work as a servant" "servants' quarters" "servantsquarters">>
+			<<set $ServQiIDs = $ServQiIDs.delete({ID: _wID, Index: _wi}),       $servantsQuartersSlaves--, $args[0].assignment = "be a servant">>
+		<<case "rest in the spa" "spa">>
+			<<set $SpaiIDs = $SpaiIDs.delete({ID: _wID, Index: _wi}),           $spaSlaves--, $args[0].assignment = "rest">>
+		<<case "be your head girl">>
+			<<set $args[0].assignment = "rest">>
+			<<if $personalAttention == "HG">>
+				<<set $personalAttention = "business">>
+			<</if>>
+		<<default>>
+			<<set $args[0].assignment = "rest">>
+	<</switch>>
+
+	<<set $args[0].assignmentVisible = 1, $args[0].choosesOwnAssignment = 0, $args[0].sentence = 0>>
+
+	<<set $slaves[_wi] = $args[0]>>
 
 <</if>>
 <</widget>>


### PR DESCRIPTION
more assignment fixes to solve duplication of slaves in facilities lists (not a retroactive fix for most facilities, but it will fix the Head Girl Suite automatically since it only has one slot - for the rest, putting the slave back into the facility where they appear more than once, and then removing them from it, should resolve the duplicate entries); fix misc typos and small bugs; implement backwards compatibility option for saves older than 0.10.1 (requires going to options menu and clicking "apply backwards compatibility updates" link after loading old save); fix facility decommission links in sectors (= instead of ==); fix minor annoyance in slave interact page with curatives/aphrodisiacs links becoming unclickable after changes; minor cleanup (some formatting issues, some missing line separators) in slave summary