### PR TITLE
Neighbors Ownership fix

### DIFF
--- a/src/uncategorized/neighborsDevelopment.tw
+++ b/src/uncategorized/neighborsDevelopment.tw
@@ -407,7 +407,11 @@ has an estimated GSP of @@.yellowgreen;¤<<print Math.trunc((0.1*$arcologies[$i]
 		<<set $arcologies[$i].minority = 100-$arcologies[$i].ownership>>
 	<</if>>
 <<else>>
-	<<set $arcologies[$i].minority = 100 - $arcologies[$i].ownership - $arcologies[$i].PCminority>>
+	<<if ($arcologies[$i].ownership + $arcologies[$i].PCminority) >= 99>>
+		<<set $arcologies[$i].ownership = 98 - $arcologies[$i].PCminority>>
+	<<else>>
+		<<set $arcologies[$i].minority = 98 - $arcologies[$i].ownership - $arcologies[$i].PCminority>>
+	<</if>>
 <</if>>
 <</if>>
 <</if>>

--- a/src/uncategorized/neighborsDevelopment.tw
+++ b/src/uncategorized/neighborsDevelopment.tw
@@ -407,7 +407,7 @@ has an estimated GSP of @@.yellowgreen;¤<<print Math.trunc((0.1*$arcologies[$i]
 		<<set $arcologies[$i].minority = 100-$arcologies[$i].ownership>>
 	<</if>>
 <<else>>
-	<<if ($arcologies[$i].ownership + $arcologies[$i].PCminority) >= 99>>
+	<<if (($arcologies[$i].ownership + $arcologies[$i].PCminority) >= 99) && ($arcologies[$i].rival != 1)>>
 		<<set $arcologies[$i].ownership = 98 - $arcologies[$i].PCminority>>
 	<<else>>
 		<<set $arcologies[$i].minority = 98 - $arcologies[$i].ownership - $arcologies[$i].PCminority>>


### PR DESCRIPTION
Fixes the situation where ownership + PCminority >= 100 would never have shares become available (issue #413).  
New code makes 2% ownership become available each week, provided it isn't the rival arcology.