### PR TITLE
more assignment fixes (last pull actually broke them even worse)

### DIFF
--- a/src/uncategorized/arcadeReport.tw
+++ b/src/uncategorized/arcadeReport.tw
@@ -33,6 +33,10 @@
 		<</if>>
 		<</for>>
 	<</if>>
+	<<if _i >= _SL || $slaves[_i].assignment != "be confined in the arcade">>
+		<<set $ArcadeiIDs.deleteAt(_dI), _dI--, _DL-->>
+		<<continue>>
+	<</if>>
 	/% Onward bound as normal %/
 	<<set $oldCash = $cash, $i = _i>>
 

--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -14,6 +14,10 @@
 	<</if>>
 	<</for>>
 <</if>>
+<<if _i >= _SL || $slaves[_i].assignment != "work in the brothel">>
+	<<set $BrothiIDs.deleteAt(_dI), _dI--, _DL-->>
+	<<continue>>
+<</if>>
 <</for>>
 <<SlaveSort $BrothiIDs>>
 

--- a/src/uncategorized/cellblockReport.tw
+++ b/src/uncategorized/cellblockReport.tw
@@ -14,6 +14,10 @@
 	<</if>>
 	<</for>>
 <</if>>
+<<if _i >= _SL || $slaves[_i].assignment != "be confined in the cellblock">>
+	<<set $CellBiIDs.deleteAt(_dI), _dI--, _DL-->>
+	<<continue>>
+<</if>>
 <</for>>
 <<SlaveSort $CellBiIDs>>
 

--- a/src/uncategorized/clinicReport.tw
+++ b/src/uncategorized/clinicReport.tw
@@ -14,6 +14,10 @@
 	<</if>>
 	<</for>>
 <</if>>
+<<if _i >= _SL || $slaves[_i].assignment != "get treatment in the clinic">>
+	<<set $CliniciIDs.deleteAt(_dI), _dI--, _DL-->>
+	<<continue>>
+<</if>>
 <</for>>
 <<SlaveSort $CliniciIDs>>
 

--- a/src/uncategorized/clubReport.tw
+++ b/src/uncategorized/clubReport.tw
@@ -174,6 +174,10 @@
 		<</if>>
 		<</for>>
 	<</if>>
+	<<if _i >= _SL || $slaves[_i].assignment != "serve in the club">>
+		<<set $ClubiIDs.deleteAt(_dI), _dI--, _DL-->>
+		<<continue>>
+	<</if>>
 	<<set $i = _i>>
 	<<if ($legendaryEntertainerID == 0) && ($slaves[_i].prestige == 0) && ($slaves[_i].entertainSkill >= 100) && ($slaves[_i].devotion > 50) && ($slaves[_i].prestige == 0)>>
 	<<set $legendaryEntertainerID = $slaves[_i].ID>>

--- a/src/uncategorized/dairyReport.tw
+++ b/src/uncategorized/dairyReport.tw
@@ -14,6 +14,10 @@
 	<</if>>
 	<</for>>
 <</if>>
+<<if _i >= _SL || $slaves[_i].assignment != "work in the dairy">>
+	<<set $DairyiIDs.deleteAt(_dI), _dI--, _DL-->>
+	<<continue>>
+<</if>>
 <</for>>
 <<SlaveSort $DairyiIDs>>
 

--- a/src/uncategorized/economics.tw
+++ b/src/uncategorized/economics.tw
@@ -1306,7 +1306,7 @@ Your ''business assistant'' manages the menial slave market.
 		<<set $cash+=$menialBioreactors*($seed),$menialBioreactors = 0>>
 	<</if>>
 <<else>>
-	Prices are average, so <<if $assistant == 0>>it<<else>>She<</if>> does not make any significant moves.
+	Prices are average, so <<if $assistant == 0>>it<<else>>she<</if>> does not make any significant moves.
 <</if>>
 <<silently>><<MenialPopCap>><</silently>>
 <</if>>

--- a/src/uncategorized/masterSuiteReport.tw
+++ b/src/uncategorized/masterSuiteReport.tw
@@ -14,6 +14,10 @@
 		<</if>>
 		<</for>>
 	<</if>>
+	<<if _i >= _SL || $slaves[_i].assignment != "serve in the master suite">>
+		<<set $MastSiIDs.deleteAt(_dI), _dI--, _DL-->>
+		<<continue>>
+	<</if>>
 <</for>>
 <<SlaveSort $MastSiIDs>>
 <<if $Concubine != 0>>

--- a/src/uncategorized/pHackerSupport.tw
+++ b/src/uncategorized/pHackerSupport.tw
@@ -1,14 +1,12 @@
 :: P hacker support
 
+<<set $nextButton = " ", $nextLink = "Random Nonindividual Event", $nextButton = "Continue">>
+
 <<nobr>>
 
-<<set $nextButton = " ">>
-<<set $nextLink = "Random Nonindividual Event">>
-	<<set $nextButton = "Continue">>
-
-<</nobr>>\
-\
 While you are reviewing your information security posture in light of the Daughters of Liberty and their apparent ability to get into your systems, you receive yet another well-secured message unannounced. To your surprise, it isn't the Daughters. It's a video call from a rather interesting individual. She is quite pretty, and has a variety of facial tattoos and piercings; her face is androgynous enough that you aren't entirely sure what gender (probably) she considers herself. Her pale skin is illuminated by the diffuse glow from what's clearly a huge bank of monitors, and the clacking sound of a traditional mechanical keyboard can be heard over the line.
+
+<br><br>
 
 "Hi!" she says cheerfully. "I seen you been contacted by these Daughters cunts. They been after me too. They're pretty decent at cyberwarfare, but I'm fuckin' better." A momentary discomfort crosses her face, and she shifts a little in her seat. "They're building up for somethin' big. Wouldn'ta contacted you at all, let us both fight our own fights, but I gotta short fuse on this vulnerability and I need to bribe a weak link. Your money can get me in, my skills can fuck 'em up. What do you say?"
 <<if $assistant > 0>>
@@ -32,8 +30,12 @@ While you are reviewing your information security posture in light of the Daught
 	and chuckles. "Haha, cute."
 <</if>>
 
+<br><br>
+
 As she finishes speaking, another spasm distorts her expression, and then she suddenly relaxes. After a moment, she looks down, out of your field of view, and hisses, <<if $seeDicks == 0>>"Keep licking, bitch, I like aftershocks. Work my clit, or it's your asshole."<<else>>"Swallow, bitch. Every fucking drop, or it's your asshole."<</if>>
-\
+
+</nobr>
+
 <span id="result">
 <<link "Decline">>
 	<<replace "#result">>

--- a/src/uncategorized/rulesAssistant.tw
+++ b/src/uncategorized/rulesAssistant.tw
@@ -802,7 +802,7 @@ Shoes: ''$currentRule.shoes.''
 
 <br>
 <span id = "baccessory">
-Corsetage: ''$currentRule.bellyAccessory.''
+Body Accessory: ''$currentRule.bellyAccessory.''
 </span>
 <<link "No default setting">>
 	<<set $currentRule.bellyAccessory = "no default setting">>

--- a/src/uncategorized/schoolroomReport.tw
+++ b/src/uncategorized/schoolroomReport.tw
@@ -14,6 +14,10 @@
 	<</if>>
 	<</for>>
 <</if>>
+<<if _i >= _SL || $slaves[_i].assignment != "learn in the schoolroom">>
+	<<set $SchlRiIDs.deleteAt(_dI), _dI--, _DL-->>
+	<<continue>>
+<</if>>
 <</for>>
 <<SlaveSort $SchlRiIDs>>
 

--- a/src/uncategorized/servantsQuartersReport.tw
+++ b/src/uncategorized/servantsQuartersReport.tw
@@ -14,6 +14,10 @@
 	<</if>>
 	<</for>>
 <</if>>
+<<if _i >= _SL || $slaves[_i].assignment != "work as a servant">>
+	<<set $ServQiIDs.deleteAt(_dI), _dI--, _DL-->>
+	<<continue>>
+<</if>>
 <</for>>
 <<SlaveSort $ServQiIDs>>
 

--- a/src/uncategorized/slaveAssignmentsReport.tw
+++ b/src/uncategorized/slaveAssignmentsReport.tw
@@ -355,7 +355,7 @@
 			<</if>>
 			<</for>>
 		<</if>>
-		<<if $i < _SL && $slaves[$i].assignment != "live with your head girl">>
+		<<if $i < _SL && $slaves[$i].assignment != "live with your Head Girl">>
 			<br>@@.red;$slaves[$i].slaveName had been assigned to live with your Head Girl, but this week she was assigned to $slaves[$i].assignment. She has been released to your penthouse for reassignment.@@
 			<<removeJob $slaves[$i] "live with your head girl">>
 		<</if>>

--- a/src/uncategorized/slaveSummary.tw
+++ b/src/uncategorized/slaveSummary.tw
@@ -23,28 +23,28 @@
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Personal Attention Select][$personalAttention = $slaves["+_i+"].ID, $activeSlave = $slaves["+_i+"], $personalAttentionChanged = 1]]">>
 <<case "Agent Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.assignment != "guard you") && (_Slave.assignment != "recruit girls") && (_Slave.assignment != "be your Head Girl") && (_Slave.devotion >= 20) && (_Slave.intelligence > 0) && (_Slave.intelligenceImplant > 0) && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.assignment != "be your agent") && (_Slave.devotion >= 20) && (_Slave.intelligence > 0) && (_Slave.intelligenceImplant > 0) && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Agent Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
 <<case "BG Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "guard you") && (_Slave.assignment != "recruit girls") && (_Slave.assignment != "be your Head Girl") && canWalk(_Slave) && canSee(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "guard you") && canWalk(_Slave) && canSee(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Bodyguard Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
 <<case "Recruiter Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "guard you") && (_Slave.assignment != "recruit girls") && (_Slave.assignment != "be your Head Girl") && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "recruit girls") && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Recruiter Workaround][$i = "+_i+"]]">>
 <<else>>
 	<<continue>>
 <</if>>
 <<case "HG Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "guard you") && (_Slave.assignment != "recruit girls") && (_Slave.assignment != "be your Head Girl") && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "be your Head Girl") && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|HG Workaround][$i = "+_i+"]]">>
 <<else>>
@@ -53,7 +53,7 @@
 <<case "Head Girl Suite">>
 <<if _Slave.fuckdoll > 0>><<continue>><</if>>
 <<if $Flag == 0>>
-	<<if (_Slave.assignmentVisible == 1) && (_Slave.assignment != "be your Head Girl") && (_Slave.indentureRestrictions <= 0)>>
+	<<if (_Slave.assignment != "be your Head Girl") && (_Slave.indentureRestrictions <= 0)>>
 		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 	<<else>>
@@ -105,7 +105,7 @@
 	<</if>>
 <</if>>
 <<case "Attendant Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Attendant Workaround][$i = "+_i+"]]">>
 <<else>>
@@ -137,7 +137,7 @@
 	<</if>>
 <</if>>
 <<case "Madam Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave) && canSee(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave) && canSee(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Madam Workaround][$i = "+_i+"]]">>
 <<else>>
@@ -170,7 +170,7 @@
 	<</if>>
 <</if>>
 <<case "DJ Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|DJ Workaround][$i = "+_i+"]]">>
 <<else>>
@@ -203,7 +203,7 @@
 	<</if>>
 <</if>>
 <<case "Nurse Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) && canSee(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) && canSee(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Nurse Workaround][$i = "+_i+"]]">>
 <<else>>
@@ -241,7 +241,7 @@
 	<</if>>
 <</if>>
 <<case "Schoolteacher Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canTalk(_Slave) && canWalk(_Slave) && canSee(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canTalk(_Slave) && canWalk(_Slave) && canSee(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Schoolteacher Workaround][$i = "+_i+"]]">>
 <<else>>
@@ -300,7 +300,7 @@
 	<</if>>
 <</if>>
 <<case "Milkmaid Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 20) && canWalk(_Slave) && canSee(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 20) && canWalk(_Slave) && canSee(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Milkmaid Workaround][$i = "+_i+"]]">>
 <<else>>
@@ -333,7 +333,7 @@
 	<</if>>
 <</if>>
 <<case "Stewardess Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave) && canSee(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave) && canSee(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Stewardess Workaround][$i = "+_i+"]]">>
 <<else>>
@@ -365,7 +365,7 @@
 	<</if>>
 <</if>>
 <<case "Concubine Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) && canSee(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) && canSee(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Concubine Workaround][$i = "+_i+"]]">>
 <<else>>
@@ -396,7 +396,7 @@
 	<</if>>
 <</if>>
 <<case "Wardeness Select">>
-<<if (_Slave.assignmentVisible == 1) && (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) & canSee(_Slave)>>
+<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) & canSee(_Slave)>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Wardeness Workaround][$i = "+_i+"]]">>
 <<else>>
@@ -404,7 +404,7 @@
 <</if>>
 <<case "Arcade">>
 <<if $Flag == 0>>
-	<<if (_Slave.assignmentVisible != 1) || (($arcade <= $arcadeSlaves) && ($arcadeUpgradeFuckdolls != 1))>><<continue>><</if>>
+	<<if $arcade <= $arcadeSlaves && $arcadeUpgradeFuckdolls != 1>><<continue>><</if>>
 	<<if (_Slave.indentureRestrictions <= 0)>>
 		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 		<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
@@ -515,7 +515,7 @@
 	<</if>>
 <</if>>
 <<case "Matchmaking">>
-	<<if ($slaves[_i].assignmentVisible != 1) || ($slaves[_i].devotion < 100) || ($slaves[_i].relationship != $activeSlave.relationship) || ($slaves[_i].ID == $activeSlave.ID)>><<continue>><</if>>
+	<<if ($slaves[_i].devotion < 100) || ($slaves[_i].relationship != $activeSlave.relationship) || ($slaves[_i].ID == $activeSlave.ID)>><<continue>><</if>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_Slave.slaveName|Slave Interact][$activeSlave = $slaves["+_i+"]]]">>
 <</switch>>

--- a/src/uncategorized/spaReport.tw
+++ b/src/uncategorized/spaReport.tw
@@ -14,6 +14,10 @@
 	<</if>>
 	<</for>>
 <</if>>
+<<if _i >= _SL || $slaves[_i].assignment != "rest in the spa">>
+	<<set $SpaiIDs.deleteAt(_dI), _dI--, _DL-->>
+	<<continue>>
+<</if>>
 <</for>>
 <<SlaveSort $SpaiIDs>>
 

--- a/src/utility/assignWidgets.tw
+++ b/src/utility/assignWidgets.tw
@@ -78,7 +78,7 @@
 <<set _wID = $args[0].ID, _SL = $slaves.length>>
 
 <<if ($args[1] == "Pit")>>
-	<<set $fighterIDs.delete({ID: _wID, Index: _wi})>>
+	<<set $fighterIDs.delete(_wID)>>
 
 <<elseif ($args[1] == "Coursing Association")>>
 	<<set $Lurcher = 0>>
@@ -113,27 +113,71 @@
 	/% use .toLowerCase() to get rid of a few dupe conditions. %/
 	<<switch $args[1].toLowerCase()>>
 		<<case "be confined in the arcade" "arcade">>
-			<<set $ArcadeiIDs = $ArcadeiIDs.delete({ID: _wID, Index: _wi}),     $arcadeSlaves--, $args[0].assignment = "work a glory hole">>
+			<<for _i = 0; _i < $ArcadeiIDs.length; _i++>>
+				<<if $ArcadeiIDs[_i].ID == _wID>>
+					<<set $ArcadeiIDs.deleteAt(_i), $arcadeSlaves--, $args[0].assignment = "work a glory hole">>
+				<</if>>
+			<</for>>
 		<<case "work in the brothel" "brothel">>
-			<<set $BrothiIDs = $BrothiIDs.delete({ID: _wID, Index: _wi}),       $brothelSlaves--, $args[0].assignment = "whore">>
+			<<for _i = 0; _i < $BrothiIDs.length; _i++>>
+				<<if $BrothiIDs[_i].ID == _wID>>
+					<<set $BrothiIDs.deleteAt(_i), $brothelSlaves--, $args[0].assignment = "whore">>
+				<</if>>
+			<</for>>
 		<<case "be confined in the cellblock" "cellblock">>
-			<<set $CellBiIDs = $CellBiIDs.delete({ID: _wID, Index: _wi}),       $cellblockSlaves--, $args[0].assignment = "stay confined">>
+			<<for _i = 0; _i < $CellBiIDs.length; _i++>>
+				<<if $CellBiIDs[_i].ID == _wID>>
+					<<set $CellBiIDs.deleteAt(_i), $cellblockSlaves--, $args[0].assignment = "stay confined">>
+				<</if>>
+			<</for>>
 		<<case "get treatment in the clinic" "clinic">>
-			<<set $CliniciIDs = $CliniciIDs.delete({ID: _wID, Index: _wi}),     $clinicSlaves--, $args[0].assignment = "rest">>
+			<<for _i = 0; _i < $CliniciIDs.length; _i++>>
+				<<if $CliniciIDs[_i].ID == _wID>>
+					<<set $CliniciIDs.deleteAt(_i), $clinicSlaves--, $args[0].assignment = "rest">>
+				<</if>>
+			<</for>>
 		<<case "serve in the club" "club">>
-			<<set $ClubiIDs = $ClubiIDs.delete({ID: _wID, Index: _wi}),         $clubSlaves--, $args[0].assignment = "serve the public">>
+			<<for _i = 0; _i < $ClubiIDs.length; _i++>>
+				<<if $ClubiIDs[_i].ID == _wID>>
+					<<set $ClubiIDs.deleteAt(_i), $clubSlaves--, $args[0].assignment = "serve the public">>
+				<</if>>
+			<</for>>
 		<<case "work in the dairy" "dairy">>
-			<<set $DairyiIDs = $DairyiIDs.delete({ID: _wID, Index: _wi}),       $dairySlaves--, $args[0].assignment = "get milked">>
+			<<for _i = 0; _i < $DairyiIDs.length; _i++>>
+				<<if $DairyiIDs[_i].ID == _wID>>
+					<<set $DairyiIDs.deleteAt(_i), $dairySlaves--, $args[0].assignment = "get milked">>
+				<</if>>
+			<</for>>
 		<<case "live with your head girl" "head girl suite" "hgsuite">>
-			<<set $HGSuiteiIDs = $HGSuiteiIDs.delete({ID: _wID, Index: _wi}),   $HGSuiteSlaves--, $args[0].assignment = "rest">>
+			<<for _i = 0; _i < $HGSuiteiIDs.length; _i++>>
+				<<if $HGSuiteiIDs[_i].ID == _wID>>
+					<<set $HGSuiteiIDs.deleteAt(_i), $HGSuiteSlaves--, $args[0].assignment = "rest">>
+				<</if>>
+			<</for>>
 		<<case "serve in the master suite" "master suite" "mastersuite">>
-			<<set $MastSiIDs = $MastSiIDs.delete({ID: _wID, Index: _wi}),       $masterSuiteSlaves--, $args[0].assignment = "please you">>
+			<<for _i = 0; _i < $MastSiIDs.length; _i++>>
+				<<if $MastSiIDs[_i].ID == _wID>>
+					<<set $MastSiIDs.deleteAt(_i), $masterSuiteSlaves--, $args[0].assignment = "please you">>
+				<</if>>
+			<</for>>
 		<<case "learn in the schoolroom" "schoolroom">>
-			<<set $SchlRiIDs = $SchlRiIDs.delete({ID: _wID, Index: _wi}),       $schoolroomSlaves--, $args[0].assignment = "take classes">>
+			<<for _i = 0; _i < $SchlRiIDs.length; _i++>>
+				<<if $SchlRiIDs[_i].ID == _wID>>
+					<<set $SchlRiIDs.deleteAt(_i), $schoolroomSlaves--, $args[0].assignment = "take classes">>
+				<</if>>
+			<</for>>
 		<<case "work as a servant" "servants' quarters" "servantsquarters">>
-			<<set $ServQiIDs = $ServQiIDs.delete({ID: _wID, Index: _wi}),       $servantsQuartersSlaves--, $args[0].assignment = "be a servant">>
+			<<for _i = 0; _i < $ServQiIDs.length; _i++>>
+				<<if $ServQiIDs[_i].ID == _wID>>
+					<<set $ServQiIDs.deleteAt(_i), $servantsQuartersSlaves--, $args[0].assignment = "be a servant">>
+				<</if>>
+			<</for>>
 		<<case "rest in the spa" "spa">>
-			<<set $SpaiIDs = $SpaiIDs.delete({ID: _wID, Index: _wi}),           $spaSlaves--, $args[0].assignment = "rest">>
+			<<for _i = 0; _i < $SpaiIDs.length; _i++>>
+				<<if $SpaiIDs[_i].ID == _wID>>
+					<<set $SpaiIDs.deleteAt(_i), $spaSlaves--, $args[0].assignment = "rest">>
+				<</if>>
+			<</for>>
 		<<case "be your head girl">>
 			<<set $args[0].assignment = "rest">>
 			<<if $personalAttention == "HG">>

--- a/src/utility/raWidgets.tw
+++ b/src/utility/raWidgets.tw
@@ -478,7 +478,7 @@
 <<else>>
 	''Rest''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeAssignment, "rest")>>
+		<<set $currentRule.excludeAssignment.delete("rest")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -499,7 +499,7 @@
 <<else>>
 	''Fucktoy''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeAssignment, "please you")>>
+		<<set $currentRule.excludeAssignment.delete("please you")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -520,7 +520,7 @@
 <<else>>
 	''Subordinate Slave''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeAssignment, "be a subordinate slave")>>
+		<<set $currentRule.excludeAssignment.delete("be a subordinate slave")>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
@@ -542,7 +542,7 @@
 <<else>>
 	''House Servant''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeAssignment, "be a servant")>>
+		<<set $currentRule.excludeAssignment.delete("be a servant")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -563,7 +563,7 @@
 <<else>>
 	''Confined''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeAssignment, "stay confined")>>
+		<<set $currentRule.excludeAssignment.delete("stay confined")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -584,7 +584,7 @@
 <<else>>
 	''Whore''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeAssignment, "whore")>>
+		<<set $currentRule.excludeAssignment.delete("whore")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -605,7 +605,7 @@
 <<else>>
 	''Public Servant''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeAssignment, "serve the public")>>
+		<<set $currentRule.excludeAssignment.delete("serve the public")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -626,7 +626,7 @@
 <<else>>
 	''Classes''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeAssignment, "take classes")>>
+		<<set $currentRule.excludeAssignment.delete("take classes")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -647,7 +647,7 @@
 <<else>>
 	''Milking''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeAssignment, "get milked")>>
+		<<set $currentRule.excludeAssignment.delete("get milked")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -668,7 +668,7 @@
 <<else>>
 	''Gloryhole''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeAssignment, "work a glory hole")>>
+		<<set $currentRule.excludeAssignment.delete("work a glory hole")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -719,7 +719,7 @@
 <<else>>
 	''$HGSuiteNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.facility, "hgsuite")>>
+		<<set $currentRule.facility.delete("hgsuite")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -743,7 +743,7 @@
 <<else>>
 	''$brothelNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.facility, "brothel")>>
+		<<set $currentRule.facility.delete("brothel")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -767,7 +767,7 @@
 <<else>>
 	''$clubNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.facility, "club")>>
+		<<set $currentRule.facility.delete("club")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -791,7 +791,7 @@
 <<else>>
 	''$arcadeNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.facility, "arcade")>>
+		<<set $currentRule.facility.delete("arcade")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -815,7 +815,7 @@
 <<else>>
 	''$dairyNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.facility, "dairy")>>
+		<<set $currentRule.facility.delete("dairy")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -839,7 +839,7 @@
 <<else>>
 	''$servantsQuartersNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.facility, "servantsquarters")>>
+		<<set $currentRule.facility.delete("servantsquarters")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -863,7 +863,7 @@
 <<else>>
 	''$masterSuiteNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.facility, "mastersuite")>>
+		<<set $currentRule.facility.delete("mastersuite")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -887,7 +887,7 @@
 <<else>>
 	''$schoolroomNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.facility, "schoolroom")>>
+		<<set $currentRule.facility.delete("schoolroom")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -911,7 +911,7 @@
 <<else>>
 	''$spaNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.facility, "spa")>>
+		<<set $currentRule.facility.delete("spa")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -935,7 +935,7 @@
 <<else>>
 ''$clinicNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.facility, "clinic")>>
+		<<set $currentRule.facility.delete("clinic")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -959,7 +959,7 @@
 <<else>>
 	''$cellblockNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.facility, "cellblock")>>
+		<<set $currentRule.facility.delete("cellblock")>>
 		<<RAChangeApplyFacility>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -1012,7 +1012,7 @@
 <<else>>
 	''$HGSuiteNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeFacility, "hgsuite")>>
+		<<set $currentRule.excludeFacility.delete("hgsuite")>>
 		<<if $currentRule.assignFacility == "hgsuite">>
 			<<set $currentRule.assignFacility = "none">>
 			<<set $currentRule.facilityRemove = false>>
@@ -1041,7 +1041,7 @@
 <<else>>
 	''$brothelNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeFacility, "brothel")>>
+		<<set $currentRule.excludeFacility.delete("brothel")>>
 		<<if $currentRule.assignFacility == "brothel">>
 			<<set $currentRule.assignFacility = "none">>
 			<<set $currentRule.facilityRemove = false>>
@@ -1070,7 +1070,7 @@
 <<else>>
 	''$clubNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeFacility, "club")>>
+		<<set $currentRule.excludeFacility.delete("club")>>
 		<<if $currentRule.assignFacility == "club">>
 			<<set $currentRule.assignFacility = "none">>
 			<<set $currentRule.facilityRemove = false>>
@@ -1099,7 +1099,7 @@
 <<else>>
 	''$arcadeNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeFacility, "arcade")>>
+		<<set $currentRule.excludeFacility.delete("arcade")>>
 		<<if $currentRule.assignFacility == "arcade">>
 			<<set $currentRule.assignFacility = "none">>
 			<<set $currentRule.facilityRemove = false>>
@@ -1128,7 +1128,7 @@
 <<else>>
 	''$dairyNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeFacility, "dairy")>>
+		<<set $currentRule.excludeFacility.delete("dairy")>>
 		<<if $currentRule.assignFacility == "dairy">>
 			<<set $currentRule.assignFacility = "none">>
 			<<set $currentRule.facilityRemove = false>>
@@ -1157,7 +1157,7 @@
 <<else>>
 	''$servantsQuartersNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeFacility, "servantsquarters")>>
+		<<set $currentRule.excludeFacility.delete("servantsquarters")>>
 		<<if $currentRule.assignFacility == "servantsquarters">>
 			<<set $currentRule.assignFacility = "none">>
 			<<set $currentRule.facilityRemove = false>>
@@ -1186,7 +1186,7 @@
 <<else>>
 	''$masterSuiteNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeFacility, "mastersuite")>>
+		<<set $currentRule.excludeFacility.delete("mastersuite")>>
 		<<if $currentRule.assignFacility == "mastersuite">>
 			<<set $currentRule.assignFacility = "none">>
 			<<set $currentRule.facilityRemove = false>>
@@ -1215,7 +1215,7 @@
 <<else>>
 	''$schoolroomNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeFacility, "schoolroom")>>
+		<<set $currentRule.excludeFacility.delete("schoolroom")>>
 		<<if $currentRule.assignFacility == "schoolroom">>
 			<<set $currentRule.assignFacility = "none">>
 			<<set $currentRule.facilityRemove = false>>
@@ -1244,7 +1244,7 @@
 <<else>>
 	''$spaNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeFacility, "spa")>>
+		<<set $currentRule.excludeFacility.delete("spa")>>
 		<<if $currentRule.assignFacility == "spa">>
 			<<set $currentRule.assignFacility = "none">>
 			<<set $currentRule.facilityRemove = false>>
@@ -1273,7 +1273,7 @@
 <<else>>
 ''$clinicNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeFacility, "clinic")>>
+		<<set $currentRule.excludeFacility.delete("clinic")>>
 		<<if $currentRule.assignFacility == "clinic">>
 			<<set $currentRule.assignFacility = "none">>
 			<<set $currentRule.facilityRemove = false>>
@@ -1302,7 +1302,7 @@
 <<else>>
 	''$cellblockNameCaps''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.excludeFacility, "cellblock")>>
+		<<set $currentRule.excludeFacility.delete("cellblock")>>
 		<<if $currentRule.assignFacility == "cellblock">>
 			<<set $currentRule.assignFacility = "none">>
 			<<set $currentRule.facilityRemove = false>>
@@ -1447,7 +1447,7 @@
 		<<RAChangeApply>>
 	<</link>>
 <<else>>
-	''Milking''
+	''Classes''
 <</if>>
 |
 <<if ($currentRule.setAssignment != "get milked")>>
@@ -1511,7 +1511,7 @@
 	<<link $HGSuiteNameCaps>>
 		<<set $currentRule.assignFacility = "hgsuite">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set removeFromArray($currentRule.facility, "hgsuite")>>
+		<<set $currentRule.facility.delete("hgsuite")>>
 		<<if $currentRule.facility.length == 0>>
 			<<set $currentRule.excludeFacility.push("hgsuite")>>
 			<<RAChangeExcludeFacility>>
@@ -1532,7 +1532,7 @@
 	<<link $brothelNameCaps>>
 		<<set $currentRule.assignFacility = "brothel">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set removeFromArray($currentRule.facility, "brothel")>>
+		<<set $currentRule.facility.delete("brothel")>>
 		<<if $currentRule.facility.length == 0>>
 			<<set $currentRule.excludeFacility.push("brothel")>>
 			<<RAChangeExcludeFacility>>
@@ -1553,7 +1553,7 @@
 	<<link $clubNameCaps>>
 		<<set $currentRule.assignFacility = "club">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set removeFromArray($currentRule.facility, "club")>>
+		<<set $currentRule.facility.delete("club")>>
 		<<if $currentRule.facility.length == 0>>
 			<<set $currentRule.excludeFacility.push("club")>>
 			<<RAChangeExcludeFacility>>
@@ -1574,7 +1574,7 @@
 	<<link $arcadeNameCaps>>
 		<<set $currentRule.assignFacility = "arcade">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set removeFromArray($currentRule.facility, "arcade")>>
+		<<set $currentRule.facility.delete("arcade")>>
 		<<if $currentRule.facility.length == 0>>
 			<<set $currentRule.excludeFacility.push("arcade")>>
 			<<RAChangeExcludeFacility>>
@@ -1595,7 +1595,7 @@
 	<<link $dairyNameCaps>>
 		<<set $currentRule.assignFacility = "dairy">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set removeFromArray($currentRule.facility, "dairy")>>
+		<<set $currentRule.facility.delete("dairy")>>
 		<<if $currentRule.facility.length == 0>>
 			<<set $currentRule.excludeFacility.push("dairy")>>
 			<<RAChangeExcludeFacility>>
@@ -1616,7 +1616,7 @@
 	<<link $servantsQuartersNameCaps>>
 		<<set $currentRule.assignFacility = "servantsquarters">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set removeFromArray($currentRule.facility, "servantsquarters")>>
+		<<set $currentRule.facility.delete("servantsquarters")>>
 		<<if $currentRule.facility.length == 0>>
 			<<set $currentRule.excludeFacility.push("servantsquarters")>>
 			<<RAChangeExcludeFacility>>
@@ -1637,7 +1637,7 @@
 	<<link $masterSuiteNameCaps>>
 		<<set $currentRule.assignFacility = "mastersuite">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set removeFromArray($currentRule.facility, "mastersuite")>>
+		<<set $currentRule.facility.delete("mastersuite")>>
 		<<if $currentRule.facility.length == 0>>
 			<<set $currentRule.excludeFacility.push("mastersuite")>>
 			<<RAChangeExcludeFacility>>
@@ -1658,7 +1658,7 @@
 	<<link $schoolroomNameCaps>>
 		<<set $currentRule.assignFacility = "schoolroom">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set removeFromArray($currentRule.facility, "schoolroom")>>
+		<<set $currentRule.facility.delete("schoolroom")>>
 		<<if $currentRule.facility.length == 0>>
 			<<set $currentRule.excludeFacility.push("schoolroom")>>
 			<<RAChangeExcludeFacility>>
@@ -1679,7 +1679,7 @@
 	<<link $spaNameCaps>>
 		<<set $currentRule.assignFacility = "spa">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set removeFromArray($currentRule.facility, "spa")>>
+		<<set $currentRule.facility.delete("spa")>>
 		<<if $currentRule.facility.length == 0>>
 			<<set $currentRule.excludeFacility.push("spa")>>
 			<<RAChangeExcludeFacility>>
@@ -1700,7 +1700,7 @@
 	<<link $clinicNameCaps>>
 		<<set $currentRule.assignFacility = "clinic">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set removeFromArray($currentRule.facility, "clinic")>>
+		<<set $currentRule.facility.delete("clinic")>>
 		<<if $currentRule.facility.length == 0>>
 			<<set $currentRule.excludeFacility.push("clinic")>>
 			<<RAChangeExcludeFacility>>
@@ -1721,7 +1721,7 @@
 	<<link $cellblockNameCaps>>
 		<<set $currentRule.assignFacility = "cellblock">>
 		<<set $currentRule.setAssignment = "none">>
-		<<set removeFromArray($currentRule.facility, "cellblock")>>
+		<<set $currentRule.facility.delete("cellblock")>>
 		<<if $currentRule.facility.length == 0>>
 			<<set $currentRule.excludeFacility.push("cellblock")>>
 			<<RAChangeExcludeFacility>>
@@ -4502,7 +4502,7 @@ consequences.
 <<if !_exclude>>
 <<switch _currentRule.assignFacility>>
 <<case "hgsuite">>
-	<<if ($HGSuiteSlaves == 0) && ($args[0].indentureRestrictions <= 0) && ($args[0].assignment != "live with your Head Girl") && >>
+	<<if ($HGSuiteSlaves == 0) && ($args[0].indentureRestrictions <= 0) && ($args[0].assignment != "live with your Head Girl")>>
 		<br>$args[0].slaveName has been automatically assigned to live in your Head Girl's private suite.
 		<<if ($personalAttention == $args[0].ID)>>
 			$args[0].slaveName no longer has your personal attention; you plan to focus on business.

--- a/src/utility/raWidgets.tw
+++ b/src/utility/raWidgets.tw
@@ -133,6 +133,7 @@
 <<set _milked = false>>
 <<set _subordinate = false>>
 <<set _gloryhole = false>>
+<<set _classes = false>>
 <<if def $currentRule.assignment>>
 	<<for _a = $currentRule.assignment.length; _a >= 0; _a-->>
 		<<if $currentRule.assignment[_a] == "rest">>
@@ -162,10 +163,13 @@
 		<<if $currentRule.assignment[_a] == "stay confined">>
 			<<set _confined = true>>
 		<</if>>
+		<<if $currentRule.assignment[_a] == "take classes">>
+			<<set _classes = true>>
+		<</if>>
 	<</for>>
 <</if>>
 
-<<if _rest || _fucktoy || _servant || _confined || _whore || _public || _milked || _subordinate || _gloryhole>>
+<<if _rest || _fucktoy || _servant || _confined || _whore || _public || _milked || _subordinate || _gloryhole || _classes>>
   Apply to assignments:
 	<<link "All">>
 		<<set $currentRule.assignment = []>>
@@ -196,7 +200,7 @@
 <<else>>
 	''Rest''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.assignment, "rest")>>
+		<<set $currentRule.assignment.delete("rest")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -217,7 +221,7 @@
 <<else>>
 	''Fucktoy''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.assignment, "please you")>>
+		<<set $currentRule.assignment.delete("please you")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -238,7 +242,7 @@
 <<else>>
 	''Subordinate Slave''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.assignment, "be a subordinate slave")>>
+		<<set $currentRule.assignment.delete("be a subordinate slave")>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
@@ -261,7 +265,7 @@
 <<else>>
 	''House Servant''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.assignment, "be a servant")>>
+		<<set $currentRule.assignment.delete("be a servant")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -282,7 +286,7 @@
 <<else>>
 	''Confined''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.assignment, "stay confined")>>
+		<<set $currentRule.assignment.delete("stay confined")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -303,7 +307,7 @@
 <<else>>
 	''Whore''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.assignment, "whore")>>
+		<<set $currentRule.assignment.delete("whore")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -324,7 +328,28 @@
 <<else>>
 	''Public Servant''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.assignment, "serve the public")>>
+		<<set $currentRule.assignment.delete("serve the public")>>
+		<<RAChangeApplyAssignment>>
+		<<RAChangeSave>>
+		<<RAChangeApply>>
+	<</link>>
+<</if>>
+|
+<<if !_classes>>
+	<<link "Classes">>
+		<<set $currentRule.assignment.push("take classes")>>
+		<<set $currentRule.excludeAssignment = []>>
+		<<set $currentRule.setAssignment = "none">>
+		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
+		<<RAChangeSave>>
+		<<RAChangeApply>>
+	<</link>>
+<<else>>
+	''Classes''
+	<<link Stop>>
+		<<set $currentRule.assignment.delete("take classes")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -345,7 +370,7 @@
 <<else>>
 	''Milking''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.assignment, "get milked")>>
+		<<set $currentRule.assignment.delete("get milked")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -366,7 +391,7 @@
 <<else>>
 	''Gloryhole''
 	<<link Stop>>
-		<<set removeFromArray($currentRule.assignment, "work a glory hole")>>
+		<<set $currentRule.assignment.delete("work a glory hole")>>
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -389,6 +414,7 @@
 <<set _milked = false>>
 <<set _subordinate = false>>
 <<set _gloryhole = false>>
+<<set _classes = false>>
 <<if def $currentRule.excludeAssignment>>
 	<<for _a = $currentRule.excludeAssignment.length; _a >= 0; _a-->>
 		<<if $currentRule.excludeAssignment[_a] == "rest">>
@@ -418,9 +444,12 @@
 		<<if $currentRule.excludeAssignment[_a] == "stay confined">>
 			<<set _confined = true>>
 		<</if>>
+		<<if $currentRule.excludeAssignment[_a] == "take classes">>
+			<<set _classes = true>>
+		<</if>>
 	<</for>>
 <</if>>
-<<if _rest || _fucktoy || _servant || _confined || _whore || _public || _milked || _subordinate || _gloryhole>>
+<<if _rest || _fucktoy || _servant || _confined || _whore || _public || _milked || _subordinate || _gloryhole || _classes>>
   Include all assignments except:
 	<<link "None">>
 		<<set $currentRule.excludeAssignment = []>>
@@ -577,6 +606,27 @@
 	''Public Servant''
 	<<link Stop>>
 		<<set removeFromArray($currentRule.excludeAssignment, "serve the public")>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSave>>
+		<<RAChangeApply>>
+	<</link>>
+<</if>>
+|
+<<if !_classes>>
+	<<link "Classes">>
+		<<set $currentRule.assignment = []>>
+		<<set $currentRule.excludeAssignment.push("take classes")>>
+		<<set $currentRule.setAssignment = "none">>
+		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeSetAssignment>>
+		<<RAChangeSave>>
+		<<RAChangeApply>>
+	<</link>>
+<<else>>
+	''Classes''
+	<<link Stop>>
+		<<set removeFromArray($currentRule.excludeAssignment, "take classes")>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSave>>
 		<<RAChangeApply>>
@@ -1290,7 +1340,7 @@
 |
 <<if ($currentRule.setAssignment != "rest")>>
 	<<link "Rest">>
-		<<set removeFromArray($currentRule.assignment, "rest")>>
+		<<set $currentRule.assignment.delete("rest")>>
 		<<set $currentRule.setAssignment = "rest">>
 		<<set $currentRule.assignFacility = "none">>
 		<<set $currentRule.facilityRemove = false>>
@@ -1306,7 +1356,7 @@
 |
 <<if ($currentRule.setAssignment != "please you")>>
 	<<link "Fucktoy">>
-		<<set removeFromArray($currentRule.assignment, "please you")>>
+		<<set $currentRule.assignment.delete("please you")>>
 		<<set $currentRule.setAssignment = "please you">>
 		<<set $currentRule.assignFacility = "none">>
 		<<set $currentRule.facilityRemove = false>>
@@ -1322,7 +1372,7 @@
 |
 <<if ($currentRule.setAssignment != "be a servant")>>
 	<<link "House Servant">>
-		<<set removeFromArray($currentRule.assignment, "be a servant")>>
+		<<set $currentRule.assignment.delete("be a servant")>>
 		<<set $currentRule.setAssignment = "be a servant">>
 		<<set $currentRule.assignFacility = "none">>
 		<<set $currentRule.facilityRemove = false>>
@@ -1338,7 +1388,7 @@
 |
 <<if ($currentRule.setAssignment != "stay confined")>>
 	<<link "Confined">>
-		<<set removeFromArray($currentRule.assignment, "stay confined")>>
+		<<set $currentRule.assignment.delete("stay confined")>>
 		<<set $currentRule.setAssignment = "stay confined">>
 		<<set $currentRule.assignFacility = "none">>
 		<<set $currentRule.facilityRemove = false>>
@@ -1354,7 +1404,7 @@
 |
 <<if ($currentRule.setAssignment != "whore")>>
 	<<link "Whore">>
-		<<set removeFromArray($currentRule.assignment, "whore")>>
+		<<set $currentRule.assignment.delete("whore")>>
 		<<set $currentRule.setAssignment = "whore">>
 		<<set $currentRule.assignFacility = "none">>
 		<<set $currentRule.facilityRemove = false>>
@@ -1370,7 +1420,7 @@
 |
 <<if ($currentRule.setAssignment != "serve the public")>>
 	<<link "Public Servant">>
-		<<set removeFromArray($currentRule.assignment, "serve the public")>>
+		<<set $currentRule.assignment.delete("serve the public")>>
 		<<set $currentRule.setAssignment = "serve the public">>
 		<<set $currentRule.assignFacility = "none">>
 		<<set $currentRule.facilityRemove = false>>
@@ -1384,9 +1434,25 @@
 	''Public Servant''
 <</if>>
 |
+<<if ($currentRule.setAssignment != "take classes")>>
+	<<link "Classes">>
+		<<set $currentRule.assignment.delete("take classes")>>
+		<<set $currentRule.setAssignment = "take classes">>
+		<<set $currentRule.assignFacility = "none">>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeApplyAssignment>>
+		<<RAChangeSetAssignment>>
+		<<RAChangeAssignFacility>>
+		<<RAChangeSave>>
+		<<RAChangeApply>>
+	<</link>>
+<<else>>
+	''Milking''
+<</if>>
+|
 <<if ($currentRule.setAssignment != "get milked")>>
 	<<link "Milking">>
-		<<set removeFromArray($currentRule.assignment, "get milked")>>
+		<<set $currentRule.assignment.delete("get milked")>>
 		<<set $currentRule.setAssignment = "get milked">>
 		<<set $currentRule.assignFacility = "none">>
 		<<set $currentRule.facilityRemove = false>>
@@ -1402,7 +1468,7 @@
 |
 <<if ($currentRule.setAssignment != "work a glory hole")>>
 	<<link "Gloryhole">>
-		<<set removeFromArray($currentRule.assignment, "work a glory hole")>>
+		<<set $currentRule.assignment.delete("work a glory hole")>>
 		<<set $currentRule.setAssignment = "work a glory hole">>
 		<<set $currentRule.assignFacility = "none">>
 		<<set $currentRule.facilityRemove = false>>


### PR DESCRIPTION
add reconciliation code to the weekly facility reports to remove slaves that aren't actually assigned to the facility; replace array.delete with array.deleteAt in removeJob widget since the other method didn't work -- and keep searching the facility list after finding a match, so as to remove any duplicates there (players with old saves that have duplicates already will have to manually reassign the erroneous slaves that actually are in the facility at least once to remove the duplicate entries, but we shouldn't be creating more duplicates now)