### PR TITLE
saLongTermEffects fixes and significant refactoring

### DIFF
--- a/src/uncategorized/saLongTermEffects.tw
+++ b/src/uncategorized/saLongTermEffects.tw
@@ -4371,10 +4371,6 @@
 			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with the sight of her holes stretched to their limits.">>
 			the sight of her holes stretched to their limits,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her stuffed to her limit">>
-		<<elseif $slaves[$i].preg > 10>>
-			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with growth of her belly and her pregnant pussy.">>
-			the sight of her rounded belly and pregnant pussy,
-			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her pregnant pussy getting pounded">>
 		<<else>>
 			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with the sight of her being fucked.">>
 			the sight of her being fucked,
@@ -4418,9 +4414,6 @@
 	<<elseif ($slaves[$i].sexualQuirk == "size queen")>>
 		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring in slave pornography. Her many fans relish the sight of her holes stretched to their limits.">>
 		the sight of her holes stretched to their limits,
-	<<elseif $slaves[$i].preg > 10>>
-		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish her rounded belly and pregnant pussy.">>
-		the sight of her rounded belly and pregnant pussy,
 	<<else>>
 		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish the sight of her being fucked.">>
 		the sight of her being fucked,
@@ -4462,9 +4455,6 @@
 	<<elseif ($slaves[$i].sexualQuirk == "size queen")>>
 		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed the sight of her holes stretched to their limits.">>
 		the sight of her holes stretched to their limits,
-	<<elseif $slaves[$i].preg > 10>>
-		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed the sight of her rounded belly and pregnant pussy.">>
-		the sight of her rounded belly and pregnant pussy,
 	<<else>>
 		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed the sight of her being fucked.">>
 		the sight of her being fucked,

--- a/src/uncategorized/saLongTermEffects.tw
+++ b/src/uncategorized/saLongTermEffects.tw
@@ -129,13 +129,13 @@
 <<switch $slaves[$i].clothes>>
 <<case "no clothing">>
 <<if $slaves[$i].devotion >= -20>>
-	<<if ($slaves[$i].fetish is "humiliation") && ($slaves[$i].fetishKnown == 0)>>
+	<<if ($slaves[$i].fetish == "humiliation") && ($slaves[$i].fetishKnown == 0)>>
 	She pretends to be embarrassed by her nudity but seems to get off on it. @@.lightcoral;She's into humiliation.@@
-	<<set $slaves[$i].fetishKnown to 1>>
-	<<elseif ($slaves[$i].fetish is "humiliation") && ($slaves[$i].fetishStrength > 60)>>
+	<<set $slaves[$i].fetishKnown = 1>>
+	<<elseif ($slaves[$i].fetish == "humiliation") && ($slaves[$i].fetishStrength > 60)>>
 	She pretends to be embarrassed by her nudity but @@.hotpink;openly gets off on it.@@
 	<<set $slaves[$i].devotion += 2>>
-	<<elseif ($slaves[$i].fetish is "humiliation")>>
+	<<elseif ($slaves[$i].fetish == "humiliation")>>
 	She pretends to be embarrassed by her nudity but @@.hotpink;secretly gets off on it.@@
 	<<set $slaves[$i].devotion += 1>>
 	<<elseif ($slaves[$i].energy > 95)>>
@@ -146,71 +146,71 @@
 <<case "a penitent nuns habit">>
 	The mortification of the flesh she endures from wearing her sackcloth habit slowly and painfully @@.hotpink;purifies her mind@@ of any but devoted, @@.gold;fearful@@ thoughts. It's also @@.red;unhealthy.@@
 	<<set $slaves[$i].devotion += 2, $slaves[$i].trust -= 2, $slaves[$i].health -= 3>>
-	<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 0)>>
+	<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 0)>>
 		Her chafed skin makes sex an agonizing prospect. She seems to get off on the pain; she's a @@.lightcoral;natural masochist.@@
-		<<set $slaves[$i].fetishKnown to 1>>
-	<<elseif ($slaves[$i].fetish is "none") || ($slaves[$i].fetishKnown == 0)>>
+		<<set $slaves[$i].fetishKnown = 1>>
+	<<elseif ($slaves[$i].fetish == "none") || ($slaves[$i].fetishKnown == 0)>>
 		<<if $fetishChangeChance > random(0,100)>>
 		Her chafed skin makes sex an agonizing prospect. She learns to come in spite of, and then @@.lightcoral;because of the pain.@@
-		<<set $slaves[$i].fetish to "masochist", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+		<<set $slaves[$i].fetish = "masochist", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 		<</if>>
 	<</if>>
 <<case "uncomfortable straps">>
-	<<if ($slaves[$i].devotion >= -20) && ($slaves[$i].fetish is "masochist")>>
+	<<if ($slaves[$i].devotion >= -20) && ($slaves[$i].fetish == "masochist")>>
 	The uncomfortable straps she's wearing constantly give her little twinges of pain, @@.hotpink;titillating her.@@
 	<<set $slaves[$i].devotion += 2>>
 	<<elseif ($slaves[$i].devotion <= 20) && ($slaves[$i].trust >= -50)>>
 	The uncomfortable straps she's wearing keep her @@.hotpink;servile@@ and @@.gold;afraid.@@
 	<<set $slaves[$i].devotion += 1, $slaves[$i].trust -= 1>>
-	<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 0)>>
+	<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 0)>>
 		The straps pinch and constrict her whenever she's used.  She seems to get off on the discomfort; she's a  @@.lightcoral;natural masochist.@@
-		<<set $slaves[$i].fetishKnown to 1>>
-	<<elseif ($slaves[$i].fetish is "none") || ($slaves[$i].fetishKnown == 0)>>
+		<<set $slaves[$i].fetishKnown = 1>>
+	<<elseif ($slaves[$i].fetish == "none") || ($slaves[$i].fetishKnown == 0)>>
 		<<if $fetishChangeChance > random(0,100)>>
 		The straps pinch and constrict her whenever she's used.  She learns to come in spite of, and then @@.lightcoral;because of the discomfort.@@
-		<<set $slaves[$i].fetish to "masochist", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+		<<set $slaves[$i].fetish = "masochist", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 		<</if>>
 	<</if>>
 	<<else>>
-	<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 0)>>
+	<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 0)>>
 		Her straps pinch and constrict her whenever she's used.  She seems to get off on the discomfort; she's a  @@.lightcoral;natural masochist.@@
-		<<set $slaves[$i].fetishKnown to 1>>
-	<<elseif ($slaves[$i].fetish is "none") || ($slaves[$i].fetishKnown == 0)>>
+		<<set $slaves[$i].fetishKnown = 1>>
+	<<elseif ($slaves[$i].fetish == "none") || ($slaves[$i].fetishKnown == 0)>>
 		<<if $fetishChangeChance > random(0,100)>>
 		Her straps pinch and constrict her whenever she's used.  She learns to come in spite of, and then @@.lightcoral;because of the discomfort.@@
-		<<set $slaves[$i].fetish to "masochist", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+		<<set $slaves[$i].fetish = "masochist", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 		<</if>>
 	<</if>>
 	<</if>>
 <<case "chains">>
-	<<if ($slaves[$i].devotion >= -20) && ($slaves[$i].fetish is "masochist")>>
+	<<if ($slaves[$i].devotion >= -20) && ($slaves[$i].fetish == "masochist")>>
 	The chains she's wearing constantly give her little twinges of pain, @@.hotpink;titillating her.@@
 	<<set $slaves[$i].devotion += 2>>
 	<<elseif ($slaves[$i].devotion <= 20) && ($slaves[$i].trust >= -50)>>
 	The chains she's wearing keep her @@.hotpink;servile@@ and @@.gold;afraid.@@
 	<<set $slaves[$i].devotion += 1, $slaves[$i].trust -= 1>>
-	<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 0)>>
+	<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 0)>>
 		Her chains pinch and constrict her whenever she's used.  She seems to get off on the discomfort; she's a  @@.lightcoral;natural masochist.@@
-		<<set $slaves[$i].fetishKnown to 1>>
-	<<elseif ($slaves[$i].fetish is "none") || ($slaves[$i].fetishKnown == 0)>>
+		<<set $slaves[$i].fetishKnown = 1>>
+	<<elseif ($slaves[$i].fetish == "none") || ($slaves[$i].fetishKnown == 0)>>
 		<<if $fetishChangeChance > random(0,100)>>
 		Her chains pinch and constrict her whenever she's used.  She learns to come in spite of, and then @@.lightcoral;because of the discomfort.@@
-		<<set $slaves[$i].fetish to "masochist", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+		<<set $slaves[$i].fetish = "masochist", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 		<</if>>
 	<</if>>
 	<<else>>
-	<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 0)>>
+	<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 0)>>
 		Her chains pinch and constrict her whenever she's used.  She seems to get off on the discomfort; she's a  @@.lightcoral;natural masochist.@@
-		<<set $slaves[$i].fetishKnown to 1>>
-	<<elseif ($slaves[$i].fetish is "none") || ($slaves[$i].fetishKnown == 0)>>
+		<<set $slaves[$i].fetishKnown = 1>>
+	<<elseif ($slaves[$i].fetish == "none") || ($slaves[$i].fetishKnown == 0)>>
 		<<if $fetishChangeChance > random(0,100)>>
 		Her chains pinch and constrict her whenever she's used.  She learns to come in spite of, and then @@.lightcoral;because of the discomfort.@@
-		<<set $slaves[$i].fetish to "masochist", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+		<<set $slaves[$i].fetish = "masochist", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 		<</if>>
 	<</if>>
 	<</if>>
 <<case "restrictive latex">>
-	<<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust >= -50) && ($slaves[$i].fetish is "submissive")>>
+	<<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust >= -50) && ($slaves[$i].fetish == "submissive")>>
 	<<if ($slaves[$i].fetishStrength > 60)>>
 	As a submissive she @@.hotpink;openly enjoys being immured in latex.@@
 	<<set $slaves[$i].devotion += 2>>
@@ -223,7 +223,7 @@
 	<<set $slaves[$i].devotion += 1, $slaves[$i].trust -= 1>>
 	<</if>>
 <<case "shibari ropes">>
-	<<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust >= -50) && ($slaves[$i].fetish is "submissive")>>
+	<<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust >= -50) && ($slaves[$i].fetish == "submissive")>>
 	<<if ($slaves[$i].fetishStrength > 60)>>
 	As a submissive she @@.hotpink;openly enjoys wearing binding ropes as clothing.@@
 	<<set $slaves[$i].devotion += 2>>
@@ -239,7 +239,7 @@
 	<<if ($slaves[$i].devotion <= 20)>>
 		She is @@.mediumorchid;inappropriately proud@@ of the nice clothes she's wearing, @@.mediumaquamarine;building her confidence.@@
 		<<set $slaves[$i].devotion -= 5, $slaves[$i].trust += 3>>
-	<<elseif $slaves[$i].fetish is "humiliation" && ($slaves[$i].clothes is "a string bikini" || $slaves[$i].clothes is "clubslut netting")>>
+	<<elseif $slaves[$i].fetish == "humiliation" && ($slaves[$i].clothes == "a string bikini" || $slaves[$i].clothes == "clubslut netting")>>
 		<<if ($slaves[$i].fetishStrength > 60)>>
 			She pretends to be embarrassed by her extremely revealing clothing but @@.hotpink;openly gets off on it.@@
 			<<set $slaves[$i].devotion += 2>>
@@ -247,10 +247,10 @@
 			She pretends to be embarrassed by her extremely revealing clothing but @@.hotpink;secretly gets off on it.@@
 			<<set $slaves[$i].devotion += 1>>
 		<</if>>
-	<<elseif ($slaves[$i].clothes is "attractive lingerie") && ($slaves[$i].dick > 0)>>
+	<<elseif ($slaves[$i].dick > 0) && ($slaves[$i].clothes == "attractive lingerie")>>
 		She is @@.hotpink;proud@@ of the pretty lingerie she's wearing, but she constantly has to adjust her g-string to cover her penis.
 		<<set $slaves[$i].devotion += 1>>
-	<<elseif ($slaves[$i].clothes is "a string bikini") && ($slaves[$i].dick > 0)>>
+	<<elseif ($slaves[$i].dick > 0) && ($slaves[$i].clothes == "a string bikini")>>
 		She is @@.hotpink;proud@@ of the slutty lingerie she's wearing, but she constantly has to adjust her string bikini bottom in a vain effort to cover her penis.
 		<<set $slaves[$i].devotion += 1>>
 	<<else>>
@@ -260,7 +260,7 @@
 <</switch>>
 
 <<if ($slaves[$i].fetishKnown == 0)>>
-<<if ($slaves[$i].fetish is "humiliation")>>
+<<if ($slaves[$i].fetish == "humiliation")>>
 <<if random(1,100) > 90>>
 <<if $slaves[$i].clothes != "conservative clothing">>
 <<if $slaves[$i].clothes != "a toga">>
@@ -288,7 +288,7 @@
 <<if $slaves[$i].clothes != "a latex catsuit">>
 <<if $slaves[$i].clothes != "a military uniform">>
 	Surprisingly, she takes to her extremely revealing clothing, and gets an obvious thrill from it. @@.green;She's a humiliation fetishist!@@
-	<<set  $slaves[$i].fetishKnown to 1>>
+	<<set $slaves[$i].fetishKnown = 1>>
 <</if>>
 <</if>>
 <</if>>
@@ -318,10 +318,10 @@
 <</if>>
 <</if>>
 
-<<if ($slaves[$i].vaginalAccessory is "chastity belt")>>
+<<if ($slaves[$i].vaginalAccessory == "chastity belt")>>
 	<<if ($slaves[$i].devotion > 20)>>
 	<<if ($slaves[$i].vagina == 0)>>
-		<<if ($slaves[$i].fetish is "buttslut") && ($slaves[$i].fetishStrength > 60)>>
+		<<if ($slaves[$i].fetish == "buttslut") && ($slaves[$i].fetishStrength > 60)>>
 			She's such an anal whore that she's @@.hotpink;perversely proud@@ of the chastity belt that covers her neglected pussy.
 			<<set $slaves[$i].devotion += 1>>
 		<<else>>
@@ -330,7 +330,7 @@
 		<</if>>
 	<<else>>
 		<<if ($slaves[$i].energy > 60)>>
-		<<if ($slaves[$i].fetish is "buttslut") && ($slaves[$i].fetishStrength > 60)>>
+		<<if ($slaves[$i].fetish == "buttslut") && ($slaves[$i].fetishStrength > 60)>>
 			She's such a butthole slut that she doesn't care about having her pussy kept off limits.
 		<<elseif ($slaves[$i].energy > 95)>>
 			She's such a nympho that having her butthole do double duty for her pussy doesn't bother her.
@@ -342,11 +342,11 @@
 	<</if>>
 	<</if>>
 <</if>>
-<<if ($slaves[$i].dickAccessory is "chastity")>>
+<<if ($slaves[$i].dickAccessory == "chastity")>>
 	<<if ($slaves[$i].devotion >= -20)>>
 	<<if ($slaves[$i].energy > 40)>>
 	<<if ($slaves[$i].hormones <= 0)>>
-	<<if ($slaves[$i].fetish is "buttslut") && ($slaves[$i].fetishStrength > 60)>>
+	<<if ($slaves[$i].fetish == "buttslut") && ($slaves[$i].fetishStrength > 60)>>
 		She's such a butthole slut that she manages to get off just fine despite her dick being kept untouchable and soft behind a chastity cage.
 	<<elseif ($slaves[$i].energy > 95)>>
 		Her sex drive is so overcharged that she manages to orgasm often despite the chastity cage that <<if ($slaves[$i].balls == 0)>>prevents her or anyone else from touching her soft cock<<else>>keeps her dick soft and untouched<</if>>; it's almost always dripping a stream of precum.
@@ -369,8 +369,8 @@
 <</if>>
 
 <<if ($arcologies[0].FSChattelReligionist != "unset")>>
-<<if ($slaves[$i].behavioralQuirk is "sinful")>>
-<<if ($slaves[$i].clothes is "a fallen nuns habit") || ($slaves[$i].clothes is "a chattel habit") || ($slaves[$i].clothes is "a succubus outfit")>>
+<<if ($slaves[$i].behavioralQuirk == "sinful")>>
+<<if ($slaves[$i].clothes == "a fallen nuns habit") || ($slaves[$i].clothes == "a chattel habit") || ($slaves[$i].clothes == "a succubus outfit")>>
 	She's @@.hotpink;gratified@@ by the sacrilegious clothing she's wearing, glad to be an obvious anathema to old world faiths.
 	<<set $slaves[$i].devotion += 1>>
 <</if>>
@@ -380,49 +380,49 @@
 /* ACCESSORIES */
 <<if ($slaves[$i].collar != "none")>>
 <<if ($slaves[$i].devotion <= 20)>>
-	<<if ($slaves[$i].devotion <= 20) && (($slaves[$i].collar is "tight steel") || ($slaves[$i].collar is "cruel retirement counter"))>>
+	<<if ($slaves[$i].devotion <= 20) && (($slaves[$i].collar == "tight steel") || ($slaves[$i].collar == "cruel retirement counter"))>>
 		The tight metal collar she's wearing @@.gold;reminds her to be afraid@@ every time she takes a breath.
 		<<set $slaves[$i].trust -= 1>>
-	<<elseif ($slaves[$i].collar is "uncomfortable leather") || ($slaves[$i].collar is "neck corset")>>
+	<<elseif ($slaves[$i].collar == "uncomfortable leather") || ($slaves[$i].collar == "neck corset")>>
 		The uncomfortable leather collar she's wearing @@.gold;reminds her to be afraid@@ every time she turns her head.
 		<<set $slaves[$i].trust -= 1>>
-	<<elseif ($slaves[$i].collar is "dildo gag")>>
+	<<elseif ($slaves[$i].collar == "dildo gag")>>
 		The dildo gag she's wearing @@.gold;reminds her to be afraid@@ with every breath she must carefully take through her nose.
 		<<set $slaves[$i].trust -= 1>>
-	<<elseif ($slaves[$i].collar is "shock punishment")>>
+	<<elseif ($slaves[$i].collar == "shock punishment")>>
 		The shock collar she's wearing makes her frequent, deserved punishments @@.gold;immediate, inescapable,@@ and @@.mediumorchid;awful.@@
 		<<set $slaves[$i].devotion -= 2, $slaves[$i].trust -= 5>>
 		<<if ($slaves[$i].devotion < -20) && ($slaves[$i].behavioralFlaw != "odd")>>
 			Since she's rebellious her life is near-constant electroshock torture. Her resistance is @@.hotpink;worn down by the agony@@ and she is @@.gold;thoroughly cowed,@@ but she has been @@.red;emotionally damaged@@ by the experience to the extent that further shock torture is not likely to affect her as greatly.
 			<<set $slaves[$i].devotion += 10>>
 			<<set $slaves[$i].trust -= 10>>
-			<<set $slaves[$i].behavioralFlaw to "odd">>
+			<<set $slaves[$i].behavioralFlaw = "odd">>
 		<</if>>
 	<<elseif ($slaves[$i].devotion >= -20)>>
 		She is @@.mediumorchid;inappropriately proud@@ and @@.mediumaquamarine;confident@@ of the nice collar she's wearing.
 		<<set $slaves[$i].devotion -= 5, $slaves[$i].trust += 3>>
 	<</if>>
 <<else>>
-	<<if (($slaves[$i].collar is "heavy gold") || ($slaves[$i].collar is "ancient Egyptian"))>>
+	<<if (($slaves[$i].collar == "heavy gold") || ($slaves[$i].collar == "ancient Egyptian"))>>
 		She bears the burden of her heavy gold collar with @@.mediumaquamarine;confidence.@@
 		<<set $slaves[$i].trust += 1>>
-	<<elseif ($slaves[$i].collar is "bowtie")>>
+	<<elseif ($slaves[$i].collar == "bowtie")>>
 		The bowtie and shirt collar she wears fill her with @@.mediumaquamarine;confidence,@@ since although they conceal a more traditional slave collar that can be used to restrain her, they don't look like it.
 		<<set $slaves[$i].trust += 1>>
-	<<elseif ($slaves[$i].collar is "pretty jewelry") || ($slaves[$i].collar is "nice retirement counter") || ($slaves[$i].collar is "satin choker") || ($slaves[$i].collar is "nice retirement counter") || ($slaves[$i].collar is "stylish leather")>>
+	<<elseif ($slaves[$i].collar == "pretty jewelry") || ($slaves[$i].collar == "nice retirement counter") || ($slaves[$i].collar == "satin choker") || ($slaves[$i].collar == "nice retirement counter") || ($slaves[$i].collar == "stylish leather")>>
 		The lovely collar she wears fills her with @@.mediumaquamarine;confidence.@@
 		<<set $slaves[$i].trust += 1>>
-	<<elseif ($slaves[$i].collar is "leather with cowbell")>>
-		<<if ($slaves[$i].fetish is "boobs") && ($slaves[$i].fetishStrength > 95)>>
+	<<elseif ($slaves[$i].collar == "leather with cowbell")>>
+		<<if ($slaves[$i].fetish == "boobs") && ($slaves[$i].fetishStrength > 95)>>
 		  She @@.hotpink;loves@@ how her cow collar encourages everyone to fuck her udders.
 		  <<set $slaves[$i].devotion += 1>>
-		<<elseif ($slaves[$i].fetish is "boobs") || ($slaves[$i].energy > 95)>>
+		<<elseif ($slaves[$i].fetish == "boobs") || ($slaves[$i].energy > 95)>>
 		  She @@.hotpink;likes@@ how her cow collar encourages everyone to touch her udders.
 		  <<set $slaves[$i].devotion += 1>>
 		<</if>>
 	<</if>>
 <</if>>
-<<if ($slaves[$i].collar is "dildo gag")>>
+<<if ($slaves[$i].collar == "dildo gag")>>
   <<if $slaves[$i].oralSkill <= 10>>
 	Living gagged by a dildo, she can't help but get better at having things down her throat.
 	<<set $skillIncrease = 5>><<OralSkillIncrease $slaves[$i]>>
@@ -431,26 +431,26 @@
 <</if>>
 
 <<if $slaves[$i].bellyAccessory != "none">>
-<<if $slaves[$i].bellyAccessory is "an extreme corset">>
+<<if $slaves[$i].bellyAccessory == "an extreme corset">>
 	<<if $slaves[$i].preg > 10>>
 		The tight corseting has @@.orange;caused her to miscarry,@@ which @@.red;damages her health.@@
-		<<set  $slaves[$i].health -= 20>>
+		<<set $slaves[$i].health -= 20>>
 		<<if ($slaves[$i].assignmentVisible == 1) && (lastPregRule($slaves[$i], $defaultRules))>><<set $slaves[$i].preg to -1>><<else>><<set $slaves[$i].preg to 0>><</if>>
 		She is
 		<<if $slaves[$i].devotion < -50>>
 			@@.mediumorchid;filled with violent, consuming hatred@@ and @@.gold;fear.@@ Even though she knew her baby was destined for a slave orphanage, it seems she cared for it and views you as its killer.
-			<<set  $slaves[$i].devotion -= 25,  $slaves[$i].trust -= 25>>
+			<<set $slaves[$i].devotion -= 25,  $slaves[$i].trust -= 25>>
 		<<elseif $slaves[$i].devotion < -20>>
 			@@.mediumorchid;afflicted by desperate, inconsolable grief@@ and @@.gold;horror.@@ Even though she knew her baby was destined for a slave orphanage, it seems she cared for it.
-			<<set  $slaves[$i].devotion -= 10,  $slaves[$i].trust -= 20>>
+			<<set $slaves[$i].devotion -= 10,  $slaves[$i].trust -= 20>>
 		<<elseif $slaves[$i].devotion <= 20>>
 			@@.mediumorchid;consumed by enduring sorrow@@ and @@.gold;horror.@@ Even though she knew her baby was destined for a slave orphanage, it seems she cared for it.
-			<<set  $slaves[$i].devotion -= 5,  $slaves[$i].trust -= 5>>
+			<<set $slaves[$i].devotion -= 5,  $slaves[$i].trust -= 5>>
 		<<elseif $slaves[$i].devotion <= 50>>
 			dully obedient. She has been broken to slave life so thoroughly that even this is neither surprising nor affecting.
 		<<else>>
 			@@.hotpink;pleased by this stark development@@, since she is so attentive to your will. She also expects she'll be able to fuck better now.
-			<<set  $slaves[$i].devotion += 4>>
+			<<set $slaves[$i].devotion += 4>>
 		<</if>>
 	<<else>>
 		<<if $slaves[$i].waist < -95>>
@@ -466,10 +466,10 @@
 					<<set $slaves[$i].devotion += 2>>
 					<<set $slaves[$i].trust -= 2>>
 				<</if>>
-				<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 0)>>
+				<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 0)>>
 					During sex, every breath in and out is agonizing. Despite this, she seems to get off on the pain; she's a  @@.lightcoral;natural masochist.@@
 					<<set $slaves[$i].fetishKnown = 1>>
-				<<elseif ($slaves[$i].fetish is "none") || ($slaves[$i].fetishKnown == 0)>>
+				<<elseif ($slaves[$i].fetish == "none") || ($slaves[$i].fetishKnown == 0)>>
 					<<if $fetishChangeChance > random(0,100)>>
 						During sex, every breath in and out is agonizing. She learns to come in spite of, and then @@.lightcoral;because of the pain.@@
 						<<set $slaves[$i].fetish = "masochist", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
@@ -478,7 +478,7 @@
 			<</if>>
 		<</if>>
 	<</if>>
-<<elseif $slaves[$i].bellyAccessory is "a corset">>
+<<elseif $slaves[$i].bellyAccessory == "a corset">>
 	<<if $slaves[$i].preg > 10>>
 		Her corset lets her growing belly protrude comfortably, preventing any danger to her pregnancy but preventing any effect on her waist.
 	<<else>>
@@ -490,7 +490,7 @@
 		<</if>>
 	<</if>>
 <<elseif $fakeBellies.includes($bellyAccessory)>>
-  <<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust >= -50) && ($slaves[$i].fetish is "pregnancy")>>
+  <<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust >= -50) && ($slaves[$i].fetish == "pregnancy")>>
 	<<if ($slaves[$i].fetishStrength > 60)>>
 	  As a pregnancy fetishist, she @@.hotpink;openly enjoys@@ wearing her fake belly around.
 	  <<set $slaves[$i].devotion += 2>>
@@ -498,17 +498,17 @@
 	  Her interest in pregnancy helps her @@.hotpink;enjoy@@ wearing a fake belly.
 	  <<set $slaves[$i].devotion += 1>>
 	<</if>>
-  <<elseif ($slaves[$i].fetish is "pregnancy") && ($slaves[$i].devotion > 50)>>
+  <<elseif ($slaves[$i].fetish == "pregnancy") && ($slaves[$i].devotion > 50)>>
 	She carries her fake belly @@.hotpink;with pride@@, eager for the day you give her one of her own.
 	<<set $slaves[$i].devotion += 1>>
-  <<elseif ($slaves[$i].fetish is "pregnancy") && ($slaves[$i].preg == 0) && ($slaves[$i].vagina > -1)>>
+  <<elseif ($slaves[$i].fetish == "pregnancy") && ($slaves[$i].preg == 0) && ($slaves[$i].vagina > -1)>>
 	The fake belly she wears @@.mediumorchid;reminds her@@ that she isn't pregnant with a child.
 	<<set $slaves[$i].devotion -= 1>>
   <<elseif ($slaves[$i].vagina == 0)>>
 	The fake belly she wears @@.gold;worries@@ her that you will soon put a real baby in her.
 	<<set $slaves[$i].trust -= 1>>
   <</if>>
-  <<if $slaves[$i].bellyAccessory is "a huge empathy belly" and $slaves[$i].fetish != "pregnancy">>
+  <<if $slaves[$i].bellyAccessory == "a huge empathy belly" and $slaves[$i].fetish != "pregnancy">>
 	<<if $slaves[$i].devotion > 50>>
 	  Her full-sized twins belly is heavy and unwieldy, but she carries it @@.hotpink;proudly@@ for you.
 	  <<set $slaves[$i].devotion += 1>>
@@ -517,64 +517,64 @@
 	  <<set $slaves[$i].devotion -= 1>>
 	<</if>>
   <</if>>
-  <<if ($slaves[$i].fetish is "pregnancy") && ($slaves[$i].fetishStrength <= 95)>>
+  <<if ($slaves[$i].fetish == "pregnancy") && ($slaves[$i].fetishStrength <= 95)>>
   <<if random(1,100) >= 20>>
 	Pretending to be pregnant has @@.lightcoral;furthered her interest in pregnancy@@.
 	<<set $slaves[$i].fetishStrength += 4>>
   <<elseif ($slaves[$i].fetishStrength <= 40)>>
 	Lugging around a fake pregnancy for the week has shown her she isn't as into pregnancy as she thought.
-	<<set $slaves[$i].fetish to "none", $slaves[$i].fetishStrength = 10>>
+	<<set $slaves[$i].fetish = "none", $slaves[$i].fetishStrength = 10>>
   <</if>>
   <</if>>
 <</if>>
 <</if>>
 
-<<if ($slaves[$i].shoes is "heels")>>
+<<if ($slaves[$i].shoes == "heels")>>
 	<<if ($slaves[$i].amp < 0)>>
 		Her P-Limb legs work just as well in heels as they do out of them.
 	<<else>>
 		<<if $slaves[$i].devotion < -20>>
 			She @@.mediumorchid;resents being forced@@ to wear high heels.
-			<<set  $slaves[$i].devotion -= 2>>
+			<<set $slaves[$i].devotion -= 2>>
 		<</if>>
 	<</if>>
-<<elseif ($slaves[$i].shoes is "boots")>>
+<<elseif ($slaves[$i].shoes == "boots")>>
 	<<if ($slaves[$i].amp < 0)>>
 		Her P-Limb legs work just as well in boots as they do out of them.
 	<<else>>
 		<<if $slaves[$i].devotion < -20>>
 			She @@.mediumorchid;resents being forced@@ to wear high heeled boots.
-			<<set  $slaves[$i].devotion -= 2>>
+			<<set $slaves[$i].devotion -= 2>>
 		<</if>>
 	<</if>>
-<<elseif ($slaves[$i].shoes is "extreme heels")>>
+<<elseif ($slaves[$i].shoes == "extreme heels")>>
 	<<if ($slaves[$i].amp < 0)>>
 		Her P-Limb legs work just as well in extreme heels as they do out of them.
 	<<else>>
 		<<if $slaves[$i].devotion < -20>>
 			She @@.mediumorchid;resents being forced@@ to wear @@.gold;painfully@@ high heels.
-			<<set  $slaves[$i].devotion -= 2>>
-			<<set  $slaves[$i].trust -= 2>>
+			<<set $slaves[$i].devotion -= 2>>
+			<<set $slaves[$i].trust -= 2>>
 		<<else>>
 			She is kept @@.hotpink;mindful@@ and @@.gold;fearful@@ by the difficulty of walking in her extreme heels.
-			<<set  $slaves[$i].devotion += 1>>
-			<<set  $slaves[$i].trust -= 1>>
+			<<set $slaves[$i].devotion += 1>>
+			<<set $slaves[$i].trust -= 1>>
 		<</if>>
 		They're so high they're a bit @@.red;unhealthy@@ for her legs.
-		<<set  $slaves[$i].health -= 2>>
+		<<set $slaves[$i].health -= 2>>
 	<</if>>
 <<else>>
 	<<if ($slaves[$i].heels == 1)>>
 	<<if !canWalk($slaves[$i])>>
 	<<if ($slaves[$i].fetish != "mindbroken")>>
-	<<if ($slaves[$i].devotion >= -20) && ($slaves[$i].fetish is "submissive") && ($slaves[$i].fetishKnown == 1)>>
+	<<if ($slaves[$i].devotion >= -20) && ($slaves[$i].fetish == "submissive") && ($slaves[$i].fetishKnown == 1)>>
 		She @@.hotpink;loves being forced@@ to crawl around like some kind of animal.
-		<<set  $slaves[$i].devotion += 1>>
+		<<set $slaves[$i].devotion += 1>>
 	<<elseif $slaves[$i].devotion > 50>>
 		She accepts being forced to crawl around on all fours.
 	<<else>>
 		She @@.mediumorchid;resents being forced@@ to crawl around like some kind of animal, but it keeps her properly @@.gold;afraid.@@
-		<<set  $slaves[$i].devotion -= 2,  $slaves[$i].trust -= 4>>
+		<<set $slaves[$i].devotion -= 2,  $slaves[$i].trust -= 4>>
 	<</if>>
 	<</if>>
 	<</if>>
@@ -585,7 +585,7 @@
 <</if>> /* CLOSES FUCKDOLL CHECK FOR MENTAL ONLY ITEM EFFECTS */
 
 <<if ($slaves[$i].vaginalAccessory != "none")>>
-<<if ($slaves[$i].vaginalAccessory is "dildo")>>
+<<if ($slaves[$i].vaginalAccessory == "dildo")>>
 	<<if ($slaves[$i].vagina < 1) && (random(1,100) > 50)>>
 		Constantly wearing a dildo in her virgin pussy @@.lime;gets it used to penetration.@@
 		<<set $slaves[$i].vagina += 1>>
@@ -594,13 +594,13 @@
 	<</if>>
 	<<if $slaves[$i].fuckdoll == 0>>
 	<<if $slaves[$i].fetish != "mindbroken">>
-	<<if ($slaves[$i].sexualFlaw is "hates penetration") && (random(1,100) > 50)>>
+	<<if ($slaves[$i].sexualFlaw == "hates penetration") && (random(1,100) > 50)>>
 		The habit @@.green;reduces her dislike of having her pussy filled.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<</if>>
 	<</if>>
 	<</if>>
-<<elseif ($slaves[$i].vaginalAccessory is "large dildo")>>
+<<elseif ($slaves[$i].vaginalAccessory == "large dildo")>>
 	<<if $slaves[$i].vagina < 3>>
 		<<if random(1,4) == 1>>
 			Constantly wearing a large dildo in her pussy @@.lime;stretches it out.@@
@@ -615,7 +615,7 @@
 	<<if $slaves[$i].fetish != "mindbroken">>
 	<<if ($slaves[$i].vagina < 2)>>
 		The big dildo in her tight cunt
-		<<if ($slaves[$i].sexualQuirk is "size queen")>>
+		<<if ($slaves[$i].sexualQuirk == "size queen")>>
 			is a @@.hotpink;point of pride@@ for the ostentatious size queen.
 			<<set $slaves[$i].devotion += 2>>
 		<<else>>
@@ -629,17 +629,17 @@
 	<</if>>
 	<</if>>
 	<</if>>
-<<elseif ($slaves[$i].vaginalAccessory is "huge dildo")>>
+<<elseif ($slaves[$i].vaginalAccessory == "huge dildo")>>
 	<<if ($slaves[$i].vagina < 4)>>
 		<<if $slaves[$i].fuckdoll == 0>>
 		<<if $slaves[$i].fetish != "mindbroken">>
-		<<if ($slaves[$i].sexualQuirk is "size queen")>>
+		<<if ($slaves[$i].sexualQuirk == "size queen")>>
 			She thinks of the massive dildo stretching out her womanhood as @@.lime;preparation for the biggest cocks,@@ and @@.hotpink;looks forward@@ to take anything, dicks, hands, truly anything, inside her newly capacious cunt.
 			<<set $slaves[$i].devotion += 4>>
-		<<elseif ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
+		<<elseif ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
 			She gets off on the agony of having her cunt @@.lime;permanently stretched@@ by a huge dildo. The terrible combination of pain and pleasure @@.hotpink;breaks her will@@ but fills her with @@.gold;fear.@@
 			<<set $slaves[$i].devotion += 5, $slaves[$i].trust -= 5>>
-		<<elseif ($slaves[$i].fetish is "submissive") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
+		<<elseif ($slaves[$i].fetish == "submissive") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
 			She submits to the agony of having her cunt @@.lime;permanently stretched@@ by a huge dildo. Having her hole ruined at your whim @@.hotpink;breaks her will@@ but fills her with @@.gold;fear.@@
 			<<set $slaves[$i].devotion += 5, $slaves[$i].trust -= 5>>
 		<<else>>
@@ -656,7 +656,7 @@
 <</if>>
 
 <<if ($slaves[$i].buttplug != "none")>>
-<<if ($slaves[$i].buttplug is "plug")>>
+<<if ($slaves[$i].buttplug == "plug")>>
 	<<if $slaves[$i].fuckdoll == 0>>
 	<<if $slaves[$i].fetish != "mindbroken">>
 	<<if $slaves[$i].anus < 1>>
@@ -665,18 +665,18 @@
 	<<else>>
 		Her asshole is used to being penetrated and wearing her buttplug doesn't affect it.
 	<</if>>
-	<<if ($slaves[$i].sexualFlaw is "hates anal") && (random(1,100) > 50)>>
+	<<if ($slaves[$i].sexualFlaw == "hates anal") && (random(1,100) > 50)>>
 		It @@.green;gets her habituated to having her asshole filled.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<</if>>
 	<</if>>
 	<</if>>
-<<elseif ($slaves[$i].buttplug is "large plug")>>
+<<elseif ($slaves[$i].buttplug == "large plug")>>
 	<<if $slaves[$i].fuckdoll == 0>>
 	<<if $slaves[$i].fetish != "mindbroken">>
 	<<if ($slaves[$i].anus < 2)>>
 		The uncomfortable plug in her asshole
-		<<if ($slaves[$i].sexualQuirk is "size queen")>>
+		<<if ($slaves[$i].sexualQuirk == "size queen")>>
 			@@.hotpink;gets her off,@@ since she's a size queen.
 			<<set $slaves[$i].devotion += 2>>
 		<<else>>
@@ -700,17 +700,17 @@
 	<<else>>
 		Her anus accommodates the large plug she's required to wear.
 	<</if>>
-<<elseif ($slaves[$i].buttplug is "huge plug")>>
+<<elseif ($slaves[$i].buttplug == "huge plug")>>
 	<<if ($slaves[$i].anus < 4)>>
 		<<if $slaves[$i].fuckdoll == 0>>
 		<<if $slaves[$i].fetish != "mindbroken">>
-		<<if ($slaves[$i].sexualQuirk is "size queen")>>
+		<<if ($slaves[$i].sexualQuirk == "size queen")>>
 			She thinks of the horribly huge plug she has wear in her butt as @@.lime;preparation for the biggest cocks,@@ and @@.hotpink;looks forward@@ to being able to safely take unlubricated anal from them.
 			<<set $slaves[$i].devotion += 4>>
-		<<elseif ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
+		<<elseif ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
 			She gets off on the agony of having her anal sphincter @@.lime;permanently gaped@@ by a huge buttplug. The terrible combination of pain and pleasure @@.hotpink;breaks her will@@ but fills her with @@.gold;fear.@@
 			<<set $slaves[$i].devotion += 5, $slaves[$i].trust -= 5>>
-		<<elseif ($slaves[$i].fetish is "submissive") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
+		<<elseif ($slaves[$i].fetish == "submissive") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
 			She submits to the agony of having her anal sphincter @@.lime;permanently gaped@@ by a huge buttplug. Having her hole ruined at your whim @@.hotpink;breaks her will@@ but fills her with @@.gold;fear.@@
 			<<set $slaves[$i].devotion += 5, $slaves[$i].trust -= 5>>
 		<<else>>
@@ -726,14 +726,14 @@
 <</if>>
 <<if $slaves[$i].fuckdoll == 0>>
 <<if $slaves[$i].fetish != "mindbroken">>
-<<if ($slaves[$i].buttplug is "plug") || ($slaves[$i].buttplug is "large plug")>>
-	<<if ($slaves[$i].fetish is "buttslut") && ($slaves[$i].fetishKnown == 0)>>
+<<if ($slaves[$i].buttplug == "plug") || ($slaves[$i].buttplug == "large plug")>>
+	<<if ($slaves[$i].fetish == "buttslut") && ($slaves[$i].fetishKnown == 0)>>
 		She shows a surprising lack of resistance to the routine of getting the plug up her butt in the morning; she seems to @@.lightcoral;naturally enjoy anal stimulation.@@
-		<<set $slaves[$i].fetishKnown to 1>>
-	<<elseif ($slaves[$i].fetish is "none") || ($slaves[$i].fetishKnown == 0)>>
+		<<set $slaves[$i].fetishKnown = 1>>
+	<<elseif ($slaves[$i].fetish == "none") || ($slaves[$i].fetishKnown == 0)>>
 	<<if $fetishChangeChance > random(0,100)>>
 		Slowly, her anguish at getting the plug up her butt in the morning turns to secret enjoyment and finally to @@.pink;open arousal at having her anus filled.@@
-		<<set $slaves[$i].fetish to "buttslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+		<<set $slaves[$i].fetish = "buttslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 	<</if>>
 	<</if>>
 <</if>>
@@ -743,8 +743,8 @@
 
 <</if>> /* END CLOTHES AND ACCESSORIES */
 
-<<if $slaves[$i].fetish is "mindbroken">>
-	<<set $slaves[$i].fetishStrength = 10, $slaves[$i].attrXY to 50, $slaves[$i].attrXX to 50, $slaves[$i].attrKnown to 1, $slaves[$i].devotion = 40, $slaves[$i].trust = -40, $slaves[$i].vaginalSkill = Math.clamp($slaves[$i].vaginalSkill,0,15), $slaves[$i].oralSkill = Math.clamp($slaves[$i].oralSkill,0,15), $slaves[$i].analSkill = Math.clamp($slaves[$i].analSkill,0,15), $slaves[$i].combatSkill = 0, $slaves[$i].whoreSkill = 0, $slaves[$i].entertainSkill = 0, $slaves[$i].intelligence to -2, $slaves[$i].intelligenceImplant to 0, $slaves[$i].sexualFlaw to "none", $slaves[$i].sexualQuirk to "none", $slaves[$i].behavioralFlaw to "none", $slaves[$i].behavioralQuirk to "none">>
+<<if $slaves[$i].fetish == "mindbroken">>
+	<<set $slaves[$i].fetishStrength = 10, $slaves[$i].attrXY to 50, $slaves[$i].attrXX to 50, $slaves[$i].attrKnown to 1, $slaves[$i].devotion = 40, $slaves[$i].trust = -40, $slaves[$i].vaginalSkill = Math.clamp($slaves[$i].vaginalSkill,0,15), $slaves[$i].oralSkill = Math.clamp($slaves[$i].oralSkill,0,15), $slaves[$i].analSkill = Math.clamp($slaves[$i].analSkill,0,15), $slaves[$i].combatSkill = 0, $slaves[$i].whoreSkill = 0, $slaves[$i].entertainSkill = 0, $slaves[$i].intelligence to -2, $slaves[$i].intelligenceImplant to 0, $slaves[$i].sexualFlaw = "none", $slaves[$i].sexualQuirk = "none", $slaves[$i].behavioralFlaw = "none", $slaves[$i].behavioralQuirk = "none">>
 <<else>>
 <<if $slaves[$i].fuckdoll == 0>>
 
@@ -754,18 +754,18 @@
 	<<if ($slaves[$i].attrXY <= 35)>>
 		<<if ($slaves[$i].energy >= 20)>>
 			<<if ($slaves[$i].fetishKnown == 1)>>
-			<<if ($slaves[$i].fetish is "submissive")>>
+			<<if ($slaves[$i].fetish == "submissive")>>
 				Recently, she's been fantasizing about submitting to big strong men. Her revulsion at the idea of sex with a man @@.green;mellows.@@
 				<<set $slaves[$i].attrXY += 1>>
-			<<elseif ($slaves[$i].fetish is "buttslut")>>
+			<<elseif ($slaves[$i].fetish == "buttslut")>>
 				Recently, she's been reconsidering her reluctance to be sodomized a man. Her revulsion at the idea of sex with a man @@.green;mellows.@@
 				<<set $slaves[$i].attrXY += 1>>
-			<<elseif ($slaves[$i].fetish is "pregnancy")>>
+			<<elseif ($slaves[$i].fetish == "pregnancy")>>
 				Recently, she's been fantasizing about getting knocked up. Her revulsion at the idea of sex with a man @@.green;mellows.@@
 				<<set $slaves[$i].attrXY += 1>>
 			<</if>>
 			<</if>>
-			<<if ($slaves[$i].sexualQuirk is "adores men")>>
+			<<if ($slaves[$i].sexualQuirk == "adores men")>>
 				She enjoys spending time with men, and starts to @@.green;reconsider her unwillingness to be fucked by men.@@
 				<<set $slaves[$i].attrXY += 1>>
 			<</if>>
@@ -787,18 +787,18 @@
 	<<elseif ($slaves[$i].attrXY <= 65)>>
 		<<if ($slaves[$i].energy >= 40)>>
 			<<if ($slaves[$i].fetishKnown == 1)>>
-			<<if ($slaves[$i].fetish is "submissive")>>
+			<<if ($slaves[$i].fetish == "submissive")>>
 				She's found herself enjoying watching big strong men use other slaves recently. She's now @@.green;more attracted to men.@@
 				<<set $slaves[$i].attrXY += 1>>
-			<<elseif ($slaves[$i].fetish is "buttslut")>>
+			<<elseif ($slaves[$i].fetish == "buttslut")>>
 				She's started fantasizing about cocks being shoved up her butt even when there are no cocks being shoved up her butt. She's now @@.green;more attracted to men.@@
 				<<set $slaves[$i].attrXY += 1>>
-			<<elseif ($slaves[$i].fetish is "pregnancy")>>
+			<<elseif ($slaves[$i].fetish == "pregnancy")>>
 				Her fantasies about pregnancy have become quite vivid; she loves hot cum jetting into her. She's now @@.green;more attracted to men.@@
 				<<set $slaves[$i].attrXY += 1>>
 			<</if>>
 			<</if>>
-			<<if ($slaves[$i].behavioralQuirk is "adores men")>>
+			<<if ($slaves[$i].behavioralQuirk == "adores men")>>
 				She enjoys spending time with men, and is now @@.green;more attracted to men.@@
 				<<set $slaves[$i].attrXY += 1>>
 			<</if>>
@@ -820,13 +820,13 @@
 	<<elseif ($slaves[$i].attrXY <= 85)>>
 		<<if ($slaves[$i].energy >= 60)>>
 			<<if ($slaves[$i].fetishKnown == 1)>>
-			<<if ($slaves[$i].fetish is "submissive")>>
+			<<if ($slaves[$i].fetish == "submissive")>>
 				She can no longer see a man without fantasizing about how it would feel if he held her down. She's now @@.green;more aroused by men.@@
 				<<set $slaves[$i].attrXY += 1>>
-			<<elseif ($slaves[$i].fetish is "buttslut")>>
+			<<elseif ($slaves[$i].fetish == "buttslut")>>
 				She can't see a man without doing her best to get his hard cock inside her. She's now @@.green;more aroused by men.@@
 				<<set $slaves[$i].attrXY += 1>>
-			<<elseif ($slaves[$i].fetish is "pregnancy")>>
+			<<elseif ($slaves[$i].fetish == "pregnancy")>>
 				She can't see a man without doing her best to get his hot seed into her body. She's now @@.green;more aroused by men.@@
 				<<set $slaves[$i].attrXY += 1>>
 			<</if>>
@@ -839,7 +839,7 @@
 			<</if>>
 			<</if>>
 			<</if>>
-			<<if ($slaves[$i].behavioralQuirk is "adores men")>>
+			<<if ($slaves[$i].behavioralQuirk == "adores men")>>
 				She enjoys spending time with men so much that any interaction becomes flirtation; she's now @@.green;more aroused by men.@@
 				<<set $slaves[$i].attrXY += 1>>
 			<</if>>
@@ -855,18 +855,18 @@
 	<<if ($slaves[$i].attrXX <= 35)>>
 		<<if ($slaves[$i].energy >= 20)>>
 			<<if ($slaves[$i].fetishKnown == 1)>>
-			<<if ($slaves[$i].fetish is "dom")>>
+			<<if ($slaves[$i].fetish == "dom")>>
 				Recently, she's been fantasizing about how it would feel to force herself on some of the cute women all around her. Her revulsion at the idea of sex with a woman @@.green;mellows.@@
 				<<set $slaves[$i].attrXX += 1>>
-			<<elseif ($slaves[$i].fetish is "sadist")>>
+			<<elseif ($slaves[$i].fetish == "sadist")>>
 				Recently, she's been fantasizing about how it would feel to abuse a weak female slave. Her revulsion at the idea of sex with a woman @@.green;mellows.@@
 				<<set $slaves[$i].attrXX += 1>>
-			<<elseif ($slaves[$i].fetish is "boobs")>>
+			<<elseif ($slaves[$i].fetish == "boobs")>>
 				Recently, she's been fantasizing about other girls' tits. Her revulsion at the idea of sex with a woman @@.green;mellows.@@
 				<<set $slaves[$i].attrXX += 1>>
 			<</if>>
 			<</if>>
-			<<if ($slaves[$i].behavioralQuirk is "adores women")>>
+			<<if ($slaves[$i].behavioralQuirk == "adores women")>>
 				She enjoys spending time with women, and starts to @@.green;reconsider her unwillingness to have sex with a woman.@@
 				<<set $slaves[$i].attrXX += 1>>
 			<</if>>
@@ -888,18 +888,18 @@
 	<<elseif ($slaves[$i].attrXX <= 65)>>
 		<<if ($slaves[$i].energy >= 40)>>
 			<<if ($slaves[$i].fetishKnown == 1)>>
-			<<if ($slaves[$i].fetish is "dom")>>
+			<<if ($slaves[$i].fetish == "dom")>>
 				She's found herself enjoying the sight of female slaves being forced to fuck recently. She's now @@.green;more attracted to women.@@
 				<<set $slaves[$i].attrXX += 1>>
-			<<elseif ($slaves[$i].fetish is "sadist")>>
+			<<elseif ($slaves[$i].fetish == "sadist")>>
 				She's started fantasizing about how a girl might feel, struggling to get away from her. She's now @@.green;more attracted to women.@@
 				<<set $slaves[$i].attrXX += 1>>
-			<<elseif ($slaves[$i].fetish is "boobs")>>
+			<<elseif ($slaves[$i].fetish == "boobs")>>
 				Her fantasies about boobs have become quite vivid. She's now @@.green;more attracted to women.@@
 				<<set $slaves[$i].attrXX += 1>>
 			<</if>>
 			<</if>>
-			<<if ($slaves[$i].behavioralQuirk is "adores women")>>
+			<<if ($slaves[$i].behavioralQuirk == "adores women")>>
 				She enjoys spending time with women, and is now @@.green;more attracted to women.@@
 				<<set $slaves[$i].attrXX += 1>>
 			<</if>>
@@ -921,18 +921,18 @@
 	<<elseif ($slaves[$i].attrXX <= 85)>>
 		<<if ($slaves[$i].energy >= 60)>>
 			<<if ($slaves[$i].fetishKnown == 1)>>
-			<<if ($slaves[$i].fetish is "dom")>>
+			<<if ($slaves[$i].fetish == "dom")>>
 				She can't see a woman without plotting to dominate her. She's now @@.green;more aroused by women.@@
 				<<set $slaves[$i].attrXX += 1>>
-			<<elseif ($slaves[$i].fetish is "sadist")>>
+			<<elseif ($slaves[$i].fetish == "sadist")>>
 				She can't see a woman without doing her best to find a way the rules will allow her to abuse the poor girl. She's now @@.green;more aroused by women.@@
 				<<set $slaves[$i].attrXX += 1>>
-			<<elseif ($slaves[$i].fetish is "boobs")>>
+			<<elseif ($slaves[$i].fetish == "boobs")>>
 				She can't see a woman without doing her best to get her hands on her breasts. She's now @@.green;more aroused by women.@@
 				<<set $slaves[$i].attrXX += 1>>
 			<</if>>
 			<</if>>
-			<<if ($slaves[$i].behavioralQuirk is "adores women")>>
+			<<if ($slaves[$i].behavioralQuirk == "adores women")>>
 				She enjoys spending time with women so much that any interaction becomes flirtation; she's now @@.green;more aroused by women.@@
 				<<set $slaves[$i].attrXX += 1>>
 			<</if>>
@@ -974,44 +974,44 @@
 	<<if ($slaves[$i].behavioralFlaw != "none")>>
 	<<switch $slaves[$i].behavioralFlaw>>
 	<<case "arrogant">>
-		<<if ($slaves[$i].behavioralQuirk is "confident")>>
-		<<set $slaves[$i].behavioralFlaw to "none">>
+		<<if ($slaves[$i].behavioralQuirk == "confident")>>
+		<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
 	<<case "bitchy">>
-		<<if ($slaves[$i].behavioralQuirk is "cutting")>>
-		<<set $slaves[$i].behavioralFlaw to "none">>
+		<<if ($slaves[$i].behavioralQuirk == "cutting")>>
+		<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
 	<<case "odd">>
-		<<if ($slaves[$i].behavioralQuirk is "funny")>>
-		<<set $slaves[$i].behavioralFlaw to "none">>
+		<<if ($slaves[$i].behavioralQuirk == "funny")>>
+		<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
 	<<case "hates men">>
-		<<if ($slaves[$i].behavioralQuirk is "adores women")>>
-		<<set $slaves[$i].behavioralFlaw to "none">>
+		<<if ($slaves[$i].behavioralQuirk == "adores women")>>
+		<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
 	<<case "hates women">>
-		<<if ($slaves[$i].behavioralQuirk is "adores men")>>
-		<<set $slaves[$i].behavioralFlaw to "none">>
+		<<if ($slaves[$i].behavioralQuirk == "adores men")>>
+		<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
 	<<case "gluttonous">>
-		<<if ($slaves[$i].behavioralQuirk is "fitness")>>
-		<<set $slaves[$i].behavioralFlaw to "none">>
+		<<if ($slaves[$i].behavioralQuirk == "fitness")>>
+		<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
 	<<case "anorexic">>
-		<<if ($slaves[$i].behavioralQuirk is "insecure")>>
-		<<set $slaves[$i].behavioralFlaw to "none">>
+		<<if ($slaves[$i].behavioralQuirk == "insecure")>>
+		<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
 	<<case "devout")>>
-		<<if ($slaves[$i].behavioralQuirk is "sinful")>>
-		<<set $slaves[$i].behavioralFlaw to "none">>
+		<<if ($slaves[$i].behavioralQuirk == "sinful")>>
+		<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
 	<<case "liberated">>
-		<<if ($slaves[$i].behavioralQuirk is "advocate")>>
-		<<set $slaves[$i].behavioralFlaw to "none">>
+		<<if ($slaves[$i].behavioralQuirk == "advocate")>>
+		<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
 	<</switch>>
 	<</if>>
-	<<if ($slaves[$i].behavioralQuirk is "fitness")>>
+	<<if ($slaves[$i].behavioralQuirk == "fitness")>>
 		<<if $slaves[$i].energy < 70>>
 		Her physical overachievement and her growing athletic prowess @@.green;increase her sex drive.@@
 		<<set $slaves[$i].energy += 2>>
@@ -1066,42 +1066,42 @@
 		<<case "confident">>
 			<<if ($slaves[$i].fetish != "dom")>>
 			Her confidence and poise affect her sexual outlook. @@.lightcoral;She's now a dom!@@
-			<<set $slaves[$i].fetish to "dom", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "dom", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "cutting">>
 			<<if ($slaves[$i].fetish != "dom")>>
 			Her willingness to cut a partner down makes her more dominant in bed. @@.lightcoral;She's now a dom!@@
-			<<set $slaves[$i].fetish to "dom", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "dom", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "funny">>
 			<<if ($slaves[$i].fetish != "masochist")>>
 			Pain becomes an outlet for all the mental troubles lurking behind her funny facade. @@.lightcoral;She's now a masochist!@@
-			<<set $slaves[$i].fetish to "masochist", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "masochist", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "adores men">>
 			<<if ($slaves[$i].fetish != "pregnancy")>>
 			Her appreciation of men has turned into a fantasy about getting knocked up. @@.lightcoral;She's a pregnancy fetishist!@@
-			<<set $slaves[$i].fetish to "pregnancy", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "pregnancy", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "adores women">>
 			<<if ($slaves[$i].fetish != "boobs")>>
 			Her appreciation of women has turned into a fetish for breasts. @@.lightcoral;She's a boob fetishist!@@
-			<<set $slaves[$i].fetish to "boobs", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "boobs", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "insecure">>
 			<<if ($slaves[$i].fetish != "submissive")>>
 			She gets so desperate for validation from others that she becomes willing to submit to anything. @@.lightcoral;She's now a submissive!@@
-			<<set $slaves[$i].fetish to "submissive", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "submissive", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "sinful">>
 			<<if ($slaves[$i].fetish != "humiliation")>>
 			She learns that she likes nothing better than being seen doing something sacrilegious. @@.lightcoral;She's now a humiliation fetishist!@@
-			<<set $slaves[$i].fetish to "humiliation", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "humiliation", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "advocate">>
 			<<if ($slaves[$i].fetish != "submissive")>>
 			Her conviction that slavery is right seeps into her sexuality. @@.lightcoral;She's now a submissive!@@
-			<<set $slaves[$i].fetish to "submissive", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "submissive", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<</switch>>
 		<</if>>
@@ -1112,40 +1112,40 @@
 	<<if ($slaves[$i].sexualFlaw != "none")>>
 	<<switch $slaves[$i].sexualFlaw>>
 	<<case "hates oral">>
-		<<if ($slaves[$i].sexualQuirk is "gagfuck queen")>>
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<if ($slaves[$i].sexualQuirk == "gagfuck queen")>>
+		<<set $slaves[$i].sexualFlaw = "none">>
 		<</if>>
 	<<case "hates anal">>
-		<<if ($slaves[$i].sexualQuirk is "painal queen")>>
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<if ($slaves[$i].sexualQuirk == "painal queen")>>
+		<<set $slaves[$i].sexualFlaw = "none">>
 		<</if>>
 	<<case "hates penetration">>
-		<<if ($slaves[$i].sexualQuirk is "strugglefuck queen")>>
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<if ($slaves[$i].sexualQuirk == "strugglefuck queen")>>
+		<<set $slaves[$i].sexualFlaw = "none">>
 		<</if>>
 	<<case "shamefast">>
-		<<if ($slaves[$i].sexualQuirk is "tease")>>
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<if ($slaves[$i].sexualQuirk == "tease")>>
+		<<set $slaves[$i].sexualFlaw = "none">>
 		<</if>>
 	<<case "idealistic">>
-		<<if ($slaves[$i].sexualQuirk is "romantic")>>
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<if ($slaves[$i].sexualQuirk == "romantic")>>
+		<<set $slaves[$i].sexualFlaw = "none">>
 		<</if>>
 	<<case "repressed">>
-		<<if ($slaves[$i].sexualQuirk is "perverted")>>
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<if ($slaves[$i].sexualQuirk == "perverted")>>
+		<<set $slaves[$i].sexualFlaw = "none">>
 		<</if>>
 	<<case "apathetic">>
-		<<if ($slaves[$i].sexualQuirk is "caring")>>
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<if ($slaves[$i].sexualQuirk == "caring")>>
+		<<set $slaves[$i].sexualFlaw = "none">>
 		<</if>>
 	<<case "crude">>
-		<<if ($slaves[$i].sexualQuirk is "unflinching")>>
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<if ($slaves[$i].sexualQuirk == "unflinching")>>
+		<<set $slaves[$i].sexualFlaw = "none">>
 		<</if>>
 	<<case "judgemental">>
-		<<if ($slaves[$i].sexualQuirk is "size queen")>>
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<if ($slaves[$i].sexualQuirk == "size queen")>>
+		<<set $slaves[$i].sexualFlaw = "none">>
 		<</if>>
 	<</switch>>
 	<</if>>
@@ -1207,47 +1207,47 @@
 		<<case "gagfuck queen">>
 			<<if $slaves[$i].fetish != "cumslut">>
 			Her willingness to get roughly throatfucked has turned into real anticipation. @@.lightcoral;She's now a cumslut!@@
-			<<set $slaves[$i].fetish to "cumslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "cumslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "painal queen">>
 			<<if $slaves[$i].fetish != "buttslut">>
 			Her willingness to get roughly assfucked has turned into real anticipation. @@.lightcoral;She's now a buttslut!@@
-			<<set $slaves[$i].fetish to "buttslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "buttslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "strugglefuck queen">>
 			<<if $slaves[$i].fetish != "masochist">>
 			Her willingness to be roughly used has turned into real anticipation. @@.lightcoral;She's now a masochist!@@
-			<<set $slaves[$i].fetish to "masochist", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "masochist", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "tease">>
 			<<if $slaves[$i].fetish != "humiliation">>
 			The rush she feels when she shows herself off has deepened into a fetish for being publicly fucked. @@.lightcoral;She's a humiliation fetishist!@@
-			<<set $slaves[$i].fetish to "humiliation", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "humiliation", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "romantic">>
 			<<if $slaves[$i].fetish != "pregnancy">>
 			Her romantic bent has turned into a fantasy about settling down and having a child. @@.lightcoral;She's a pregnancy fetishist!@@
-			<<set $slaves[$i].fetish to "pregnancy", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "pregnancy", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "perverted">>
 			<<if $slaves[$i].fetish != "humiliation">>
 			Her perverted side has turned into a desire to be seen doing the forbidden. @@.lightcoral;She's a humiliation fetishist!@@
-			<<set $slaves[$i].fetish to "humiliation", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "humiliation", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "caring">>
 			<<if $slaves[$i].fetish != "submissive">>
 			Her caring nature has matured into a need to submit. @@.lightcoral;She's a submissive!@@
-			<<set $slaves[$i].fetish to "submissive", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "submissive", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "unflinching">>
 			<<if $slaves[$i].fetish != "masochist">>
 			She's so unflinching that she's left searching for sex extreme enough to excite her. @@.lightcoral;She's a masochist!@@
-			<<set $slaves[$i].fetish to "masochist", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "masochist", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<<case "size queen">>
 			<<if $slaves[$i].fetish != "buttslut">>
 			She's such a size queen that she's decided she prefers dicks where they'll feel biggest to her. @@.lightcoral;She's a buttslut!@@
-			<<set $slaves[$i].fetish to "buttslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+			<<set $slaves[$i].fetish = "buttslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 			<</if>>
 		<</switch>>
 		<</if>>
@@ -1292,14 +1292,14 @@
 	<</if>>
 	<<if $slaves[$i].fetishStrength <= 5>>
 		@@.pink;She has lost all interest in her fetishes and is now sexually vanilla.@@
-		<<set $slaves[$i].fetish to "none", $slaves[$i].fetishStrength = 0>>
+		<<set $slaves[$i].fetish = "none", $slaves[$i].fetishStrength = 0>>
 	<</if>>
 <</if>>
 <</if>>
 
 <<if ($slaves[$i].fetishKnown == 1)>>
 <<if ($slaves[$i].behavioralFlaw != "none")>>
-	<<if ($slaves[$i].behavioralFlaw is "devout") && ($arcologies[0].FSChattelReligionist != "unset")>>
+	<<if ($slaves[$i].behavioralFlaw == "devout") && ($arcologies[0].FSChattelReligionist != "unset")>>
 	<<if ($slaves[$i].devotion <= 20)>>
 		<<if ($slaves[$i].trust < -20)>>
 		She is inwardly @@.gold;terrified@@ by living in what she sees as a powerful theocratic society inimical to her old world faith.
@@ -1317,7 +1317,7 @@
 		<</if>>
 	<<else>>
 		She has experienced a religious epiphany, and now accepts Chattel Religionism in her mind, her heart, and her <<if $slaves[$i].vagina > -1>>womanhood<<else>>anus<</if>>. @@.green;She has become sinful,@@ maliciously eager to transgress against the faith she has abandoned.
-		<<set $slaves[$i].behavioralQuirk to "sinful", $slaves[$i].behavioralFlaw to "none">>
+		<<set $slaves[$i].behavioralQuirk = "sinful", $slaves[$i].behavioralFlaw = "none">>
 		She now sees that everything she has suffered up to now has been a necessary and divinely ordained trial to bring her into the true faith as a holy sex slave, @@.mediumaquamarine;enormously boosting her trust in you.@@
 		<<if ($slaves[$i].trust < -30)>>
 		<<set $slaves[$i].trust = -10>>
@@ -1325,119 +1325,119 @@
 		<<set $slaves[$i].trust += 20>>
 		<</if>>
 	<</if>>
-	<<elseif ($slaves[$i].behavioralQuirk is "none")>>
+	<<elseif ($slaves[$i].behavioralQuirk == "none")>>
 	<<if $slaves[$i].fetishStrength+$slaves[$i].devotion+$slaves[$i].trust > random(1,500)>>
-		<<if ($slaves[$i].behavioralFlaw is "arrogant")>>
-		<<if ($slaves[$i].fetish is "submissive")>>
+		<<if ($slaves[$i].behavioralFlaw == "arrogant")>>
+		<<if ($slaves[$i].fetish == "submissive")>>
 			Her need to submit has @@.green;softened her arrogance into confidence.@@
-			<<set $slaves[$i].behavioralQuirk to "confident">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralQuirk = "confident">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
-		<<elseif ($slaves[$i].behavioralFlaw is "bitchy")>>
-		<<if ($slaves[$i].fetish is "humiliation")>>
+		<<elseif ($slaves[$i].behavioralFlaw == "bitchy")>>
+		<<if ($slaves[$i].fetish == "humiliation")>>
 			Her need to be humiliated has @@.green;softened her bitchiness into a penchant for repartee.@@
-			<<set $slaves[$i].behavioralQuirk to "cutting">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralQuirk = "cutting">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
-		<<elseif ($slaves[$i].behavioralFlaw is "hates men")>>
-		<<if ($slaves[$i].fetish is "pregnancy")>>
+		<<elseif ($slaves[$i].behavioralFlaw == "hates men")>>
+		<<if ($slaves[$i].fetish == "pregnancy")>>
 			She dislikes men, but fetishizes pregnancy; she comes around, and decides that @@.green;she needs a man to knock her up.@@
-			<<set $slaves[$i].behavioralQuirk to "adores men">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
-		<<elseif ($slaves[$i].fetish is "boobs")>>
+			<<set $slaves[$i].behavioralQuirk = "adores men">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
+		<<elseif ($slaves[$i].fetish == "boobs")>>
 			She dislikes men and adores boobs, which @@.green;softens her hatred of men into a love of women.@@
-			<<set $slaves[$i].behavioralQuirk to "adores women">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralQuirk = "adores women">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<<elseif ($slaves[$i].attrXY > 85)>>
 			She dislikes the company of men but likes their cocks; she learns to @@.green;enjoy the male presence that comes with taking the dick.@@
-			<<set $slaves[$i].behavioralQuirk to "adores men">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralQuirk = "adores men">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<<elseif ($slaves[$i].energy > 95)>>
 			She dislikes men and has constant needs; women are the obvious answer, which @@.green;softens her hatred of men into a love of feminine company.@@
-			<<set $slaves[$i].behavioralQuirk to "adores women">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralQuirk = "adores women">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
-		<<elseif ($slaves[$i].behavioralFlaw is "hates women")>>
-		<<if ($slaves[$i].fetish is "pregnancy")>>
+		<<elseif ($slaves[$i].behavioralFlaw == "hates women")>>
+		<<if ($slaves[$i].fetish == "pregnancy")>>
 			She dislikes women, but fetishizes pregnancy; she comes around, and decides that @@.green;she loves pregnant girls.@@
-			<<set $slaves[$i].behavioralQuirk to "adores women">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
-		<<elseif ($slaves[$i].fetish is "cumslut")>>
+			<<set $slaves[$i].behavioralQuirk = "adores women">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
+		<<elseif ($slaves[$i].fetish == "cumslut")>>
 			She dislikes women and has a real oral fixation; eating dick is the obvious answer, which @@.green;softens her hatred of women into a love of men.@@
-			<<set $slaves[$i].behavioralQuirk to "adores men">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralQuirk = "adores men">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<<elseif ($slaves[$i].attrXX > 85)>>
 			She dislikes the company of women but likes fucking them; she learns to @@.green;enjoy the feminine presence that comes with getting some pussy.@@
-			<<set $slaves[$i].behavioralQuirk to "adores women">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralQuirk = "adores women">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<<elseif ($slaves[$i].energy > 95)>>
 			She dislikes women and has constant needs; men are the obvious answer, which @@.green;softens her hatred of women into a love of maleness.@@
-			<<set $slaves[$i].behavioralQuirk to "adores men">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralQuirk = "adores men">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
-		<<elseif ($slaves[$i].behavioralFlaw is "devout")>>
+		<<elseif ($slaves[$i].behavioralFlaw == "devout")>>
 		<<if ($slaves[$i].energy > 95)>>
 			Her need for constant sex has @@.green;softened her devoutness into an appetite for sacrilege.@@
-			<<set $slaves[$i].behavioralQuirk to "sinful">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralQuirk = "sinful">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
-		<<elseif ($slaves[$i].behavioralFlaw is "liberated")>>
-		<<if ($slaves[$i].fetish is "masochist")>>
+		<<elseif ($slaves[$i].behavioralFlaw == "liberated")>>
+		<<if ($slaves[$i].fetish == "masochist")>>
 			Her subconscious need to be abused has@@.green;converted her liberated philosophy into an ability to advocate for slavery.@@
-			<<set $slaves[$i].behavioralQuirk to "advocate">>
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralQuirk = "advocate">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
 		<</if>>
 	<</if>>
 	<<else>>
 	<<if $slaves[$i].fetishStrength+$slaves[$i].devotion+$slaves[$i].trust > random(1,500)>>
-		<<if ($slaves[$i].behavioralFlaw is "arrogant")>>
-		<<if ($slaves[$i].fetish is "submissive")>>
+		<<if ($slaves[$i].behavioralFlaw == "arrogant")>>
+		<<if ($slaves[$i].fetish == "submissive")>>
 			Her arrogance was probably a reflection of her subconscious need to submit, which is so satisfied by sexual slavery that @@.green;she no longer needs to act arrogant.@@
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
-		<<elseif ($slaves[$i].behavioralFlaw is "bitchy")>>
-		<<if ($slaves[$i].fetish is "humiliation")>>
+		<<elseif ($slaves[$i].behavioralFlaw == "bitchy")>>
+		<<if ($slaves[$i].fetish == "humiliation")>>
 			Her bitchiness was probably a reflection of her sexual need to be publicly humiliated, which is so satisfied by sexual slavery that @@.green;she no longer needs to be insulting@@ to get the degradation she subconsciously needs.
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
-		<<elseif ($slaves[$i].behavioralFlaw is "hates men")>>
-		<<if ($slaves[$i].fetish is "pregnancy")>>
+		<<elseif ($slaves[$i].behavioralFlaw == "hates men")>>
+		<<if ($slaves[$i].fetish == "pregnancy")>>
 			She dislikes the company of men, but fetishizes pregnancy; she decides that men, those hunky impregnators, can't be //that// bad, and @@.green;gets over her hatred.@@
-			<<set $slaves[$i].behavioralFlaw to "none">>
-		<<elseif ($slaves[$i].fetish is "boobs")>>
+			<<set $slaves[$i].behavioralFlaw = "none">>
+		<<elseif ($slaves[$i].fetish == "boobs")>>
 			She dislikes the company of men and adores boobs; she finds that she doesn't mind ogling titties with the boys, and @@.green;gets over her hatred.@@
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<<elseif ($slaves[$i].attrXY > 85)>>
 			She dislikes the company of men but likes their cocks; she gets used to putting up with maleness if it gets her the dick, and @@.green;gets over her hatred.@@
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<<elseif ($slaves[$i].energy > 95)>>
 			She dislikes the company of men and has constant needs; she can't afford to narrow the playing field, and @@.green;gets over her hatred.@@
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
-		<<elseif ($slaves[$i].behavioralFlaw is "hates women")>>
-		<<if ($slaves[$i].fetish is "pregnancy")>>
+		<<elseif ($slaves[$i].behavioralFlaw == "hates women")>>
+		<<if ($slaves[$i].fetish == "pregnancy")>>
 			She dislikes the company of women, but fetishizes pregnancy; that women, with their motherly hips and fertile cunts, can't be //that// bad, and @@.green;gets over her hatred.@@
-			<<set $slaves[$i].behavioralFlaw to "none">>
-		<<elseif ($slaves[$i].fetish is "cumslut")>>
+			<<set $slaves[$i].behavioralFlaw = "none">>
+		<<elseif ($slaves[$i].fetish == "cumslut")>>
 			She dislikes the company of women and has a real oral fixation; she decides that women, with their soft, kissable lips can't be //that// bad, and @@.green;gets over her hatred.@@
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<<elseif ($slaves[$i].attrXX > 85)>>
 			She dislikes the company of women but likes fucking them; she gets used to putting up with girls to get into their pants, and @@.green;gets over her hatred.@@
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<<elseif ($slaves[$i].energy > 95)>>
 			She dislikes the company of women and has constant needs; she can't afford to narrow the playing field, and @@.green;gets over her hatred.@@
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
-		<<elseif ($slaves[$i].behavioralFlaw is "devout")>>
+		<<elseif ($slaves[$i].behavioralFlaw == "devout")>>
 		<<if ($slaves[$i].energy > 95)>>
 			She finally resolves her internal dilemma between the faith she was brought up in and her all-consuming need to be a slut by deciding that she prefers being a sinner. @@.green;She is no longer devoutly faithful@@ to her old religion.
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
-		<<elseif ($slaves[$i].behavioralFlaw is "liberated")>>
-		<<if ($slaves[$i].fetish is "masochist")>>
+		<<elseif ($slaves[$i].behavioralFlaw == "liberated")>>
+		<<if ($slaves[$i].fetish == "masochist")>>
 			Her pre-enslavement belief that she deserves rights and respect fades in light of how much she likes being beaten and abused. @@.green;She is no longer a modern, liberated girl,@@ and accepts her place as a sex slave as natural.
-			<<set $slaves[$i].behavioralFlaw to "none">>
+			<<set $slaves[$i].behavioralFlaw = "none">>
 		<</if>>
 		<</if>>
 	<</if>>
@@ -1448,152 +1448,152 @@
 <<if ($slaves[$i].sexualFlaw != "none")>>
 <<if ($slaves[$i].fetishKnown == 1)>>
 <<if $slaves[$i].fetishStrength+$slaves[$i].devotion+$slaves[$i].trust > random(1,500)>>
-<<if ($slaves[$i].sexualQuirk is "none")>>
-	<<if ($slaves[$i].sexualFlaw is "hates anal")>>
-	<<if ($slaves[$i].fetish is "buttslut")>>
+<<if ($slaves[$i].sexualQuirk == "none")>>
+	<<if ($slaves[$i].sexualFlaw == "hates anal")>>
+	<<if ($slaves[$i].fetish == "buttslut")>>
 		Her sexual fascination with things entering her asshole @@.green;softens her hatred of anal into an appetite for anal pain.@@
-		<<set $slaves[$i].sexualQuirk to "painal queen", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "painal queen", $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		As a nymphomaniac she appreciates kinky sex, so she @@.green;softens her hatred of anal into an appetite for anal pain.@@
-		<<set $slaves[$i].sexualQuirk to "painal queen", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "painal queen", $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "hates oral")>>
-	<<if ($slaves[$i].fetish is "cumslut")>>
+	<<elseif ($slaves[$i].sexualFlaw == "hates oral")>>
+	<<if ($slaves[$i].fetish == "cumslut")>>
 		She can't get her beloved cum without choking down dick, so she @@.green;softens her hatred of oral into a willingness to be roughly throatfucked.@@
-		<<set $slaves[$i].sexualQuirk to "gagfuck queen", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "gagfuck queen", $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		She needs sex so much she often has to encourage her partners orally, so she @@.green;softens her hatred of oral into a willingness to be roughly throatfucked.@@
-		<<set $slaves[$i].sexualQuirk to "gagfuck queen", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "gagfuck queen", $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "hates penetration")>>
-	<<if ($slaves[$i].fetish is "buttslut")>>
+	<<elseif ($slaves[$i].sexualFlaw == "hates penetration")>>
+	<<if ($slaves[$i].fetish == "buttslut")>>
 		Her sexual fascination with anal penetration @@.green;softens her hatred of penetration into an appetite for abusive sex.@@
-		<<set $slaves[$i].sexualQuirk to "strugglefuck queen", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "strugglefuck queen", $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		As a nymphomaniac she appreciates kinky sex, so she @@.green;softens her hatred of penetration into an appetite for abusive intercourse.@@
-		<<set $slaves[$i].sexualQuirk to "strugglefuck queen", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "strugglefuck queen", $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "apathetic")>>
-	<<if ($slaves[$i].fetish is "submissive")>>
+	<<elseif ($slaves[$i].sexualFlaw == "apathetic")>>
+	<<if ($slaves[$i].fetish == "submissive")>>
 		Her subconscious drive to submit @@.green;softens her sexual apathy into constant care for her partners' wants.@@
-		<<set $slaves[$i].sexualQuirk to "caring", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "caring", $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		She needs sex so badly that she can no longer be apathetic in bed, and @@.green;softens her sexual apathy into care for what keeps her partners aroused.@@
-		<<set $slaves[$i].sexualQuirk to "caring", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "caring", $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "crude")>>
-	<<if ($slaves[$i].fetish is "buttslut")>>
+	<<elseif ($slaves[$i].sexualFlaw == "crude")>>
+	<<if ($slaves[$i].fetish == "buttslut")>>
 		She needs to avoid making unsexy noises during buttsex to be an appealing enough anal partner to satisfy her backdoor needs, @@.green;softening her crudeness into a willingness to do anything.@@
-		<<set $slaves[$i].sexualQuirk to "unflinching", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "unflinching", $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		She needs sex so badly that she can no longer afford to disgust partners, and @@.green;softens her sexual crudeness into a willingness to do anything.@@
-		<<set $slaves[$i].sexualQuirk to "unflinching", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "unflinching", $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "judgemental")>>
-	<<if ($slaves[$i].fetish is "submissive")>>
+	<<elseif ($slaves[$i].sexualFlaw == "judgemental")>>
+	<<if ($slaves[$i].fetish == "submissive")>>
 		Her subconscious belief that she's worthless @@.green;softens her judgemental behavior into eagerness to be fucked by the biggest cocks.@@
-		<<set $slaves[$i].sexualQuirk to "size queen", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "size queen", $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		She needs sex so badly that she can no longer be selective, and @@.green;softens her judgemental behavior into a love of big dicks, though she now loves them all.@@
-		<<set $slaves[$i].sexualQuirk to "size queen", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "size queen", $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "shamefast")>>
-	<<if ($slaves[$i].fetish is "humiliation")>>
+	<<elseif ($slaves[$i].sexualFlaw == "shamefast")>>
+	<<if ($slaves[$i].fetish == "humiliation")>>
 		She decides that hiding won't get her the humiliation she craves, and @@.green;softens her shamefastness into a willingness to tease.@@
-		<<set $slaves[$i].sexualQuirk to "tease", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "tease", $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		She decides that hiding isn't getting her enough sex, and @@.green;softens her shamefastness into a willingness to tease.@@
-		<<set $slaves[$i].sexualQuirk to "tease", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "tease", $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "idealistic")>>
-	<<if ($slaves[$i].fetish is "submissive")>>
+	<<elseif ($slaves[$i].sexualFlaw == "idealistic")>>
+	<<if ($slaves[$i].fetish == "submissive")>>
 		Her appetite for submission has @@.green;softened her innocent ideas about sex into an ability to find romance@@ in the life of a sex slave.
-		<<set $slaves[$i].sexualQuirk to "romantic", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "romantic", $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		Her appetite for sex has @@.green;softened her innocent ideas about sex into an ability to find something romantic@@ in a constant whirl of intercourse.
-		<<set $slaves[$i].sexualQuirk to "romantic", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "romantic", $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "repressed")>>
-	<<if ($slaves[$i].fetish is "buttslut")>>
+	<<elseif ($slaves[$i].sexualFlaw == "repressed")>>
+	<<if ($slaves[$i].fetish == "buttslut")>>
 		She grew up being taught that good girls do not take cock up their good girl anuses, but she's just now decided she prefers being a bad girl and has @@.green;softened her repression into arousal at the perversion@@  of dicks up her behind.
-		<<set $slaves[$i].sexualQuirk to "perverted", $slaves[$i].sexualFlaw to "none">>
-	<<elseif ($slaves[$i].fetish is "cumslut")>>
+		<<set $slaves[$i].sexualQuirk = "perverted", $slaves[$i].sexualFlaw = "none">>
+	<<elseif ($slaves[$i].fetish == "cumslut")>>
 		She grew up being taught that good girls do not put their good girl mouths on boys' private parts, but she's just now decided she prefers being a bad girl and has @@.green;softened her repression into arousal at the perverted@@ idea of dicks down her throat.
-		<<set $slaves[$i].sexualQuirk to "perverted", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "perverted", $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		She grew up being taught that good girls do not happily fuck anything that moves, but she's just now decided she prefers being a bad girl and has @@.green;softened her repression into arousal at the perversion@@ of revelling in sexual addiction.
-		<<set $slaves[$i].sexualQuirk to "perverted", $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualQuirk = "perverted", $slaves[$i].sexualFlaw = "none">>
 	<</if>>
 	<</if>>
 <<else>>
-	<<if ($slaves[$i].sexualFlaw is "hates anal")>>
-	<<if ($slaves[$i].fetish is "buttslut")>>
+	<<if ($slaves[$i].sexualFlaw == "hates anal")>>
+	<<if ($slaves[$i].fetish == "buttslut")>>
 		Her sexual fascination with things entering her asshole overcomes her professed hatred of anal, so @@.green;her previous hesitations about buttsex vanish.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		As a nymphomaniac she doesn't really care which hole she's getting fucked in, so @@.green;her previous hesitations about buttsex vanish.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "hates oral")>>
-	<<if ($slaves[$i].fetish is "cumslut")>>
+	<<elseif ($slaves[$i].sexualFlaw == "hates oral")>>
+	<<if ($slaves[$i].fetish == "cumslut")>>
 		She can't get her beloved cum without sucking, so @@.green;she forcibly overcomes her strong gag reflex.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		She needs sex so much she often has to encourage her partners orally, so @@.green;she forcibly overcomes her strong gag reflex.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "hates penetration")>>
-	<<if ($slaves[$i].fetish is "buttslut")>>
+	<<elseif ($slaves[$i].sexualFlaw == "hates penetration")>>
+	<<if ($slaves[$i].fetish == "buttslut")>>
 		She's fascinated with the perversity of being anally penetrated, so @@.green;her previous hesitations about getting fucked vanish.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		She needs sex like she needs air, so @@.green;her previous hesitations about getting fucked vanish.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "apathetic")>>
-	<<if ($slaves[$i].fetish is "dom")>>
+	<<elseif ($slaves[$i].sexualFlaw == "apathetic")>>
+	<<if ($slaves[$i].fetish == "dom")>>
 		She likes being on top so much @@.green;she can no longer bear being lazy in bed.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		She needs sex so badly that @@.green;she can no longer afford to wait apathetically for others to fuck her.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "crude")>>
+	<<elseif ($slaves[$i].sexualFlaw == "crude")>>
 	<<if ($slaves[$i].energy > 95)>>
 		She needs sex so badly that @@.green;she can no longer afford to disgust partners into abandoning intercourse.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "judgemental")>>
+	<<elseif ($slaves[$i].sexualFlaw == "judgemental")>>
 	<<if ($slaves[$i].energy > 95)>>
 		She needs sex so badly that @@.green;she can no longer afford to turn potential partners off by judging them.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "shamefast")>>
-	<<if ($slaves[$i].fetish is "humiliation")>>
+	<<elseif ($slaves[$i].sexualFlaw == "shamefast")>>
+	<<if ($slaves[$i].fetish == "humiliation")>>
 		Her shamefastness is no longer anything but a pretense; @@.green;she's decided she really does like getting fucked in public.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		She needs sex so badly that @@.green;she can no longer afford to be embarrassed by public fucking.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "idealistic")>>
-	<<if ($slaves[$i].fetish is "submissive")>>
+	<<elseif ($slaves[$i].sexualFlaw == "idealistic")>>
+	<<if ($slaves[$i].fetish == "submissive")>>
 		She always expected to be able to turn down sex, but @@.green;she's finally realized that she doesn't want to be asked.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		Hard as it is for her to admit, she recognizes her own willingness to take sex from other slaves if it isn't forthcoming, and @@.green;accepts that a slave nympho can't worry about trifles like consent.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<</if>>
-	<<elseif ($slaves[$i].sexualFlaw is "repressed")>>
-	<<if ($slaves[$i].fetish is "buttslut")>>
+	<<elseif ($slaves[$i].sexualFlaw == "repressed")>>
+	<<if ($slaves[$i].fetish == "buttslut")>>
 		She grew up being taught that good girls do not take cock up their good girl anuses, but @@.green;she's just now decided she prefers being a bad girl.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
-	<<elseif ($slaves[$i].fetish is "cumslut")>>
+		<<set $slaves[$i].sexualFlaw = "none">>
+	<<elseif ($slaves[$i].fetish == "cumslut")>>
 		She grew up being taught that good girls do not put their good girl mouths on boys' private parts, but @@.green;she's just now decided she prefers being a bad girl.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<<elseif ($slaves[$i].energy > 95)>>
 		She grew up being taught that good girls do not happily fuck anything that moves, but @@.green;she's just now decided she prefers being a bad girl.@@
-		<<set $slaves[$i].sexualFlaw to "none">>
+		<<set $slaves[$i].sexualFlaw = "none">>
 	<</if>>
 	<</if>>
 <</if>>
@@ -1603,36 +1603,36 @@
 /* PARAPHILIA IMPACTS */
 
 <<switch $slaves[$i].sexualFlaw>>
-	<<case "cum addict">>
-		<<if $slaves[$i].fetish != "cumslut">>
-			<<if $slaves[$i].fetishStrength > 60>>
-				Her cum addiction @@.pink;disinterests her in her current fetish,@@ and the conflict of sexual identity causes her @@.mediumorchid;some anguish.@@
-				<<set $slaves[$i].fetishStrength -= 5>>
-				<<set $slaves[$i].devotion -= 3>>
-			<<else>>
-				Her cum addiction @@.lightcoral;forces her back towards oral fixation.@@
-				<<set $slaves[$i].fetish = "cumslut">>
-			<</if>>
+<<case "cum addict">>
+	<<if $slaves[$i].fetish != "cumslut">>
+		<<if $slaves[$i].fetishStrength > 60>>
+			Her cum addiction @@.pink;disinterests her in her current fetish,@@ and the conflict of sexual identity causes her @@.mediumorchid;some anguish.@@
+			<<set $slaves[$i].fetishStrength -= 5>>
+			<<set $slaves[$i].devotion -= 3>>
 		<<else>>
-			<<if $slaves[$i].fetishStrength <= 95>>
-				Her cum addiction @@.lightcoral;forces her back towards her past life as an abject cumslut.@@
-				<<set $slaves[$i].fetishStrength += 5>>
-				<<set $slaves[$i].devotion -= 3>>
-			<</if>>
+			Her cum addiction @@.lightcoral;forces her back towards oral fixation.@@
+			<<set $slaves[$i].fetish = "cumslut">>
 		<</if>>
-		<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club") || ($slaves[$i].assignment is "work a glory hole") || ($slaves[$i].assignment is "be confined in the arcade")>>
-			Her paraphilia is satisfied by how many dicks she gets to suck at work.
-		<<elseif $slaves[$i].dietCum == 1>>
-			Her paraphilia is satisfied by what she gets to eat.
-		<<elseif $slaves[$i].dietCum == 2>>
-			Other slaves in your penthouse are disturbed by her insatiable appetite for human ejaculate, which her heavy cum-diet encourages.
-		<<elseif $feeder != 0>>
-			Her paraphilia is satisfied by the way she gets to eat.
-		<<elseif ($slaves[$i].assignment is "work in the dairy") && ($dairyFeedersSetting > 0)>>
-		<<else>>
-			She doesn't seem to feel she's getting enough cum, leaving the cum addict @@.mediumorchid;depressed and anxious.@@
-			<<set $slaves[$i].devotion -= 2>>
+	<<else>>
+		<<if $slaves[$i].fetishStrength <= 95>>
+			Her cum addiction @@.lightcoral;forces her back towards her past life as an abject cumslut.@@
+			<<set $slaves[$i].fetishStrength += 5>>
+			<<set $slaves[$i].devotion -= 3>>
 		<</if>>
+	<</if>>
+	<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club") || ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade")>>
+		Her paraphilia is satisfied by how many dicks she gets to suck at work.
+	<<elseif $slaves[$i].dietCum == 1>>
+		Her paraphilia is satisfied by what she gets to eat.
+	<<elseif $slaves[$i].dietCum == 2>>
+		Other slaves in your penthouse are disturbed by her insatiable appetite for human ejaculate, which her heavy cum-diet encourages.
+	<<elseif $feeder != 0>>
+		Her paraphilia is satisfied by the way she gets to eat.
+	<<elseif ($slaves[$i].assignment == "work in the dairy") && ($dairyFeedersSetting > 0)>>
+	<<else>>
+		She doesn't seem to feel she's getting enough cum, leaving the cum addict @@.mediumorchid;depressed and anxious.@@
+		<<set $slaves[$i].devotion -= 2>>
+	<</if>>
 <<case "anal addict">>
 	<<if $slaves[$i].fetish != "buttslut">>
 		<<if $slaves[$i].fetishStrength > 60>>
@@ -1650,13 +1650,13 @@
 			<<set $slaves[$i].devotion -= 3>>
 		<</if>>
 	<</if>>
-	<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club") || ($slaves[$i].assignment is "work a glory hole") || ($slaves[$i].assignment is "be confined in the arcade")>>
+	<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club") || ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade")>>
 		Her paraphilia is satisfied by how many dicks get shoved up her butt at work.
 	<<elseif $suppository != 0>>
 		Her paraphilia is satisfied by the way she gets to take medication.
-	<<elseif $slaves[$i].buttplug is "huge plug">>
+	<<elseif $slaves[$i].buttplug == "huge plug">>
 		Her paraphilia is satisfied by the enormous plug she wears in her ass.
-	<<elseif ($slaves[$i].assignment is "work in the dairy") && ($dairyStimulatorsSetting > 0)>>
+	<<elseif ($slaves[$i].assignment == "work in the dairy") && ($dairyStimulatorsSetting > 0)>>
 	<<else>>
 		She doesn't seem to feel she's getting buttfucked often enough, leaving the anal addict @@.mediumorchid;depressed and anxious.@@
 		<<set $slaves[$i].devotion -= 2>>
@@ -1687,9 +1687,9 @@
 			<<set $slaves[$i].devotion -= 3>>
 		<</if>>
 	<</if>>
-	<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club")>>
+	<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club")>>
 		Her paraphilia is satisfied by how often she gets publicly fucked at work.
-	<<elseif $slaves[$i].clothes is "none">>
+	<<elseif $slaves[$i].clothes == "none">>
 		Her paraphilia is satisfied by her total nudity.
 	<<else>>
 		She doesn't seem to feel she's getting fucked in public enough, leaving the attention whore @@.mediumorchid;depressed and anxious.@@
@@ -1712,11 +1712,11 @@
 			<<set $slaves[$i].devotion -= 3>>
 		<</if>>
 	<</if>>
-	<<if ($slaves[$i].assignment is "get milked") || ($slaves[$i].assignment is "work in the dairy")>>
+	<<if ($slaves[$i].assignment == "get milked") || ($slaves[$i].assignment == "work in the dairy")>>
 		Her paraphilia is satisfied by her work as a cow; she can feel her udders swelling with milk.
 	<<elseif $slaves[$i].health < 0>>
 		Her paraphilia is ameliorated by her poor health; she knows she can't take expansion right now.
-	<<elseif $slaves[$i].drugs is "breast injections">>
+	<<elseif $slaves[$i].drugs == "breast injections">>
 		Her paraphilia makes breast injections very satisfying for her.
 	<<else>>
 		She feels her breasts are shrinking horribly, leaving the growth addict @@.mediumorchid;depressed and anxious.@@
@@ -1739,9 +1739,9 @@
 			<<set $slaves[$i].devotion -= 3>>
 		<</if>>
 	<</if>>
-	<<if ($slaves[$i].assignment is "be your Head Girl")>>
+	<<if ($slaves[$i].assignment == "be your Head Girl")>>
 		Her paraphilia is satisfied by her work as your Head Girl.
-	<<elseif ($slaves[$i].assignment is "be the Wardeness")>>
+	<<elseif ($slaves[$i].assignment == "be the Wardeness")>>
 		Her paraphilia is satisfied by her work as your Wardeness.
 	<<else>>
 		She gets few chances to indulge her need to hold others down as she fucks them, leaving her @@.mediumorchid;depressed and anxious.@@
@@ -1764,9 +1764,9 @@
 			<<set $slaves[$i].devotion -= 3>>
 		<</if>>
 	<</if>>
-	<<if ($slaves[$i].assignment is "be your Head Girl")>>
+	<<if ($slaves[$i].assignment == "be your Head Girl")>>
 		Her paraphilia is satisfied by her work as your Head Girl.
-	<<elseif ($slaves[$i].assignment is "be the Wardeness")>>
+	<<elseif ($slaves[$i].assignment == "be the Wardeness")>>
 		Her paraphilia is satisfied by her work as your Wardeness.
 	<<else>>
 		She gets few chances to indulge her need to subject others to sexual anguish, leaving her @@.mediumorchid;depressed and anxious.@@
@@ -1789,9 +1789,9 @@
 			<<set $slaves[$i].devotion -= 3>>
 		<</if>>
 	<</if>>
-	<<if ($slaves[$i].assignment is "work in the dairy") && ($dairyRestraintsSetting >= 2)>>
+	<<if ($slaves[$i].assignment == "work in the dairy") && ($dairyRestraintsSetting >= 2)>>
 		Her paraphilia is satisfied by her horrible life as a producer of useful fluids and a receptacle for machine rape.
-	<<elseif ($slaves[$i].assignment is "work a glory hole") || ($slaves[$i].assignment is "be confined in the arcade")>>
+	<<elseif ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade")>>
 		Her paraphilia is satisfied by her horrible life as a helpless hole for an infinite bag of dicks.
 	<<elseif $slaves[$i].trust < -50>>
 		Her paraphilia is satisfied by her constant terror.
@@ -1816,9 +1816,9 @@
 			<<set $slaves[$i].devotion -= 3>>
 		<</if>>
 	<</if>>
-	<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club") || ($slaves[$i].assignment is "work a glory hole") || ($slaves[$i].assignment is "be confined in the arcade")>>
+	<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club") || ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade")>>
 		Her paraphilia is satisfied by how she's expected to serve others' sexual needs at work.
-	<<elseif $slaves[$i].assignment is "be a subordinate slave">>
+	<<elseif $slaves[$i].assignment == "be a subordinate slave">>
 		Her paraphilia is satisfied by how she's expected to serve other slaves' sexual needs.
 	<<else>>
 		She doesn't seem to feel she's serving others' sexual needs enough, leaving her @@.mediumorchid;depressed and anxious.@@
@@ -1852,17 +1852,17 @@
 	<</if>>
 <</switch>>
 
-<</if>>
+<</if>> /* closes sexualFlaw != none */
 
-<<if ($slaves[$i].assignment is "get milked") || ($slaves[$i].assignment is "work in the dairy")>>
+<<if ($slaves[$i].assignment == "get milked") || ($slaves[$i].assignment == "work in the dairy")>>
 	<<if ($slaves[$i].lactation > 0)>>
 	<<if ($slaves[$i].fetishStrength <= 95)>>
 	<<if ($slaves[$i].fetish != "boobs")>>
 	<<if $fetishChangeChance > random(0,100)>>
 		Since she has had her lactating nipples constantly caressed by the milkers, @@.lightcoral;she begins to appreciate nipple stimulation in a new way.@@
-		<<set $slaves[$i].fetish to "boobs", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+		<<set $slaves[$i].fetish = "boobs", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 	<</if>>
-	<<elseif ($slaves[$i].fetish is "boobs") && ($slaves[$i].fetishStrength <= 95)>>
+	<<elseif ($slaves[$i].fetish == "boobs") && ($slaves[$i].fetishStrength <= 95)>>
 		Since she has had her lactating nipples constantly caressed by the milkers, @@.lightcoral;she sinks deeper into sexual reliance on nipple stimulation.@@
 		<<set $slaves[$i].fetishStrength += 4>>
 	<</if>>
@@ -1874,7 +1874,7 @@
 	<<if $slaves[$i].fetish != "buttslut">>
 		<<if $fetishChangeChance > random(0,100)>>
 			Since she has had her prostate constantly stimulated to encourage her to give cum, @@.lightcoral;she begins to look forward to anal penetration.@@
-			<<set $slaves[$i].fetish to "buttslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+			<<set $slaves[$i].fetish = "buttslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 		<</if>>
 	<<else>>
 		<<if $slaves[$i].fetishStrength <= 95>>
@@ -1907,9 +1907,9 @@
 <<if $slaves[$i].fetish != "submissive">>
 <<if $fetishChangeChance > random(0,100)>>
 	Living as a sex slave on all fours @@.lightcoral;turns her into a sexual submissive.@@
-	<<set $slaves[$i].fetish to "submissive", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
+	<<set $slaves[$i].fetish = "submissive", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
 <</if>>
-<<elseif ($slaves[$i].fetish is "submissive") && ($slaves[$i].fetishStrength <= 95)>>
+<<elseif ($slaves[$i].fetish == "submissive") && ($slaves[$i].fetishStrength <= 95)>>
 	Living as a sex slave on all fours @@.lightcoral;pushes her deeper into submission.@@
 	<<set $slaves[$i].fetishStrength += 4>>
 <</if>>
@@ -1917,18 +1917,18 @@
 <</if>>
 <</if>>
 
-<<if $slaves[$i].career is "a slave">>
+<<if $slaves[$i].career == "a slave">>
 	She has been a slave so long that she can barely remember making decisions for herself, and @@.hotpink;feels naturally drawn@@ to her <<if $PC.title == 1>>Master<<else>>Mistress<</if>>.
 	<<set $slaves[$i].devotion += 1>>
-<<elseif $slaves[$i].career is "a Fuckdoll">>
+<<elseif $slaves[$i].career == "a Fuckdoll">>
 	She was once a Fuckdoll, leaving her @@.hotpink;willing to obey on an instinctual level.@@
 	<<set $slaves[$i].devotion += 5>>
-<<elseif $slaves[$i].career is "a bioreactor">>
+<<elseif $slaves[$i].career == "a bioreactor">>
 	She remembers what it was like to be a living, breathing, milk-jetting,<<if isFertile($slaves[$i]) && ($dairyPregUpgrade > 0)>> baby-filled,<</if>><<if ($slaves[$i].balls != 0)>> cum-squirting,<</if>> drug-filled piece of industrial equipment, and is @@.hotpink;thankful@@ and @@.mediumaquamarine;grateful@@ that she isn't any more.
 	<<set $slaves[$i].trust += 1, $slaves[$i].devotion += 1>>
-<<elseif $slaves[$i].career is "a Futanari Sister">>
+<<elseif $slaves[$i].career == "a Futanari Sister">>
 	<<if $masterSuiteUpgradeLuxury is 2>>
-	<<if $slaves[$i].assignment is "serve in the master suite">>
+	<<if $slaves[$i].assignment == "serve in the master suite">>
 	She knows that $masterSuiteName features a fuckpit much like the one she spent years enjoying as a Futanari Sister, and @@.hotpink;does her best@@ to be a good girl in the hope you'll send her there someday.
 	<<set $slaves[$i].devotion += 1>>
 	<<else>>
@@ -1995,7 +1995,7 @@
 <<if ($slaves[$i].clitPiercing is 3)>>
 <<if $slaves[$i].fuckdoll > 0>>
 	Its smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing is slaved to its stimulation systems.
-<<elseif $slaves[$i].fetish is "mindbroken">>
+<<elseif $slaves[$i].fetish == "mindbroken">>
 	The effects of her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing cannot reach her shattered mind.
 <<else>>
 <<switch $slaves[$i].clitSetting>>
@@ -2016,7 +2016,7 @@
 	<<if $slaves[$i].attrXX < 95>>
 		Her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing successfully @@.green;increases her attraction to girls@@ by pleasuring her when she's around them.
 		<<set $slaves[$i].attrXX += 2+$assistant>>
-		<<if $slaves[$i].energy < 100>>
+		<<if $slaves[$i].energy < 80>>
 			This has the secondary effect of slightly @@.green;enhancing her libido.@@
 			<<set $slaves[$i].energy++>>
 		<</if>>
@@ -2034,7 +2034,7 @@
 	<<if $slaves[$i].attrXY < 95>>
 		Her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing successfully @@.green;increases her attraction to guys@@ by pleasuring her when she's around cocks.
 		<<set $slaves[$i].attrXY += 2+$assistant>>
-		<<if $slaves[$i].energy < 100>>
+		<<if $slaves[$i].energy < 80>>
 			This has the secondary effect of slightly @@.green;enhancing her libido.@@
 			<<set $slaves[$i].energy++>>
 		<</if>>
@@ -2051,7 +2051,7 @@
 <<case "vanilla">>
 	<<if ($slaves[$i].fetish != "none") && ($fetishChangeChance > random(0,100)-20*$assistant)>>
 		After her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing encourages many orgasms during straightforward sex, @@.lightcoral;her sexuality returns to normal.@@
-		<<set $slaves[$i].fetish to "none", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+		<<set $slaves[$i].fetish = "none", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 	<</if>>
 <<case "oral">>
 	<<if ($slaves[$i].fetish != "cumslut")>>
@@ -2060,7 +2060,7 @@
 		<<set $slaves[$i].fetishStrength -= 20>>
 	<<elseif ($fetishChangeChance > random(0,100)-20*$assistant)>>
 		After her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing encourages many orgasms as she performs oral sex, @@.lightcoral;she develops a fetish for cum.@@
-		<<set $slaves[$i].fetish to "cumslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+		<<set $slaves[$i].fetish = "cumslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 	<</if>>
 	<<elseif ($slaves[$i].fetishStrength <= 95)>>
 		Her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing @@.lightcoral;advances her oral fetish.@@
@@ -2073,7 +2073,7 @@
 	<<set $slaves[$i].fetishStrength -= 20>>
 <<elseif ($fetishChangeChance > random(0,100)-20*$assistant)>>
 	After her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing encourages many orgasms when her ass is being stimulated, @@.lightcoral;she develops a fetish for being an anal bottom.@@
-	<<set $slaves[$i].fetish to "buttslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+	<<set $slaves[$i].fetish = "buttslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 <</if>>
 <<elseif ($slaves[$i].fetishStrength <= 95)>>
 	Her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing @@.lightcoral;advances her anal fetish.@@
@@ -2086,7 +2086,7 @@
 	<<set $slaves[$i].fetishStrength -= 20>>
 <<elseif ($fetishChangeChance > random(0,100)-20*$assistant)>>
 	After her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing encourages many orgasms when her nipples are being stimulated, @@.lightcoral;she develops a fetish for her tits.@@
-	<<set $slaves[$i].fetish to "boobs", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+	<<set $slaves[$i].fetish = "boobs", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 <</if>>
 <<elseif ($slaves[$i].fetishStrength <= 95)>>
 	Her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing @@.lightcoral;advances her boob fetish.@@
@@ -2099,7 +2099,7 @@
 	<<set $slaves[$i].fetishStrength -= 20>>
 <<elseif ($fetishChangeChance > random(0,100)-20*$assistant)>>
 	After her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing encourages many orgasms when she is restrained, @@.lightcoral;she develops a fetish for submission.@@
-	<<set $slaves[$i].fetish to "submissive", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+	<<set $slaves[$i].fetish = "submissive", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 <</if>>
 <<elseif ($slaves[$i].fetishStrength <= 95)>>
 	Her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing @@.lightcoral;advances her submission.@@
@@ -2112,7 +2112,7 @@
 	<<set $slaves[$i].fetishStrength -= 20>>
 <<elseif ($fetishChangeChance > random(0,100)-20*$assistant)>>
 	After her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing encourages many orgasms when she is being humiliated, @@.lightcoral;she develops a fetish for humiliation.@@
-	<<set $slaves[$i].fetish to "humiliation", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+	<<set $slaves[$i].fetish = "humiliation", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 <</if>>
 <<elseif ($slaves[$i].fetishStrength <= 95)>>
 	Her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing @@.lightcoral;advances her humiliation fetish.@@
@@ -2125,7 +2125,7 @@
 	<<set $slaves[$i].fetishStrength -= 20>>
 <<elseif ($fetishChangeChance > random(0,100)-20*$assistant)>>
 	After her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing encourages many orgasms during <<if $PC.dick == 1>>unprotected sex<<if $PC.vagina == 1>> and <</if>><</if>><<if $PC.vagina == 1>>loving contact with the female anatomy<</if>>, @@.lightcoral;she begins to fantasize about pregnancy.@@
-	<<set $slaves[$i].fetish to "pregnancy", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+	<<set $slaves[$i].fetish = "pregnancy", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 <</if>>
 <<elseif ($slaves[$i].fetishStrength <= 95)>>
 	Her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing @@.lightcoral;advances her pregnancy fetish.@@
@@ -2138,7 +2138,7 @@
 	<<set $slaves[$i].fetishStrength -= 20>>
 <<elseif ($fetishChangeChance > random(0,100)-20*$assistant)>>
 	After her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing encourages many orgasms while she's taking an active, dominant sexual role, @@.lightcoral;she begins to enjoy dominance.@@
-	<<set $slaves[$i].fetish to "dom", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+	<<set $slaves[$i].fetish = "dom", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 <</if>>
 <<elseif ($slaves[$i].fetishStrength <= 95)>>
 	Her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing @@.lightcoral;advances her dominance.@@
@@ -2151,7 +2151,7 @@
 	<<set $slaves[$i].fetishStrength -= 20>>
 <<elseif ($fetishChangeChance > random(0,100)-20*$assistant)>>
 	After her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing encourages many orgasms while she's being beaten, @@.lightcoral;she begins to enjoy pain.@@
-	<<set $slaves[$i].fetish to "masochist", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+	<<set $slaves[$i].fetish = "masochist", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 <</if>>
 <<elseif ($slaves[$i].fetishStrength <= 95)>>
 	Her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing @@.lightcoral;advances her masochism.@@
@@ -2164,7 +2164,7 @@
 			<<set $slaves[$i].fetishStrength -= 20>>
 		<<elseif ($fetishChangeChance > random(0,100)-20*$assistant)>>
 			After her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing encourages many orgasms while she's involved in the abuse of other slaves, @@.lightcoral;she begins to develop a sadistic streak.@@
-			<<set $slaves[$i].fetish to "sadist", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
+			<<set $slaves[$i].fetish = "sadist", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
 		<</if>>
 	<<elseif ($slaves[$i].fetishStrength <= 95)>>
 			Her smart <<if $slaves[$i].vagina > -1>>clit<<else>>frenulum<</if>> piercing @@.lightcoral;advances her sadism.@@
@@ -2178,26 +2178,26 @@
 
 <<if $slaves[$i].fuckdoll == 0>>
 <<if ($slaves[$i].fetish != "mindbroken")>>
-<<if ($slaves[$i].clitPiercing != 3) || ($slaves[$i].clitSetting is "off") || ($slaves[$i].clitSetting is "none") || ($slaves[$i].clitSetting is "all") || ($slaves[$i].clitSetting is "men") || ($slaves[$i].clitSetting is "women")>>
+<<if ($slaves[$i].clitPiercing != 3) || ($slaves[$i].clitSetting == "off") || ($slaves[$i].clitSetting == "none") || ($slaves[$i].clitSetting == "all") || ($slaves[$i].clitSetting == "men") || ($slaves[$i].clitSetting == "women")>>
 
 <<if canDoAnal($slaves[$i])>>
-<<if ($slaves[$i].vaginalAccessory is "chastity belt")>>
+<<if ($slaves[$i].vaginalAccessory == "chastity belt")>>
 	<<if ($slaves[$i].prostate != 0) || ($slaves[$i].vagina > -1)>>
 	<<if ($slaves[$i].fetishStrength <= 95)>>
 	<<if $fetishChangeChance > random(0,100)>>
-	<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "serve in the club")>>
+	<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "serve in the club")>>
 		<<if $slaves[$i].fetish != "buttslut">>
 			With so much sexual attention focused on her anus, @@.lightcoral;she comes to view buttsex as the centerpiece of her sexuality.@@
-			<<set $slaves[$i].fetish to "buttslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
-		<<elseif ($slaves[$i].fetish is "buttslut") && ($slaves[$i].fetishStrength <= 95)>>
+			<<set $slaves[$i].fetish = "buttslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
+		<<elseif ($slaves[$i].fetish == "buttslut") && ($slaves[$i].fetishStrength <= 95)>>
 			With so much sexual attention focused on her anus, @@.lightcoral;her love of anal increases.@@
 			<<set $slaves[$i].fetishStrength += 4>>
 		<</if>>
-	<<elseif ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel")>>
+	<<elseif ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel")>>
 		<<if $slaves[$i].fetish != "buttslut">>
 			With her anus constantly sold for use, @@.lightcoral;she comes to view buttsex as the centerpiece of her sexuality.@@
-			<<set $slaves[$i].fetish to "buttslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
-		<<elseif ($slaves[$i].fetish is "buttslut")>>
+			<<set $slaves[$i].fetish = "buttslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
+		<<elseif ($slaves[$i].fetish == "buttslut")>>
 			With her anus constantly sold for use, @@.lightcoral;her love of anal increases.@@
 			<<set $slaves[$i].fetishStrength += 4>>
 		<</if>>
@@ -2209,19 +2209,19 @@
 	<<if $slaves[$i].prostate != 0>>
 	<<if $slaves[$i].fetishStrength <= 95>>
 	<<if $fetishChangeChance > random(0,90)>>
-	<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "serve in the club")>>
+	<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "serve in the club")>>
 		<<if $slaves[$i].fetish != "buttslut">>
 		Since most of her orgasms are caused by prostate stimulation from anal sex with citizens, @@.lightcoral;she comes to view her asshole as her primary sexual organ.@@
-		<<set $slaves[$i].fetish to "buttslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
-		<<elseif ($slaves[$i].fetish is "buttslut") && ($slaves[$i].fetishStrength <= 95)>>
+		<<set $slaves[$i].fetish = "buttslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
+		<<elseif ($slaves[$i].fetish == "buttslut") && ($slaves[$i].fetishStrength <= 95)>>
 		After many, many prostate orgasms with a citizen's cock up her butt, @@.lightcoral;her love of anal increases.@@
 		<<set $slaves[$i].fetishStrength += 4>>
 		<</if>>
-	<<elseif ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel")>>
+	<<elseif ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel")>>
 		<<if $slaves[$i].fetish != "buttslut">>
 		Since most of her orgasms are caused by prostate stimulation from anal sex with customers, @@.lightcoral;she comes to view her asshole as her primary sexual organ.@@
-		<<set $slaves[$i].fetish to "buttslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
-		<<elseif ($slaves[$i].fetish is "buttslut") && ($slaves[$i].fetishStrength <= 95)>>
+		<<set $slaves[$i].fetish = "buttslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
+		<<elseif ($slaves[$i].fetish == "buttslut") && ($slaves[$i].fetishStrength <= 95)>>
 		After many, many prostate orgasms with a customer's cock up her butt, @@.lightcoral;her love of anal increases.@@
 		<<set $slaves[$i].fetishStrength += 4>>
 		<</if>>
@@ -2232,15 +2232,15 @@
 <</if>>
 <</if>>
 
-<<if ($slaves[$i].drugs is "testicle enhancement")>>
+<<if ($slaves[$i].drugs == "testicle enhancement")>>
 <<if ($slaves[$i].balls > 0)>>
-<<if ($slaves[$i].releaseRules is "permissive")>>
+<<if ($slaves[$i].releaseRules == "permissive")>>
 	<<if ($slaves[$i].fetishStrength <= 95)>>
 	<<if $fetishChangeChance > random(0,100)>>
 		<<if $slaves[$i].fetish != "cumslut">>
 		While masturbating, she's at first surprised but then aroused by her drug-enhanced ejaculation. After repeatedly covering herself in the stuff, @@.lightcoral;she's become a cum fetishist.@@
-		<<set $slaves[$i].fetish to "cumslut", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 10>>
-		<<elseif ($slaves[$i].fetish is "cumslut") && ($slaves[$i].fetishStrength <= 95)>>
+		<<set $slaves[$i].fetish = "cumslut", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 10>>
+		<<elseif ($slaves[$i].fetish == "cumslut") && ($slaves[$i].fetishStrength <= 95)>>
 		Her masturbation sessions have come to consist mainly of her blowing massive loads of cum into her own mouth. @@.lightcoral;Her ejaculate addiction increases.@@
 		<<set $slaves[$i].fetishStrength += 4>>
 		<</if>>
@@ -2266,7 +2266,7 @@
 <<case "submissive">>
 	<<if $slaves[$i].sexualFlaw != "neglectful">>
 		<<if $slaves[$i].energy < 80>>
-		<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club") || ($slaves[$i].assignment is "work a glory hole") || ($slaves[$i].assignment is "be confined in the arcade")>>
+		<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club") || ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade")>>
 			Serving as a sex worker drives her deeper and deeper into submission, and she pays less and less attention to her own pleasure. @@.yellow;She's become sexually self neglectful,@@ and only cares about getting others off.
 			<<set $slaves[$i].sexualFlaw = "neglectful">>
 		<</if>>
@@ -2285,7 +2285,7 @@
 		<<if $slaves[$i].diet == "cum">>
 			In addition to being an orally fixated cumslut, she eats ejaculate in her food, making the taste omnipresent for her. @@.yellow;She's become psychologically addicted to cum.@@
 			<<set $slaves[$i].sexualFlaw = "cum addict">>
-		<<elseif $slaves[$i].cockfeeder != 0>>
+		<<elseif $cockFeeder != 0>>
 			In addition to being an orally fixated cumslut, she eats by sucking dick. @@.yellow;She's become psychologically addicted to cum.@@
 			<<set $slaves[$i].sexualFlaw = "cum addict">>
 		<</if>>
@@ -2322,7 +2322,7 @@
 	<</if>>
 <<case "humiliation">>
 	<<if $slaves[$i].sexualFlaw != "attention whore">>
-		<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club")>>
+		<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club")>>
 			Serving as a public sex worker gives her plenty of delicious humiliation, and she cares less and less about sex itself and more about making people blush. @@.yellow;She's become an attention whore.@@
 			<<set $slaves[$i].sexualFlaw = "attention whore">>
 		<</if>>
@@ -2337,7 +2337,7 @@
 	<</if>>
 <<case "boobs">>
 	<<if $slaves[$i].sexualFlaw != "breast growth">>
-		<<if $slaves[$i].drugs is "breast injections">>
+		<<if $slaves[$i].drugs == "breast injections">>
 			She loves her tits, and feeling them respond to drug injections starts to hold more fascination for her than mere sex. @@.yellow;Her sexual identity is now dominated by her swelling boobs.@@
 			<<set $slaves[$i].sexualFlaw = "breast growth">>
 		<<elseif ($slaves[$i].hormones > 0) && ($slaves[$i].boobs < 1000)>>
@@ -2391,10 +2391,10 @@
 	<</if>>
 <<case "masochist">>
 	<<if $slaves[$i].sexualFlaw != "self hating">>
-		<<if ($slaves[$i].assignment is "work a glory hole") || ($slaves[$i].assignment is "be confined in the arcade")>>
+		<<if ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade")>>
 			Condemned to serve as a public fuckhole, her masochistic tendencies darken into sexual appreciation for her life as a human sex toy. @@.yellow;She's descended into true self hatred.@@
 			<<set $slaves[$i].sexualFlaw = "self hating">>
-		<<elseif ($slaves[$i].assignment is "work in the dairy") && ($dairyRestraintsSetting >= 2)>>
+		<<elseif ($slaves[$i].assignment == "work in the dairy") && ($dairyRestraintsSetting >= 2)>>
 			Strapped into a milking machine's tender, penetrative embrace, her masochistic tendencies darken into sexual appreciation for her life as a human factory. @@.yellow;She's descended into true self hatred.@@
 			<<set $slaves[$i].sexualFlaw = "self hating">>
 		<</if>>
@@ -2409,10 +2409,10 @@
 	<</if>>
 <<case "pregnancy">>
 	<<if $slaves[$i].sexualFlaw != "breeder">>
-		<<if $slaves[$i].births > 1>>
-			She's been bred so much that she starts to pay as much sexual attention to pregnancy than to impregnation. @@.yellow;She's become obsessed with breeding.@@
+		<<if $slaves[$i].births > 10>>
+			She's been bred so much that she starts to pay as much sexual attention to pregnancy as to impregnation. @@.yellow;She's become obsessed with breeding.@@
 			<<set $slaves[$i].sexualFlaw = "breeder">>
-		<<elseif ($slaves[$i].assignment is "work in the dairy") && ($dairyPregSetting >= 2) && ($slaves[$i].preg > 0)>>
+		<<elseif ($slaves[$i].assignment == "work in the dairy") && ($dairyPregSetting >= 2) && ($slaves[$i].preg > 0)>>
 			With her womanhood fucked full of cum and fertility drugs, her pregnancy fetish deepens into true perversity. @@.yellow;She's become obsessed with breeding.@@
 			<<set $slaves[$i].sexualFlaw = "breeder">>
 		<</if>>
@@ -2442,22 +2442,22 @@
 	<</if>>
 <</if>>
 <<if ($slaves[$i].nipplesPiercing == 1)>>
-	<<if ($slaves[$i].nipples is "tiny")>>
+	<<if ($slaves[$i].nipples == "tiny")>>
 	<<if (random(1,100) > 95)>>
 		$possessiveCap piercings keep $possessive nipples half-hard all the time, and @@.lime;$possessive nipples have stretched out a bit.@@
-		<<set $slaves[$i].nipples to "cute">>
+		<<set $slaves[$i].nipples = "cute">>
 	<</if>>
-	<<elseif ($slaves[$i].nipples is "partially inverted")>>
+	<<elseif ($slaves[$i].nipples == "partially inverted")>>
 	<<if (random(1,100) > 70)>>
 		$possessiveCap piercings keep $possessive nipples half-hard all the time, which @@.lime;permanently protrudes them.@@
 		<<if (random(1,2) == 1)>>
 		It turns out they're pretty cute.
-		<<set $slaves[$i].nipples to "cute">>
+		<<set $slaves[$i].nipples = "cute">>
 		<<else>>
 		It turns out they're nice and puffy.
-		<<set $slaves[$i].nipples to "puffy">>
+		<<set $slaves[$i].nipples = "puffy">>
 		<</if>>
-		<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 1)>>
+		<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 1)>>
 		This is @@.hotpink;a long and uncomfortable experience, which $pronoun gets off on.@@
 		<<set $slaves[$i].devotion += 1>>
 		<<else>>
@@ -2466,7 +2466,7 @@
 		<</if>>
 	<<else>>
 		Having $possessive nipples held protruded by $possessive piercings is uncomfortable, which $pronoun
-		<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 1)>>
+		<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 1)>>
 		@@.hotpink;gets off on.@@
 		<<set $slaves[$i].devotion += 1>>
 		<<else>>
@@ -2474,17 +2474,17 @@
 		<<set $slaves[$i].devotion -= 1>>
 		<</if>>
 	<</if>>
-	<<elseif ($slaves[$i].nipples is "inverted")>>
+	<<elseif ($slaves[$i].nipples == "inverted")>>
 	<<if (random(1,100) > 90)>>
 		$possessiveCap piercings keep $possessive nipples half-hard all the time, which eventually @@.lime;permanently protrudes them.@@
 		<<if (random(1,2) == 1)>>
 		It turns out they're absolutely massive.
-		<<set $slaves[$i].nipples to "huge">>
+		<<set $slaves[$i].nipples = "huge">>
 		<<else>>
 		It turns out they're nice and puffy.
-		<<set $slaves[$i].nipples to "puffy">>
+		<<set $slaves[$i].nipples = "puffy">>
 		<</if>>
-		<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 1)>>
+		<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 1)>>
 		This is @@.hotpink;a long and very uncomfortable experience, which $pronoun gets off on.@@
 		<<set $slaves[$i].devotion += 3>>
 		<<else>>
@@ -2493,7 +2493,7 @@
 		<</if>>
 	<<else>>
 		Having $possessive nipples held protruded by $possessive piercings is very uncomfortable, which $pronoun
-		<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 1)>>
+		<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 1)>>
 		@@.hotpink;gets off on.@@
 		<<set $slaves[$i].devotion += 1>>
 		<<else>>
@@ -2503,22 +2503,22 @@
 	<</if>>
 	<</if>>
 <<elseif ($slaves[$i].nipplesPiercing is 2)>>
-	<<if ($slaves[$i].nipples is "tiny")>>
+	<<if ($slaves[$i].nipples == "tiny")>>
 	<<if (random(1,100) > 80)>>
 		$possessiveCap's got so much metal in $possessive nipples that the weight @@.lime;stretches and lengthens them.@@
-		<<set $slaves[$i].nipples to "cute">>
+		<<set $slaves[$i].nipples = "cute">>
 	<</if>>
-	<<elseif ($slaves[$i].nipples is "partially inverted")>>
+	<<elseif ($slaves[$i].nipples == "partially inverted")>>
 	<<if (random(1,100) > 50)>>
 		$possessiveCap's got so much metal in $possessive nipples that the weight @@.lime;permanently protrudes them.@@
 		<<if (random(1,2) == 1)>>
 		It turns out they're pretty cute.
-		<<set $slaves[$i].nipples to "cute">>
+		<<set $slaves[$i].nipples = "cute">>
 		<<else>>
 		It turns out they're nice and puffy.
-		<<set $slaves[$i].nipples to "puffy">>
+		<<set $slaves[$i].nipples = "puffy">>
 		<</if>>
-		<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 1)>>
+		<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 1)>>
 		This is @@.hotpink;a long and uncomfortable experience, which $possessive gets off on.@@
 		<<set $slaves[$i].devotion += 2>>
 		<<else>>
@@ -2527,7 +2527,7 @@
 		<</if>>
 	<<else>>
 		Having $possessive nipples held protruded by $possessive piercings is uncomfortable, which $possessive
-		<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 1)>>
+		<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 1)>>
 		@@.hotpink;gets off on.@@
 		<<set $slaves[$i].devotion += 1>>
 		<<else>>
@@ -2535,17 +2535,17 @@
 		<<set $slaves[$i].devotion -= 1>>
 		<</if>>
 	<</if>>
-	<<elseif ($slaves[$i].nipples is "inverted")>>
+	<<elseif ($slaves[$i].nipples == "inverted")>>
 	<<if (random(1,100) > 70)>>
 		$possessiveCap's got so much metal in $possessive nipples that the weight @@.lime;permanently protrudes them.@@
 		<<if (random(1,2) == 1)>>
 		It turns out they're absolutely massive.
-		<<set $slaves[$i].nipples to "huge">>
+		<<set $slaves[$i].nipples = "huge">>
 		<<else>>
 		It turns out they're nice and puffy.
-		<<set $slaves[$i].nipples to "puffy">>
+		<<set $slaves[$i].nipples = "puffy">>
 		<</if>>
-		<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 1)>>
+		<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 1)>>
 		This is @@.hotpink;a long and extremely uncomfortable experience, which she gets off on.@@
 		<<set $slaves[$i].devotion += 4>>
 		<<else>>
@@ -2554,7 +2554,7 @@
 		<</if>>
 	<<else>>
 		Having $possessive nipples held protruded by $possessive piercings is extremely uncomfortable, which $possessive
-		<<if ($slaves[$i].fetish is "masochist") && ($slaves[$i].fetishKnown == 1)>>
+		<<if ($slaves[$i].fetish == "masochist") && ($slaves[$i].fetishKnown == 1)>>
 		@@.hotpink;gets off on.@@
 		<<set $slaves[$i].devotion += 2>>
 		<<else>>
@@ -2569,25 +2569,25 @@
 
 <<if ($slaves[$i].nipples != "huge")>>
 <<if ($slaves[$i].lactation >= 2)>>
-	<<if ($slaves[$i].nipples is "tiny")>>
+	<<if ($slaves[$i].nipples == "tiny")>>
 	<<if (random(1,100) > 70)>>
 		Having $possessive heavy milk production forced through $possessive tiny nipples @@.lime;stretches and engorges them.@@
-		<<set $slaves[$i].nipples to "cute">>
+		<<set $slaves[$i].nipples = "cute">>
 	<</if>>
-	<<elseif ($slaves[$i].nipples is "cute") || ($slaves[$i].nipples is "inverted")>>
+	<<elseif ($slaves[$i].nipples == "cute") || ($slaves[$i].nipples == "inverted")>>
 	<<if (random(1,100) > 80)>>
 		$pronounCap's lactating so heavily that $possessive permanently swollen nipples gradually become accustomed to the constant flow of milk. They @@.lime;become puffy@@ and engorged.
-		<<set $slaves[$i].nipples to "puffy">>
+		<<set $slaves[$i].nipples = "puffy">>
 	<</if>>
-	<<elseif ($slaves[$i].nipples is "partially inverted") || ($slaves[$i].nipples is "inverted")>>
+	<<elseif ($slaves[$i].nipples == "partially inverted") || ($slaves[$i].nipples == "inverted")>>
 	<<if (random(1,100) > 80)>>
 		$pronounCap's lactating so heavily that $possessive swollen nipples almost never retreat into their inverted state. Lactation has @@.lime;permanently protruded them,@@ leaving them engorged and puffy.
-		<<set $slaves[$i].nipples to "puffy">>
+		<<set $slaves[$i].nipples = "puffy">>
 	<</if>>
 	<<else>>
 	<<if (random(1,100) > 90)>>
 		Lactation has @@.lime;swollen $possessive nipples@@ to an absurd size, making $possessive status as a cow obvious even when $possessive chest faucets aren't gushing cream.
-		<<set $slaves[$i].nipples to "huge">>
+		<<set $slaves[$i].nipples = "huge">>
 	<</if>>
 	<</if>>
 <</if>>
@@ -2690,9 +2690,10 @@
 	<</if>>
 <</if>>
 
+<<if $slaves[$i].diet == "muscle building">>
 <<if ($slaves[$i].muscles > 30)>>
 	<<if (($slaves[$i].face-($slaves[$i].faceImplant*20)) > 10) && (random(1,100) > 90)>>
-		All the hormones in $possessive system from $possessive heavy workouts @@.orange;harden $possessive beautiful face a little.@@
+		All the hormones in $possessive system from $possessive heavy workouts @@.orange;harden $possessive face a little.@@
 		<<set $slaves[$i].face -= 5>>
 	<</if>>
 	<<if (($slaves[$i].boobs - $slaves[$i].boobsImplant) > 250)>>
@@ -2701,6 +2702,7 @@
 		<<set $slaves[$i].boobs -= 50>>
 	<</if>>
 	<</if>>
+<</if>>
 <</if>>
 
 <<if $slaves[$i].addict > 2>>
@@ -2727,12 +2729,12 @@
 	<<if (($slaves[$i].boobs-$slaves[$i].boobsImplant) < 500)>>
 		<<set _Effects.push("BoobsBigger")>>
 	<</if>>
-	<<if (($slaves[$i].face-($slaves[$i].faceImplant*20)) <= 10) && ($slaves[$i].face <= 95)>>
+	<<if (($slaves[$i].face-($slaves[$i].faceImplant*20)) <= 10)>>
 		<<set _Effects.push("FaceSofter")>>
 	<</if>>
-	<<if ($slaves[$i].faceShape is "masculine")>>
+	<<if ($slaves[$i].faceShape == "masculine")>>
 		<<set _Effects.push("FaceSofterAndrogynous")>>
-	<<elseif ($slaves[$i].faceShape is "androgynous")>>
+	<<elseif ($slaves[$i].faceShape == "androgynous")>>
 		<<set _Effects.push("FaceNormal")>>
 	<</if>>
 	<<if ($slaves[$i].devotion <= 20)>>
@@ -2807,396 +2809,387 @@
 
 <<if ($slaves[$i].preg > 0)>> /*EFFECTS OF PREGNANCY*/
 
-<<if $slaves[$i].fuckdoll == 0>>
-<<if $slaves[$i].fetish != "mindbroken">>
-<<if ($slaves[$i].energy <= 95)>>
-<<if ($slaves[$i].fetish is "pregnancy")>>
-	<<if ($slaves[$i].preg > 30)>>
-		Being a pregnancy fetishist and hugely pregnant confers an @@.green;improvement in her sexual appetite.@@
-		<<set $slaves[$i].energy += 3>>
-	<<elseif ($slaves[$i].preg > 20)>>
-		Being a pregnancy fetishist and pregnant confers a @@.green;slow improvement in her sexual appetite.@@
-		<<set $slaves[$i].energy += 2>>
-	<<elseif ($slaves[$i].preg > 5)>>
-		Her new pregnancy excites her and produces @@.green;very slow improvement in her sexual appetite.@@
-		<<set $slaves[$i].energy += 1>>
-	<<elseif ($slaves[$i].preg <= 5)>>
-		The rigors of early pregnancy do not seem to decrease her sex drive. If anything, it seems to be exciting her.
-	<</if>>
-	<<if $slaves[$i].fetishKnown == 0>>
-		Given her enthusiasm, she appears to have a @@.lightcoral;pregnancy fetish@@.
-		<<set $slaves[$i].fetishKnown = 1>>
-	<</if>>
-<<else>>
-	<<if ($slaves[$i].energy < 41)>>
-		<<if ($slaves[$i].preg <= 5)>>
-		  The rigors of early pregnancy @@.red;reduce her sexual appetite.@@
-		  <<set $slaves[$i].energy -= 3>>
-		<<elseif ($slaves[$i].preg > 30)>>
-		  Her advanced pregnancy @@.red;greatly suppresses her sexual appetite.@@
-		  <<set $slaves[$i].energy -= 3>>
-		<<elseif ($slaves[$i].preg > 20)>>
-		  Her growing pregnancy @@.red;suppresses her sexual appetite.@@
-		  <<set $slaves[$i].energy -= 2>>
-		<<elseif ($slaves[$i].preg > 10)>>
-		  Her visible pregnancy causes her to feel unattractive, @@.red;reducing her sex drive.@@
-		  <<set $slaves[$i].energy -= 1>>
+	<<if ($slaves[$i].fuckdoll == 0) && ($slaves[$i].fetish != "mindbroken")>>
+		<<if ($slaves[$i].fetish == "pregnancy")>>
+			<<if ($slaves[$i].preg <= 5)>>
+				The rigors of early pregnancy do not seem to decrease her sex drive. If anything, she seems excited.
+			<<elseif ($slaves[$i].energy <= 100)>>
+				<<if ($slaves[$i].preg > 30)>>
+					Being hugely pregnant confers a @@.green;rapid improvement in her sexual appetite.@@
+					<<set $slaves[$i].energy += 3>>
+				<<elseif ($slaves[$i].preg > 20)>>
+					Being pregnant confers a @@.green;noticeable improvement in her sexual appetite.@@
+					<<set $slaves[$i].energy += 2>>
+				<<elseif ($slaves[$i].preg > 5)>>
+					Her new pregnancy excites her and produces @@.green;slow improvement in her sexual appetite.@@
+					<<set $slaves[$i].energy += 1>>
+				<</if>>
+			<</if>>
+			<<if ($slaves[$i].fetishKnown == 0)>>
+				Her pregnancy, combined with her already strong libido, has her begging for sex whenever she has a spare moment. Given her enthusiasm, she appears to have a @@.lightcoral;pregnancy fetish@@.
+				<<set $slaves[$i].fetishKnown = 1>>
+			<</if>>
+		<<else>> /* not pregnancy fetish */
+			<<if ($slaves[$i].energy < 41)>>
+				<<if ($slaves[$i].preg <= 5)>>
+					The rigors of early pregnancy @@.red;reduce her sexual appetite.@@
+					<<set $slaves[$i].energy -= 3>>
+				<<elseif ($slaves[$i].preg > 30)>>
+					Her advanced pregnancy @@.red;greatly suppresses her sexual appetite.@@
+					<<set $slaves[$i].energy -= 4>>
+				<<elseif ($slaves[$i].preg > 20)>>
+					Her growing pregnancy @@.red;suppresses her sexual appetite.@@
+					<<set $slaves[$i].energy -= 2>>
+				<<elseif ($slaves[$i].preg > 10)>>
+					Her visible pregnancy causes her to feel unattractive, @@.red;reducing her sex drive.@@
+					<<set $slaves[$i].energy -= 1>>
+				<</if>>
+			<<elseif ($slaves[$i].energy < 61)>>
+				<<if ($slaves[$i].preg <= 5)>>
+					The rigors of early pregnancy @@.red;slightly reduce her sexual appetite.@@
+					<<set $slaves[$i].energy -= 1>>
+				<<elseif ($slaves[$i].preg > 30)>>
+					Her advanced pregnancy @@.green;increases her libido.@@
+					<<set $slaves[$i].energy += 1>>
+				<</if>>
+			<<elseif ($slaves[$i].energy < 95)>>
+				<<if ($slaves[$i].preg <= 5)>>
+					The rigors of early pregnancy @@.red;reduce her sexual appetite.@@
+					<<set $slaves[$i].energy -= 3>>
+				<<elseif ($slaves[$i].preg > 20)>>
+					Her growing pregnancy comes with an increased libido, @@.green;spurring her sexual appetite.@@
+					<<set $slaves[$i].energy += 1>>
+				<</if>>
+			<</if>>
 		<</if>>
-	<<elseif ($slaves[$i].energy < 61)>>
-		<<if ($slaves[$i].preg <= 5)>>
-		  The rigors of early pregnancy @@.red;slightly reduce her sexual appetite.@@
-		  <<set $slaves[$i].energy -= 1>>
-		<<elseif ($slaves[$i].preg > 30)>>
-		  Her advanced pregnancy @@.green;increases her libido.@@
-		  <<set $slaves[$i].energy += 1>>
-		<</if>>
-	<<elseif ($slaves[$i].energy < 95)>>
-		<<if ($slaves[$i].preg <= 5)>>
-		  The rigors of early pregnancy @@.red;reduce her sexual appetite.@@
-		  <<set $slaves[$i].energy -= 3>>
-		<<elseif ($slaves[$i].preg > 30)>>
-		  Her advanced pregnancy comes with a hugely increased libido, @@.green;greatly increasing her sexual drive.@@
-		  <<set $slaves[$i].energy += 3>>
-		<<elseif ($slaves[$i].preg > 20)>>
-		  Her growing pregnancy comes with an increased libido, @@.green;spurring her sexual appetite.@@
-		  <<set $slaves[$i].energy += 2>>
-		<</if>>
 	<</if>>
-<</if>>
-<</if>>
-<</if>>
-<</if>>
 
-<<if $slaves[$i].preg >= 10>>
-	<<if $slaves[$i].fuckdoll == 0>>
-	<<if $slaves[$i].fetish != "mindbroken">>
-		<<if ($slaves[$i].devotion) <= 20 && ($slaves[$i].pregSource == -1)>>
-			She is filled with a feeling of @@.mediumorchid;revulsion@@ that your child is growing within her body.
-			<<set $slaves[$i].devotion -= 1>>
-		<<elseif ($slaves[$i].devotion) > 50 && ($slaves[$i].pregSource == -1)>>
-			She @@.hotpink;loves@@ that your child is growing within her.
-			<<set $slaves[$i].devotion += 1>>
-		<</if>>
-		<<if ($slaves[$i].pregSource == $slaves[$i].relationshipTarget)>>
-			She can't help but feel @@.mediumaquamarine;satisfaction@@ in carrying her lover's child.
-			<<set $slaves[$i].trust += 1>>
-		<</if>>
-		<<if $slaves[$i].preg > 20>>
-		<<if random(1,100) == 69>>
-		<<if $slaves[$i].behavioralFlaw == "none" && $slaves[$i].behavioralQuirk == "none">>
-			<<set $seed to random(1,4)>>
-			<<if $seed == 1>>
-				<<set $slaves[$i].behavioralFlaw = "odd">>
-				The stress of her growing pregnancy leads her to begin @@.red;acting oddly@@.
-			<<elseif $seed == 2>>
-				<<set $slaves[$i].behavioralFlaw = "hates men">>
-				The stress of her growing pregnancy leads her to begin @@.red;disliking the company of men@@.
-			<<elseif $seed == 3>>
-				<<set $slaves[$i].behavioralFlaw = "hates women">>
-				The stress of her growing pregnancy leads her to begin @@.red;disliking the company of women@@.
-			<<else>>
-				<<set $slaves[$i].behavioralFlaw = "gluttonous">>
-				The stress of her growing pregnancy leads her to begin @@.red;taking solace in overeating@@.
+	<<if ($slaves[$i].preg >= 10)>>
+		<<if ($slaves[$i].fuckdoll == 0) && ($slaves[$i].fetish != "mindbroken")>>
+			<<if ($slaves[$i].devotion <= 20) && ($slaves[$i].pregSource == -1)>>
+				She is filled with a feeling of @@.mediumorchid;revulsion@@ that your child is growing within her body.
+				<<set $slaves[$i].devotion -= 1>>
+			<<elseif ($slaves[$i].devotion > 50) && ($slaves[$i].pregSource == -1)>>
+				She @@.hotpink;loves@@ that your child is growing within her.
+				<<set $slaves[$i].devotion += 1>>
 			<</if>>
-		<<elseif $slaves[$i].sexualFlaw == "none" && $slaves[$i].sexualQuirk == "none">>
-			<<set $seed to random(1,8)>>
-			<<if $seed == 1>>
-				<<set $slaves[$i].sexualFlaw = "hates oral">>
-				The stress of her growing pregnancy leads her to begin @@.red;rejecting oral sex@@.
-			<<elseif $seed == 2>>
-				<<set $slaves[$i].sexualFlaw = "hates anal">>
-				The stress of her growing pregnancy leads her to begin @@.red;rejecting anal sex@@.
-			<<elseif $seed == 3>>
-				<<set $slaves[$i].sexualFlaw = "hates penetration">>
-				The stress of her growing pregnancy leads her to begin @@.red;rejecting penetrative sex@@.
-			<<elseif $seed == 4>>
-				<<set $slaves[$i].sexualFlaw = "shamefast">>
-				The stress of her growing pregnancy leads her to become @@.red;paranoid about her naked body@@.
-			<<elseif $seed == 5>>
-				<<set $slaves[$i].sexualFlaw = "repressed">>
-				The stress of her growing pregnancy leads her to begin @@.red;rejecting sex@@.
-			<<elseif $seed == 6>>
-				<<set $slaves[$i].sexualFlaw = "apathetic">>
-				The stress of her growing pregnancy causes her to become @@.red;inert during sex@@.
-			<<elseif $seed == 7>>
-				<<set $slaves[$i].sexualFlaw = "crude">>
-				The stress of her growing pregnancy leads her to @@.red;become quite crude@@.
-			<<else>>
-				<<set $slaves[$i].sexualFlaw = "judgemental">>
-				The stress of her growing pregnancy causes her to become overly @@.red;judgemental of her partners@@.
+			<<if ($slaves[$i].pregSource == $slaves[$i].relationshipTarget)>>
+				She can't help but feel @@.mediumaquamarine;satisfaction@@ in carrying her lover's child.
+				<<set $slaves[$i].trust += 1>>
 			<</if>>
+			<<if ($slaves[$i].preg > 20) && (random(1,100) == 69)>>
+				<<if ($slaves[$i].behavioralFlaw == "none") && ($slaves[$i].behavioralQuirk == "none")>>
+					<<switch random(1,4)>>
+					<<case 1>>
+						<<set $slaves[$i].behavioralFlaw = "odd">>
+						The stress of her growing pregnancy leads her to begin @@.red;acting oddly@@.
+					<<case 2>>
+						<<set $slaves[$i].behavioralFlaw = "hates men">>
+						The stress of her growing pregnancy leads her to begin @@.red;disliking the company of men@@.
+					<<case 3>>
+						<<set $slaves[$i].behavioralFlaw = "hates women">>
+						The stress of her growing pregnancy leads her to begin @@.red;disliking the company of women@@.
+					<<case 4>>
+						<<set $slaves[$i].behavioralFlaw = "gluttonous">>
+						The stress of her growing pregnancy leads her to begin @@.red;taking solace in overeating@@.
+					<</switch>>
+				<<elseif ($slaves[$i].sexualFlaw == "none") && ($slaves[$i].sexualQuirk == "none")>>
+					<<switch random(1,8)>>
+					<<case 1>>
+						<<set $slaves[$i].sexualFlaw = "hates oral">>
+						The stress of her growing pregnancy leads her to begin @@.red;rejecting oral sex@@.
+					<<case 2>>
+						<<set $slaves[$i].sexualFlaw = "hates anal">>
+						The stress of her growing pregnancy leads her to begin @@.red;rejecting anal sex@@.
+					<<case 3>>
+						<<set $slaves[$i].sexualFlaw = "hates penetration">>
+						The stress of her growing pregnancy leads her to begin @@.red;rejecting penetrative sex@@.
+					<<case 4>>
+						<<set $slaves[$i].sexualFlaw = "shamefast">>
+						The stress of her growing pregnancy leads her to become @@.red;paranoid about her naked body@@.
+					<<case 5>>
+						<<set $slaves[$i].sexualFlaw = "repressed">>
+						The stress of her growing pregnancy leads her to begin @@.red;rejecting sex@@.
+					<<case 6>>
+						<<set $slaves[$i].sexualFlaw = "apathetic">>
+						The stress of her growing pregnancy causes her to become @@.red;inert during sex@@.
+					<<case 7>>
+						<<set $slaves[$i].sexualFlaw = "crude">>
+						The stress of her growing pregnancy leads her to @@.red;become quite crude@@.
+					<<case 8>>
+						<<set $slaves[$i].sexualFlaw = "judgemental">>
+						The stress of her growing pregnancy causes her to become overly @@.red;judgemental of her partners@@.
+					<</switch>>
+				<</if>>
+			<</if>>
+			<<if ($slaves[$i].fetishStrength <= 95) && ($fetishChangeChance > random(0,100)) && ($slaves[$i].oralCount+$slaves[$i].vaginalCount+$slaves[$i].analCount > 200) && ($slaves[$i].fetish != "pregnancy")>>
+				The combination of pregnancy and constant sex has @@.pink;sexualized pregnancy for her.@@
+				<<set $slaves[$i].fetish = "pregnancy", $slaves[$i].fetishKnown = 1, $slaves[$i].fetishStrength = 65>>
+			<</if>>
+		<</if>> /* closes not fuckdoll or mindbroken check; still .preg >= 10 */
+		<<if (random(1,100) > 80) && ($slaves[$i].boobs - $slaves[$i].boobsImplant) < 1000>>
+			Pregnancy @@.lime;causes $possessive breasts to swell somewhat.@@
+			<<set $slaves[$i].boobs += 50>>
 		<</if>>
-		<</if>>
-		<</if>>
-		<<if ($slaves[$i].fetish != "pregnancy")>>
-		<<if ($slaves[$i].fetish != "mindbroken")>>
-		<<if ($slaves[$i].fetishStrength <= 95)>>
-		<<if ($slaves[$i].oralCount+$slaves[$i].vaginalCount+$slaves[$i].analCount > 200)>>
-		<<if $fetishChangeChance > random(0,100)>>
-			The combination of pregnancy and constant sex has @@.pink;sexualized pregnancy for her.@@
-			<<set $slaves[$i].fetish to "pregnancy", $slaves[$i].fetishKnown to 1, $slaves[$i].fetishStrength = 65>>
-		<</if>>
-		<</if>>
-		<</if>>
-		<</if>>
-		<</if>>
-	<</if>>
-	<</if>>
-	<<if ($slaves[$i].boobs - $slaves[$i].boobsImplant) < 1000>>
-	<<if random(1,100) > 80>>
-		Pregnancy @@.lime;causes $possessive breasts to swell somewhat.@@
-		<<set $slaves[$i].boobs += 50>>
-		<<if $slaves[$i].boobShape != "saggy">>
-		<<if $slaves[$i].preg > random(25,100)>>
+		<<if $slaves[$i].preg > random(25,100) && ($slaves[$i].boobs - $slaves[$i].boobsImplant) >= 800 && ($slaves[$i].boobShape != "saggy")>>
 			$possessiveCap @@.orange;breasts become saggy@@ in the last stages of $possessive pregnancy as $possessive body undergoes changes in anticipation of the forthcoming birth.
-			<<set $slaves[$i].boobShape to "saggy">>
+			<<set $slaves[$i].boobShape = "saggy">>
 		<</if>>
-		<</if>>
-	<</if>>
-	<</if>>
-	<<if $slaves[$i].preg == 10>>
-		$possessiveCap areolae darken with $possessive progressing pregnancy.
-	<<else>>
-		<<if $fakeBellies.includes($bellyAccessory)>>
-			Her growing pregnancy renders her fake belly moot.
-			<<set $slaves[$i].bellyAccessory to "none">>
-		<</if>>
-		<<if $slaves[$i].preg > 20>>
-		<<if $slaves[$i].lactation == 0>>
-			<<if $slaves[$i].health < -20>>
-				$pronoun's so unwell that natural lactation is unlikely.
-			<<elseif $slaves[$i].weight <= -30>>
-				$pronoun's so skinny that natural lactation is unlikely.
-			<<elseif $slaves[$i].preg > random(18,30)>>
-				Pregnancy @@.lime;causes $object to begin lactating.@@
-				<<set $slaves[$i].lactation to 1>>
+		<<if $slaves[$i].preg == 10>>
+			$possessiveCap areolae darken with $possessive progressing pregnancy.
+		<<else>>
+			<<if $fakeBellies.includes($bellyAccessory)>>
+				Her growing pregnancy renders her fake belly moot.
+				<<set $slaves[$i].bellyAccessory = "none">>
+			<</if>>
+			<<if ($slaves[$i].preg > 20) && ($slaves[$i].lactation == 0)>>
+				<<if $slaves[$i].health < -20>>
+					$pronounCap's so unwell that natural lactation is unlikely.
+				<<elseif $slaves[$i].weight <= -30>>
+					$pronounCap's so skinny that natural lactation is unlikely.
+				<<elseif $slaves[$i].preg > random(18,30)>>
+					Pregnancy @@.lime;causes $object to begin lactating.@@
+					<<set $slaves[$i].lactation = 1>>
+				<</if>>
 			<</if>>
 		<</if>>
-		<</if>>
-	<</if>>
-<<else>>
+	<</if>> /* closes .preg >= 10 */
+
 	<<if $slaves[$i].pregType == 0>>
-		<<if ($slaves[$i].drugs is "fertility drugs")>>
+		<<if ($slaves[$i].drugs == "fertility drugs")>>
 			<<if ($slaves[$i].hormones == 2)>>
-				<<set $slaves[$i].pregType to random(1,5)>>
+				<<set $slaves[$i].pregType = random(1,5)>>
 			<<else>>
 				<<set $slaves[$i].pregType to either(1, 1, 1, 1, 2, 2, 2, 3, 3, 4)>>
 			<</if>>
 		<<else>>
-			<<set $slaves[$i].pregType to either(1, 1, 1, 1, 1, 1, 1, 1, 1, 2)>>
+			<<set $slaves[$i].pregType = either(1, 1, 1, 1, 1, 1, 1, 1, 1, 2)>>
 		<</if>>
 	<</if>>
-<</if>>
 
 <</if>> /* END PREG EFFECTS */
 
 /* IS NOT PREGNANT */
 
-<<if $slaves[$i].fuckdoll == 0>>
-<<if $slaves[$i].fetish != "mindbroken">>
-<<if isFertile($slaves[$i]) && ($slaves[$i].preg == -1)>>
-	<<if ($slaves[$i].devotion > 20)>>
-	<<if ($slaves[$i].fetish is "pregnancy")>>
-	<<if ($slaves[$i].fetishStrength > 60)>>
-	<<if ($slaves[$i].fetishKnown == 0)>>
+<<if ($slaves[$i].fuckdoll == 0) && ($slaves[$i].preg == -1) && ($slaves[$i].devotion > 20) && ($slaves[$i].fetishStrength > 60) && ($slaves[$i].fetish == "pregnancy") && isFertile($slaves[$i])>>
+	<<if $slaves[$i].fetishKnown == 0>>
 		@@.mediumorchid;She's unhappy@@ that she's on contraceptives, revealing that she has a @@.lightcoral;deep desire to get pregnant.@@
-		<<set $slaves[$i].fetishKnown to 1>>
+		<<set $slaves[$i].fetishKnown = 1>>
 	<<else>>
 		She badly wants to have a child, so @@.mediumorchid;she's unhappy@@ that she's on contraceptives.
 	<</if>>
 	<<set $slaves[$i].devotion -= 4>>
-	<</if>>
-	<</if>>
-	<</if>>
-<</if>>
-<</if>>
 <</if>>
 
+/* CAN GET PREGNANT (fertile, not on contraceptives and not wearing chastity) */
+
 <<if canGetPregnant($slaves[$i])>>
-<<if $universalRulesImpregnation == "HG">>
-<<if $HeadGirl != 0>>
-<<if $HGCum == 0>>
-	It's $HeadGirl.slaveName's responsibility to impregnate fertile slaves, but your Head Girl can only fuck a limited number of slaves enough to ensure impregnation each week.
-<</if>>
-<</if>>
-<</if>>
-<<if ($universalRulesImpregnation is "PC")>>
+
+<<set _seed = random(1,100)>>
+
+<<if ($PC.dick > 0) && ($universalRulesImpregnation == "PC")>>
 	$slaves[$i].slaveName is ripe for breeding, so you ejaculate inside $object often. When you bore of $possessive fertile cunt, you keep $object around as you fuck other slaves so you can pull out of them, shove your cock into $object, and fill $object with your seed anyway.
-	<<if $slaves[$i].fuckdoll == 0>>
-	<<if $slaves[$i].fetish != "mindbroken">>
+	<<if ($slaves[$i].fuckdoll == 0) && ($slaves[$i].fetish != "mindbroken")>>
 		<<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust > -20)>>
-		She attempts to resist this treatment, and spends most of her days bound securely, with your cum dripping out of her pussy. This regimen fills her with @@.mediumorchid;hatred,@@ @@.gold;fear,@@ and @@.lime;a pregnancy.@@
-		<<set $slaves[$i].devotion -= 5, $slaves[$i].trust -= 5>>
-		<<if ($slaves[$i].sexualFlaw is "none")>>
-			This unpleasant interlude leaves her @@.red;hating penetration@@ of her now-pregnant pussy.
-			<<set $slaves[$i].sexualFlaw to "hates penetration">>
-		<</if>>
+			She attempts to resist this treatment, and spends most of her days bound securely, with your cum dripping out of her pussy. This regimen fills her with @@.mediumorchid;hatred,@@ @@.gold;fear,@@ and @@.lime;a pregnancy.@@
+			<<set $slaves[$i].devotion -= 5, $slaves[$i].trust -= 5>>
+			<<if ($slaves[$i].sexualFlaw == "none")>>
+				This unpleasant interlude leaves her @@.red;hating penetration@@ of her now-pregnant pussy.
+				<<set $slaves[$i].sexualFlaw = "hates penetration">>
+			<</if>>
 		<<elseif ($slaves[$i].devotion <= 20)>>
-		She complies fearfully with your use of her body.
-		<<elseif ($slaves[$i].fetish is "pregnancy") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
-		She is @@.hotpink;absurdly pleased@@ by this treatment, @@.mediumaquamarine;trustingly@@ serving as your breeding bitch until she @@.lime;conceives.@@ She's so aroused by the constant insemination that having your dick, wet from another slave, pushed inside her to climax is often enough to bring her to orgasm in turn.
-		<<set $slaves[$i].devotion += 5, $slaves[$i].trust += 5>>
-		<<if ($slaves[$i].fetishStrength <= 95)>>
-			Such total satisfaction of her pregnancy fantasies @@.green;strengthens her fetish.@@
-			<<set $slaves[$i].fetishStrength += 4>>
-		<</if>>
+			She complies fearfully with your use of her body.
+		<<elseif ($slaves[$i].fetish == "pregnancy") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
+			She is @@.hotpink;absurdly pleased@@ by this treatment, @@.mediumaquamarine;trustingly@@ serving as your breeding bitch until she @@.lime;conceives.@@ She's so aroused by the constant insemination that having your dick, wet from another slave, pushed inside her to climax is often enough to bring her to orgasm in turn.
+			<<set $slaves[$i].devotion += 5, $slaves[$i].trust += 5>>
+			<<if ($slaves[$i].fetishStrength <= 95)>>
+				Such total satisfaction of her pregnancy fantasies @@.green;strengthens her fetish.@@
+				<<set $slaves[$i].fetishStrength += 4>>
+			<</if>>
 		<<else>>
-		She serves you dutifully in this, @@.mediumaquamarine;trustingly@@ serving as your breeding bitch until she @@.lime;conceives.@@
-		<<set $slaves[$i].trust += 5>>
+			She serves you dutifully in this, @@.mediumaquamarine;trustingly@@ serving as your breeding bitch until she @@.lime;conceives.@@
+			<<set $slaves[$i].trust += 5>>
 		<</if>>
 	<</if>>
-	<</if>>
-	<<set $activeSlave to $slaves[$i]>><<VaginalVCheck 10>><<set $slaves[$i] to $activeSlave, $slaves[$i].preg to 1, $slaves[$i].pregSource to -1>>
-	<<for $j to 0; $j < $slaves.length; $j++>>
-	<<if $HeadGirl.ID == $slaves[$j].ID>>
-		<<set $slaves[$j] to $HeadGirl>>
-		<<break>>
-	<</if>>
-	<</for>>
-<<elseif $slaves[$i].vagina <= 0>>
-<<elseif ($universalRulesImpregnation is "HG") && ($HGCum > 0) && ($slaves[$i].ID != $HeadGirl.ID)>>
-	It's $HeadGirl.slaveName's responsibility to get $object pregnant, a task your
-	<<if ($HeadGirl.fetish is "pregnancy") && ($HeadGirl.fetishKnown == 1) && ($HeadGirl.fetishStrength > 60)>>
-	pregnancy fetishist Head Girl is @@.hotpink;extremely pleased@@ to take on.
-	<<set $HeadGirl.devotion += 2>>
-	<<if ($HeadGirl.fetishStrength <= 95)>>
-		The opportunity @@.green;strengthens her pregnancy fetish@@ by indulgence.
-		<<set $HeadGirl.fetishStrength += 4>>
-	<</if>>
-	<<elseif ($HeadGirl.attrXX > 65) && ($HeadGirl.attrKnown == 1)>>
-	pussy-hungry Head Girl is @@.hotpink;happy@@ to take on.
-	<<set $HeadGirl.devotion += 1>>
+
+	<<set $slaves[$i].preg = 1, $slaves[$i].pregSource = -1>>
+	<<set $activeSlave to $slaves[$i]>><<VaginalVCheck 10>><<set $slaves[$i] to $activeSlave>>
+
+<<elseif ($HeadGirl != 0) && ($HeadGirl.dick > 0) && ($slaves[$i].ID != $HeadGirl.ID) && ($universalRulesImpregnation == "HG") && canImpreg($slaves[$i], $HeadGirl)>>
+	<<if $HGCum == 0>>
+		It's $HeadGirl.slaveName's responsibility to impregnate fertile slaves, but your Head Girl can only fuck a limited number of slaves enough to ensure impregnation each week.
 	<<else>>
-	Head Girl approaches dutifully.
-	<</if>>
-	<<if $slaves[$i].fuckdoll == 0>>
-	<<if $slaves[$i].fetish != "mindbroken">>
-		<<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust > -20)>>
-		<<if (($HeadGirl.fetish is "sadist") || ($HeadGirl.fetish is "dom")) && ($HeadGirl.fetishKnown == 1) && ($HeadGirl.fetishStrength > 60)>>
-			Her interest is piqued, however, when $slaves[$i].slaveName shows signs of resistance. $HeadGirl.slaveName @@.hotpink;enthusiastically@@ @@.mediumorchid;rapes the poor girl@@ pregnant, ejaculating inside her victim more often than is really necessary for @@.lime;conception.@@
-			<<set $HeadGirl.devotion += 2, $slaves[$i].devotion -= 5>>
-		<<else>>
-			$slaves[$i].slaveName tries to resist her, so $HeadGirl.slaveName is forced to @@.mediumorchid;rape the poor girl@@ pregnant, regularly ejaculating inside her until @@.lime;conception@@ is confirmed.
-			<<set $slaves[$i].devotion -= 4>>
-		<</if>>
-		<<if ($slaves[$i].sexualFlaw is "none")>>
-			This unpleasant interlude leaves her @@.red;hating penetration@@ of her violated pussy.
-			<<set $slaves[$i].sexualFlaw to "hates penetration">>
-		<</if>>
-		<<elseif ($slaves[$i].devotion <= 20)>>
-		<<if (($HeadGirl.fetish is "sadist") || ($HeadGirl.fetish is "dom")) && ($HeadGirl.fetishKnown == 1) && ($HeadGirl.fetishStrength > 60)>>
-			Her interest is piqued, however, when it becomes clear that $slaves[$i].slaveName, though fearfully obedient, is not happy with being bred. $HeadGirl.slaveName @@.hotpink;enthusiastically@@ ensures that her victim @@.mediumorchid;does not enjoy@@ a week of being @@.lime;raped pregnant.@@
-			<<set $HeadGirl.devotion += 2, $slaves[$i].devotion -= 3>>
-		<<else>>
-			$slaves[$i].slaveName, though fearfully obedient, is not happy with being bred, but $HeadGirl.slaveName @@.mediumorchid;rapes the poor girl@@ pregnant anyway, regularly ejaculating inside her until @@.lime;conception@@ is confirmed.
-			<<set $slaves[$i].devotion -= 2>>
-		<</if>>
-		<<if ($slaves[$i].sexualFlaw is "none")>>
-			This unpleasant interlude leaves her @@.red;hating penetration@@ of her violated pussy.
-			<<set $slaves[$i].sexualFlaw to "hates penetration">>
-		<</if>>
-		<<elseif ($slaves[$i].devotion < 75)>>
-		<<if ($slaves[$i].fetish is "pregnancy") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
-			$slaves[$i].slaveName, a pregnancy fetishist, is @@.hotpink;very willing to be bred@@ by the Head Girl, and eagerly takes her superior's cock bareback until @@.lime;conception@@ is verified.
-			<<set $slaves[$i].devotion += 2>>
-			<<if ($slaves[$i].fetishStrength <= 95)>>
-			Such total satisfaction of her pregnancy fantasies @@.green;strengthens her fetish.@@
-			<<set $slaves[$i].fetishStrength += 4>>
+		It's $HeadGirl.slaveName's responsibility to get $object pregnant, a task your
+		<<if ($HeadGirl.fetish == "pregnancy") && ($HeadGirl.fetishKnown == 1) && ($HeadGirl.fetishStrength > 60)>>
+			pregnancy fetishist Head Girl is @@.hotpink;extremely pleased@@ to take on.
+			<<set $HeadGirl.devotion += 2>>
+			<<if ($HeadGirl.fetishStrength <= 95)>>
+				The opportunity @@.green;strengthens her pregnancy fetish@@ by indulgence.
+				<<set $HeadGirl.fetishStrength += 4>>
 			<</if>>
+		<<elseif ($HeadGirl.attrXX > 65) && ($HeadGirl.attrKnown == 1)>>
+			pussy-hungry Head Girl is @@.hotpink;happy@@ to take on.
+			<<set $HeadGirl.devotion += 1>>
 		<<else>>
-			$slaves[$i].slaveName is willing to be bred by the Head Girl, and takes her superior's cock bareback until @@.lime;conception@@ is verified.
+			Head Girl approaches dutifully.
 		<</if>>
-		<<else>>
-		<<if ($slaves[$i].fetish is "pregnancy") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
-			$slaves[$i].slaveName, a pregnancy fetishist, considers breeding by the Head Girl @@.hotpink;a dream come true,@@ and the slaves carry on a torrid affair until @@.lime;conception@@ is verified.
-			<<set $slaves[$i].devotion += 2>>
-			<<if ($slaves[$i].fetishStrength <= 95)>>
-			Such total satisfaction of her pregnancy fantasies @@.green;strengthens her fetish.@@
-			<<set $slaves[$i].fetishStrength += 4>>
+
+		<<if ($slaves[$i].fuckdoll == 0) && ($slaves[$i].fetish != "mindbroken")>>
+			<<if ($slaves[$i].devotion <= 20) && ($slaves[$i].trust > -20)>>
+				<<if (($HeadGirl.fetish == "sadist") || ($HeadGirl.fetish == "dom")) && ($HeadGirl.fetishKnown == 1) && ($HeadGirl.fetishStrength > 60)>>
+					Her interest is piqued, however, when $slaves[$i].slaveName shows signs of resistance. $HeadGirl.slaveName @@.hotpink;enthusiastically@@ @@.mediumorchid;rapes the poor girl@@ pregnant, ejaculating inside her victim more often than is really necessary for @@.lime;conception.@@
+					<<set $HeadGirl.devotion += 2, $slaves[$i].devotion -= 5>>
+				<<else>>
+					$slaves[$i].slaveName tries to resist her, so $HeadGirl.slaveName is forced to @@.mediumorchid;rape the poor girl@@ pregnant, regularly ejaculating inside her until @@.lime;conception@@ is confirmed.
+					<<set $slaves[$i].devotion -= 4>>
+				<</if>>
+				<<if ($slaves[$i].sexualFlaw == "none")>>
+					This unpleasant interlude leaves her @@.red;hating penetration@@ of her violated pussy.
+					<<set $slaves[$i].sexualFlaw = "hates penetration">>
+				<</if>>
+			<<elseif ($slaves[$i].devotion <= 20)>>
+				<<if (($HeadGirl.fetish == "sadist") || ($HeadGirl.fetish == "dom")) && ($HeadGirl.fetishKnown == 1) && ($HeadGirl.fetishStrength > 60)>>
+					Her interest is piqued, however, when it becomes clear that $slaves[$i].slaveName, though fearfully obedient, is not happy with being bred. $HeadGirl.slaveName @@.hotpink;enthusiastically@@ ensures that her victim @@.mediumorchid;does not enjoy@@ a week of being @@.lime;raped pregnant.@@
+					<<set $HeadGirl.devotion += 2, $slaves[$i].devotion -= 3>>
+				<<else>>
+					$slaves[$i].slaveName, though fearfully obedient, is not happy with being bred, but $HeadGirl.slaveName @@.mediumorchid;rapes the poor girl@@ pregnant anyway, regularly ejaculating inside her until @@.lime;conception@@ is confirmed.
+					<<set $slaves[$i].devotion -= 2>>
+				<</if>>
+				<<if ($slaves[$i].sexualFlaw == "none")>>
+					This unpleasant interlude leaves her @@.red;hating penetration@@ of her violated pussy.
+					<<set $slaves[$i].sexualFlaw = "hates penetration">>
+				<</if>>
+			<<elseif ($slaves[$i].devotion < 75)>>
+				<<if ($slaves[$i].fetish == "pregnancy") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
+					$slaves[$i].slaveName, a pregnancy fetishist, is @@.hotpink;very willing to be bred@@ by the Head Girl, and eagerly takes her superior's cock bareback until @@.lime;conception@@ is verified.
+					<<set $slaves[$i].devotion += 2>>
+					<<if ($slaves[$i].fetishStrength <= 95)>>
+						Such total satisfaction of her pregnancy fantasies @@.green;strengthens her fetish.@@
+						<<set $slaves[$i].fetishStrength += 4>>
+					<</if>>
+				<<else>>
+					$slaves[$i].slaveName is willing to be bred by the Head Girl, and takes her superior's cock bareback until @@.lime;conception@@ is verified.
+				<</if>>
+			<<else>>
+				<<if ($slaves[$i].fetish == "pregnancy") && ($slaves[$i].fetishKnown == 1) && ($slaves[$i].fetishStrength > 60)>>
+					$slaves[$i].slaveName, a pregnancy fetishist, considers breeding by the Head Girl @@.hotpink;a dream come true,@@ and the slaves carry on a torrid affair until @@.lime;conception@@ is verified.
+					<<set $slaves[$i].devotion += 2>>
+					<<if ($slaves[$i].fetishStrength <= 95)>>
+						Such total satisfaction of her pregnancy fantasies @@.green;strengthens her fetish.@@
+						<<set $slaves[$i].fetishStrength += 4>>
+					<</if>>
+				<<else>>
+					$slaves[$i].slaveName is @@.hotpink;quite willing to be bred@@ by the Head Girl, whom she respects, and submissively takes her superior's cock bareback until @@.lime;conception@@ is verified.
+					<<set $slaves[$i].devotion += 1>>
+				<</if>>
 			<</if>>
-		<<else>>
-			$slaves[$i].slaveName is @@.hotpink;quite willing to be bred@@ by the Head Girl, who she respects, and submissively takes her superior's cock bareback until @@.lime;conception@@ is verified.
-			<<set $slaves[$i].devotion += 1>>
-		<</if>>
-		<</if>>
-	<</if>>
-	<</if>>
-	<<set $slaves[$i].preg to 1, $slaves[$i].pregSource to $HeadGirl.ID, $HGCum -= 1, $HeadGirl.penetrativeCount += 10, $penetrativeTotal += 10, $slaves[$i].vaginalCount += 10, $vaginalTotal += 10>>
-	<<for $j to 0; $j < $slaves.length; $j++>>
-	<<if $HeadGirl.ID == $slaves[$j].ID>>
-		<<set $slaves[$j] to $HeadGirl>>
-		<<break>>
-	<</if>>
-	<</for>>
-<<elseif ($slaves[$i].assignment is "whore") && (random(1,100) > 50)>>
-		Due to all the customers cumming in $possessive fertile pussy, @@.lime;$pronoun has gotten pregnant.@@
-		<<set $slaves[$i].preg to 1, $slaves[$i].pregSource to -2>>
-<<elseif ($slaves[$i].assignment is "serve the public") && (random(1,100) > 50)>>
-		Due to all the guys cumming in $possessive fertile pussy, @@.lime;$pronoun has gotten pregnant.@@
-		<<set $slaves[$i].preg to 1, $slaves[$i].pregSource to -2>>
-<<elseif ($slaves[$i].assignment is "work a glory hole") && (random(1,100) > 10)>>
-		Due to all the customers cumming in $possessive fertile, restrained pussy, @@.lime;$pronoun has gotten pregnant.@@
-		<<set $slaves[$i].preg to 1, $slaves[$i].pregSource to -2>>
-<<elseif (random(1,100) > 80)>>
-	<<if ($slaves[$i].vaginalCount > 0)>>
-	<<if ($slaves[$i].assignment != "rest")>>
-	<<if ($slaves[$i].assignment != "stay confined")>>
-		@@.lime;$pronounCap has gotten pregnant.@@
-		<<set $slaves[$i].preg to 1>>
-		<<for $m to 0; $m < $slaves.length; $m++>>
-			<<if $slaves[$i].relationshipTarget is $slaves[$m].ID>>
-				<<set $tempLover to $slaves[$m]>>
-			<<elseif $slaves[$i].rivalryTarget is $slaves[$m].ID>>
-				<<set $tempRival to $slaves[$m]>>
-			<<elseif $slaves[$i].subTarget is $slaves[$m].ID>>
-				<<set $tempSub to $slaves[$m]>>
+		<</if>> /* closes not fuckdoll not mindbroken */
+
+		<<set $slaves[$i].preg = 1, $slaves[$i].pregSource = $HeadGirl.ID, $HGCum -= 1, $HeadGirl.penetrativeCount += 10, $penetrativeTotal += 10>>
+		<<set $activeSlave = $slaves[$i]>><<VaginalVCheck 10>><<set $slaves[$i] = $activeSlave>>
+		<<for $j = 0; $j < $slaves.length; $j++>>
+			<<if $HeadGirl.ID == $slaves[$j].ID>>
+				<<set $slaves[$j] = $HeadGirl>>
+				<<break>>
 			<</if>>
 		<</for>>
-		<<set $seed to random(1,100)>>
-		<<if ($slaves[$i].relationship is -3 or $slaves[$i].relationship is -2) and $PC.dick == 1>>
-			<<set $slaves[$i].pregSource to -1>>
-		<<elseif $slaves[$i].relationship > 2 and canAchieveErection($tempLover) and $tempLover.dickAccessory != "chastity">>
-			<<set $slaves[$i].pregSource to $tempLover.ID>>
-		<<elseif $slaves[$i].rivalry > 2 and canAchieveErection($tempRival) and $tempRival.dickAccessory != "chastity" and $seed > 95>>/* raped and knocked up by rival */
-			<<set $slaves[$i].pregSource to $tempRival.ID>>
-		<<elseif $slaves[$i].subTarget != 0 and $slaves[$i].assignment is "be a subordinate slave">>
-			<<if canAchieveErection($tempSub) and $slaves[$m].dickAccessory != "chastity">>
-			<<set $slaves[$i].pregSource to $tempSub.ID>>
-			<</if>>
-		<<elseif $seed > 60 and $PC.dick == 1>>
-			<<set $slaves[$i].pregSource to -1>>
-		<<elseif $seed <= 10>>
-			<<set $slaves[$i].pregSource to -2>>
-		<<else>>
-			<<set $sourceSeed to random(0,$slaves.length-1)>>
-			/* random starting point in the slave array */
-			<<set $slaves[$i].pregSource to -2>>
-			/* temp .pregSource incase no matches are found */
-/*starts one above starting point and advances until it reaches starting point again or finds a suitable slave. */
-			<<for $m to $sourceSeed+1; $m is $sourceSeed; $m++>>
-				<<if $m >= $slaves.length>> /* oob catch */
-					<<set $m to -1>>
-				<<elseif $slaves[$m].dick > 0 and $slaves[$m].balls > 0 and $slaves[$m].dickAccessory != "chastity">>
-					<<if $slaves[$i].ID is $slaves[$m].ID>>
+
+	<</if>> /* closes HG impregnation */
+<<elseif (_seed > 50)>>
+	<<switch $slaves[$i].assignment>>
+	<<case "rest" "stay confined" "be confined in the cellblock">>
+		/* these assignments are safe from random impregnation */
+
+	<<case "be your Concubine">>
+		<<if ($PC.dick == 1) && ($slaves[$i].fuckdoll == 0) && ($slaves[$i].fetish != "mindbroken")>>
+			As your concubine, she takes care to only share her fertile pussy with you. Her efforts paid off; @@.lime;she has become pregnant with your child@@.
+			<<set $slaves[$i].preg = 1, $slaves[$i].pregSource = -1>>
+		<</if>>
+
+	<<case "serve in the master suite" "please you">>
+		<<if ($PC.dick == 1) && (($slaves[$i].toyHole == "all her holes") || ($slaves[$i].toyHole == "pussy"))>>
+			You frequently avail yourself to her fertile pussy. It's no surprise when @@.lime;she ends up pregnant with your child@@.
+			<<set $slaves[$i].preg = 1, $slaves[$i].pregSource = -1>>
+
+		<<else>> /% look for a random father among master suite slaves %/
+			<<for _m = 0; _m < $MastSiIDs.length; _m++>>
+				<<if canImpreg($slaves[$i], $MastSiIDs[_m])>>
 					/* catch for self-impregnation */
-						<<if random(1,100) > 95>>
-						<<set $slaves[$i].pregSource to $slaves[$m].ID>>
-						<<set $m to $sourceSeed-1>>
+					<<if $slaves[$i].ID == $MastSiIDs[_m].ID>>
+						<<if (_seed <= 95)>>
+							<<continue>> /* 95% chance not to self-impregnate */
 						<</if>>
-					<<else>>
-					<<set $slaves[$i].pregSource to $slaves[$m].ID>>
-					<<set $m to $sourceSeed-1>>
 					<</if>>
-				<<elseif $m >= $slaves.length-1>>
-					<<set $m to -1>>
+					/* found eligible father */
+					After all the unprotected sex she had this week, it's really no surprise when @@.lime;$pronoun ends up pregnant@@.
+					<<set $slaves[$i].preg = 1, $slaves[$i].pregSource = $MastSiIDs[_m].ID>>
+					<<break>>
 				<</if>>
 			<</for>>
 		<</if>>
-	<</if>>
-	<</if>>
-	<</if>>
-<</if>>
+
+	<<case "work in the brothel" "serve in the club" "whore" "serve the public">>
+		Due to all the citizens cumming in $possessive fertile pussy, @@.lime;$pronoun has become pregnant@@.
+		<<set $slaves[$i].preg = 1, $slaves[$i].pregSource = -2>>
+
+	<<case "work a glory hole" "be confined in the arcade">>
+		Due to all the customers cumming in $possessive fertile, restrained pussy, @@.lime;$pronoun has become pregnant@@.
+		<<set $slaves[$i].preg = 1, $slaves[$i].pregSource = -2>>
+
+	<<default>> /* random impregnation chance on other assignments - consider relationships first */
+		<<if (_seed > 80) && ($slaves[$i].vaginalCount > 0)>> /* TODO: compare to previous week totals? */
+			<<for _m = 0; _m < $slaves.length; _m++>>
+				<<if $slaves[$i].relationshipTarget == $slaves[_m].ID>>
+					<<set _tempLover = $slaves[_m]>>
+				<<elseif $slaves[$i].rivalryTarget == $slaves[_m].ID>>
+					<<set _tempRival = $slaves[_m]>>
+				<<elseif $slaves[$i].subTarget == $slaves[_m].ID>>
+					<<set _tempSub = $slaves[_m]>>
+				<</if>>
+			<</for>>
+			<<if ($PC.dick == 1) && (($slaves[$i].relationship == -3) || ($slaves[$i].relationship == -2))>>
+				<<set $slaves[$i].pregSource = -1>>
+			<<elseif ($slaves[$i].relationship > 2) && canImpreg($slaves[$i], _tempLover)>> /* erection not needed for impregnation via consensual sex play (FWB or better) */
+				<<set $slaves[$i].pregSource = _tempLover.ID>>
+			<<elseif ($slaves[$i].subTarget != 0) && ($slaves[$i].assignment == "be a subordinate slave") && canAchieveErection($tempSub) && canImpreg($slaves[$i], _tempSub)>> /* subordinate must have erection to impregnate target */
+				<<set $slaves[$i].pregSource = _tempSub.ID>>
+			<<elseif (_seed > 95) && ($slaves[$i].rivalry > 2) && canAchieveErection(_tempRival) && canImpreg($slaves[$i], _tempRival)>> /* 5% chance to be raped and knocked up by bitter rival - erection needed */
+				Driven by the bitter rivalry between them, _tempRival.slaveName @@.red;violently raped@@ $slaves[$i].slaveName and $pronoun has @@.lime;become pregnant@@ as a result. $possessiveCap @@.gold;confidence has been shaken@@ by the experience.
+				<<set $slaves[$i].pregSource = _tempRival.ID, $slaves[$i].health -= 20, $slaves[$i].trust -= 80>>
+			<<elseif (_seed > 60) && ($PC.dick == 1)>> /* still 40% chance of impregnation by PC */
+				<<set $slaves[$i].pregSource = -1>>
+			<<elseif (_seed > 95)>> /* 5% chance of impregnation by random citizen - TODO: make this optional for players who want random fathers from among their own slaves only */
+				<<set $slaves[$i].pregSource = -2>>
+			<<else>>
+				/* clear pregSource in case no eligible father is found */
+				<<set $slaves[$i].pregSource = 0>>
+				/* pick a random starting point in the slave array and iterate (wrapping around) until finding eligible father or coming back to starting point */
+				<<set _sourceSeed = random(0,$slaves.length-1)>>
+				<<for _m = _sourceSeed + 1; _m != _sourceSeed; _m++>>
+					<<if _m == $slaves.length>><<set _m = 0>><</if>> /* wrap around */
+					<<if canImpreg($slaves[_m], $slaves[$i])>>
+						/* self-impregnation check */
+						<<if ($slaves[_m].ID == $slaves[$i].ID) && (_seed <= 95)>>
+							<<continue>> /* 95% chance not to self-impregnate */
+						<</if>>
+						<<set $slaves[$i].pregSource = $slaves[_m].ID>> /* passed the checks above, so this is an eligible father */
+						<<break>>
+					<</if>>
+				<</for>>
+			<</if>>
+			<<if $slaves[$i].pregSource != 0>>
+				A routine scan reveals that @@.lime;$pronounCap has become pregnant@@.
+				<<set $slaves[$i].preg = 1>>
+			<</if>>
+		<</if>> /* closes random chance and non-zero sex acts check */
+	<</switch>> /* closes assignment checks */
+<</if>> /* closes all impregnation checks */
 <</if>> /* CLOSES CAN GET PREGNANT */
+
+/* PREGNANCY TYPE SANITY CHECK (not for pregnancies started above) */
+<<if $slaves[$i].pregType != 0 && ($slaves[$i].preg < 1)>> /* pregType set but not pregnant */
+	<<set $slaves[$i].pregType = 0>>
+<</if>>
 
 /* MINDBREAK */
 
@@ -3233,7 +3226,7 @@
 	<</if>>
 	<</if>>
 	<<if $slaves[$i].fuckdoll == 0>>
-		<<if ($slaves[$i].behavioralFlaw is "none")>>
+		<<if ($slaves[$i].behavioralFlaw == "none")>>
 		<<if ($slaves[$i].trust < -20)>>
 		<<if ($slaves[$i].devotion <= 50)>>
 		<<if (random(1,100) > 100+$slaves[$i].trust)>>
@@ -3241,44 +3234,44 @@
 			Being so afraid so constantly drives her to find solace in
 			<<if $seed == 1>>
 			self-denial. @@.red;She has developed anorexia.@@
-			<<set $slaves[$i].behavioralFlaw to "anorexic">>
+			<<set $slaves[$i].behavioralFlaw = "anorexic">>
 			<<elseif $seed is 2>>
 			stress eating. @@.red;She's now a nervous glutton.@@
-			<<set $slaves[$i].behavioralFlaw to "gluttonous">>
+			<<set $slaves[$i].behavioralFlaw = "gluttonous">>
 			<<elseif $seed is 3>>
 			the scraps of prayer and superstition she can remember from her life before she was a slave. @@.red;She's now religious.@@
-			<<set $slaves[$i].behavioralFlaw to "devout">>
+			<<set $slaves[$i].behavioralFlaw = "devout">>
 			<<else>>
 			the remnants of modern philosophy and education she can remember from her life before she was a slave. @@.red;She feels mentally liberated.@@
-			<<set $slaves[$i].behavioralFlaw to "liberated">>
+			<<set $slaves[$i].behavioralFlaw = "liberated">>
 			<</if>>
 		<</if>>
 		<</if>>
 		<</if>>
 		<</if>>
-		<<if ($slaves[$i].sexualFlaw is "none")>>
+		<<if ($slaves[$i].sexualFlaw == "none")>>
 		<<if ($slaves[$i].devotion < -20)>>
 		<<if (random(1,500) > 500+$slaves[$i].devotion)>>
 			<<set $seed to random(1,6)>>
 			Being so angry at her life as a sex slave has
 			<<if $seed == 1>>
 			driven her into @@.red;sexual apathy.@@
-			<<set $slaves[$i].sexualFlaw to "apathetic">>
+			<<set $slaves[$i].sexualFlaw = "apathetic">>
 			<<elseif $seed is 2>>
 			convinced her that the conservative parts of her upbringing were right: sex is evil. @@.red;She's now repressed.@@
-			<<set $slaves[$i].sexualFlaw to "repressed">>
+			<<set $slaves[$i].sexualFlaw = "repressed">>
 			<<elseif $seed is 3>>
 			given her a dread of being nude. @@.red;She's now shamefast.@@
-			<<set $slaves[$i].sexualFlaw to "shamefast">>
+			<<set $slaves[$i].sexualFlaw = "shamefast">>
 			<<elseif $seed is 4>>
 			deprived her of any motivation to keep sex appealing or even clean. @@.red;She's now crude.@@
-			<<set $slaves[$i].sexualFlaw to "crude">>
+			<<set $slaves[$i].sexualFlaw = "crude">>
 			<<elseif $seed is 5>>
 			driven her to find refuge in high standards. @@.red;She's now judgemental.@@
-			<<set $slaves[$i].sexualFlaw to "judgemental">>
+			<<set $slaves[$i].sexualFlaw = "judgemental">>
 			<<else>>
 			convinced her that sex is only this way here. Convinced that sexual slavery is wrong, @@.red;She's become sexually idealistic.@@
-			<<set $slaves[$i].sexualFlaw to "idealistic">>
+			<<set $slaves[$i].sexualFlaw = "idealistic">>
 			<</if>>
 		<</if>>
 		<</if>>
@@ -3287,10 +3280,10 @@
 <</if>>
 
 <<if (canTalk($slaves[$i]) == false)>>
-<<if ($slaves[$i].behavioralFlaw is "bitchy")>>
+<<if ($slaves[$i].behavioralFlaw == "bitchy")>>
 	If $pronoun has anything bitchy to say, @@.green;no one can tell,@@ since $pronoun can't talk.
 <</if>>
-<<if ($slaves[$i].behavioralQuirk is "cutting")>>
+<<if ($slaves[$i].behavioralQuirk == "cutting")>>
 	If $pronoun has anything witty to say, @@.red;no one can tell,@@ since $pronoun can't talk.
 <</if>>
 <</if>>
@@ -3317,7 +3310,7 @@
 
 <<if $arcologies[0].FSSupremacist != "unset">>
 	<<if ($slaves[$i].race is $arcologies[0].FSSupremacistRace)>>
-		<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club") || ($slaves[$i].assignment is "work a glory hole") || ($slaves[$i].assignment is "be confined in the arcade")>>
+		<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club") || ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade")>>
 			<<if $arcologies[0].FSSupremacist >= $FSLockinLevel*0.6>>
 				Society @@.red;strongly disapproves@@ of your keeping a slave of the $arcologies[0].FSSupremacistRace race in a degrading, public role; this also holds back acceptance of $arcologies[0].FSSupremacistRace superiority.
 			<<elseif $arcologies[0].FSSupremacist >= $FSLockinLevel*0.3>>
@@ -3326,13 +3319,13 @@
 				Society @@.red;disapproves@@ of your keeping a slave of the $arcologies[0].FSSupremacistRace race in a degrading, public role; this also holds back acceptance of $arcologies[0].FSSupremacistRace superiority.
 			<</if>>
 			<<FSChangePorn "Supremacist" -1>>
-		<<elseif ($slaves[$i].assignment is "be your Head Girl")>>
+		<<elseif ($slaves[$i].assignment == "be your Head Girl")>>
 			Society @@.green;strongly approves@@ of your keeping a slave of the $arcologies[0].FSSupremacistRace race in a position of leadership as your head girl, advancing the notion that those of the  $arcologies[0].FSSupremacistRace race should be in positions of authority over others.
 			<<FSChangePorn "Supremacist" 2>>
-		<<elseif ($slaves[$i].assignment is "recruit girls")>>
+		<<elseif ($slaves[$i].assignment == "recruit girls")>>
 			Society @@.green;strongly approves@@ of your keeping a slave of the $arcologies[0].FSSupremacistRace race in a position of leadership as your recruiter, advancing the notion that it is only natural that those of the $arcologies[0].FSSupremacistRace race should lead the charge in enslaving others.
 			<<FSChangePorn "Supremacist" 2>>
-		<<elseif ($slaves[$i].assignment is "be your concubine")>>
+		<<elseif ($slaves[$i].assignment == "be your concubine")>>
 			Society @@.green;strongly approves@@ of your keeping a slave of the $arcologies[0].FSSupremacistRace race in a position of importance as your concubine, advancing the notion that the most favoured of your bedslaves should naturally be of the $arcologies[0].FSSupremacistRace race.
 			<<FSChangePorn "Supremacist" 2>>
 			/* Code contributed by Anon1888 */
@@ -3340,20 +3333,20 @@
 			Society does not disapprove of your keeping a slave of the $arcologies[0].FSSupremacistRace race, since $pronoun is not in a publicly degrading role.
 		<</if>>
 		<<if $slaves[$i].preg > 0>>
-		<<if $slaves[$i].pregSource > 0>>
-			<<for $j to 0; $j < $slaves.length; $j++>>
-			<<if $slaves[$i].pregSource == $slaves[$j].ID>>
-				<<if $slaves[$i].race != $slaves[$j].race>>
-					Society @@.red;strongly disapproves@@ of your allowing a pure $arcologies[0].FSSupremacistRace slave to be miscegenated by $slaves[$j].slaveName.
-					<<FSChangePorn "Supremacist" -2>>
-				<<else>>
-					Society @@.green;strongly approves@@ of your using slave breeders like $slaves[$i].slaveName to propagate the $arcologies[0].FSSupremacistRace race.
-					<<FSChangePorn "Supremacist" 2>>
+			<<if $slaves[$i].pregSource > 0>>
+				<<for $j to 0; $j < $slaves.length; $j++>>
+				<<if $slaves[$i].pregSource == $slaves[$j].ID>>
+					<<if $slaves[$i].race != $slaves[$j].race>>
+						Society @@.red;strongly disapproves@@ of your allowing a pure $arcologies[0].FSSupremacistRace slave to be miscegenated by $slaves[$j].slaveName.
+						<<FSChangePorn "Supremacist" -2>>
+					<<else>>
+						Society @@.green;strongly approves@@ of your using slave breeders like $slaves[$i].slaveName to propagate the $arcologies[0].FSSupremacistRace race.
+						<<FSChangePorn "Supremacist" 2>>
+					<</if>>
+					<<break>>
 				<</if>>
-				<<break>>
+				<</for>>
 			<</if>>
-			<</for>>
-		<</if>>
 		<</if>>
 		<<if $slaves[$i].fuckdoll > 0>>
 			Society @@.red;strongly disapproves@@ of your owning a $arcologies[0].FSSupremacistRace Fuckdoll.
@@ -3441,17 +3434,9 @@
 	Society <<if $arcologies[0].FSGenderFundamentalist >= $FSLockinLevel*0.5>>@@.green;approves@@<<else>>@@.green;approves@@<</if>> of your keeping a slave fertile; this also supports the idea that slave women should bear babies.
 	<<FSChangePorn "GenderFundamentalist" 1>>
 	<</if>>
-	<<if ($slaves[$i].dick > 0)>>
-	<<if ($slaves[$i].balls > 0)>>
-	<<if ($slaves[$i].hormones <= 0)>>
-	<<if ($slaves[$i].dickAccessory != "chastity")>>
-	<<if ($slaves[$i].devotion <= 95)>>
-	Society @@.red;disapproves@@ of $slaves[$i].slaveName's stiff, unrestrained dick, since $pronoun isn't even worshipful of you.
-	<<FSChangePorn "GenderFundamentalist" -1>>
-	<</if>>
-	<</if>>
-	<</if>>
-	<</if>>
+	<<if ($slaves[$i].devotion <= 95) && canPenetrate($slaves[$i])>>
+		Society @@.red;disapproves@@ of $slaves[$i].slaveName's stiff, unrestrained dick, since $pronoun isn't even worshipful of you.
+		<<FSChangePorn "GenderFundamentalist" -1>>
 	<</if>>
 <</if>>
 
@@ -3501,7 +3486,7 @@
 		<<FSChangePorn "Paternalist" -2>>
 	<</if>>
 <<elseif $arcologies[0].FSDegradationist != "unset">>
-	<<if ($slaves[$i].fetish is "mindbroken")>>
+	<<if ($slaves[$i].fetish == "mindbroken")>>
 	Society @@.green;approves@@ of $possessive broken spirit; $pronoun serves as an example of a soulless fuckpuppet.
 	<<FSChangePorn "Degradationist" 1>>
 	<<else>>
@@ -3509,9 +3494,9 @@
 		Society @@.green;approves@@ of $slaves[$i].slaveName's fear of you.
 		<<FSChangePorn "Degradationist" 1>>
 	<<else>>
-		<<if ($slaves[$i].assignment is "be your Head Girl")>>
+		<<if ($slaves[$i].assignment == "be your Head Girl")>>
 			Society accepts of $slaves[$i].slaveName trusting you, since $pronoun is your Head Girl and keeps the other slaves down.
-		<<elseif ($slaves[$i].assignment is "recruit girls")>>
+		<<elseif ($slaves[$i].assignment == "recruit girls")>>
 			Society accepts of $slaves[$i].slaveName trusting you, since $pronoun is your Recruiter and entraps new slaves.
 		<<elseif ($slaves[$i].devotion > 95)>>
 			Society reluctantly accepts of $slaves[$i].slaveName trusting you, since $pronoun worshipful of you.
@@ -3521,7 +3506,7 @@
 		<</if>>
 	<</if>>
 	<</if>>
-	<<if ($slaves[$i].assignment is "work a glory hole") || ($slaves[$i].assignment is "be confined in the arcade")>>
+	<<if ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade")>>
 	Society @@.green;approves@@ of how $pronoun is restrained for involuntary use, seeing this as the future of sexual relations.
 	<<FSChangePorn "Degradationist" 1>>
 	<</if>>
@@ -3564,7 +3549,7 @@
 		<<FSChangePorn "TransformationFetishist" 1>>
 		<<set _transformed = 1>>
 	<</if>>
-	<<if ($slaves[$i].waist < -95) || ($slaves[$i].teeth == "removable") || ($slaves[$i].teeth == "pointy") || ($slaves[$i].amp == 1)>>
+	<<if ($slaves[$i].amp == 1) || ($slaves[$i].waist < -95) || ($slaves[$i].teeth == "pointy") || ($slaves[$i].teeth == "removable")>>
 		Society @@.green;approves@@ of $possessive extreme surgeries; interest in $object stirs interest in transformations of all kinds.
 		<<FSChangePorn "TransformationFetishist" 1>>
 		<<set _transformed = 1>>
@@ -3636,7 +3621,7 @@
 	Society @@.green;approves@@ of $slaves[$i].slaveName's milky udders; the sight of $possessive creamy milk encourages the public taste for dairy straight from the nipple.
 	<<FSChangePorn "Pastoralist" 1>>
 	<</if>>
-	<<if ($slaves[$i].assignment is "get milked") && ($slaves[$i].balls > 0)>>
+	<<if ($slaves[$i].assignment == "get milked") && ($slaves[$i].balls > 0)>>
 	Society @@.green;approves@@ of how $slaves[$i].slaveName gets cockmilked; the sight of $possessive product encourages experimentation with cum-based concoctions.
 	<<FSChangePorn "Pastoralist" 1>>
 	<</if>>
@@ -3662,14 +3647,14 @@
 <</if>>
 
 <<if $arcologies[0].FSChattelReligionist != "unset">>
-	<<if ($slaves[$i].collar is "tight steel") || ($slaves[$i].collar is "uncomfortable leather") || ($slaves[$i].collar is "cruel retirement counter")>>
+	<<if ($slaves[$i].collar == "tight steel") || ($slaves[$i].collar == "uncomfortable leather") || ($slaves[$i].collar == "cruel retirement counter")>>
 	Society @@.green;approves@@ of $slaves[$i].slaveName's collar as an expression of the old ideal of mortification of the flesh, advancing the combination of religious originalism and modern slavery.
 	<<FSChangePorn "ChattelReligionist" 1>>
 	<</if>>
-	<<if ($slaves[$i].clothes is "a chattel habit") || ($slaves[$i].clothes is "a fallen nuns habit") || ($slaves[$i].clothes is "a penitent nuns habit") || ($slaves[$i].clothes is "a hijab and abaya") || ($slaves[$i].clothes is "a succubus outfit")>>
+	<<if ($slaves[$i].clothes == "a chattel habit") || ($slaves[$i].clothes == "a fallen nuns habit") || ($slaves[$i].clothes == "a penitent nuns habit") || ($slaves[$i].clothes == "a hijab and abaya") || ($slaves[$i].clothes == "a succubus outfit")>>
 		Society @@.green;approves@@ of $possessive religiously themed clothing, strengthening the connection between sexual servitude and faith.
 		<<FSChangePorn "ChattelReligionist" 1>>
-	<<elseif ($slaves[$i].clothes is "uncomfortable straps") or ($slaves[$i].clothes is "shibari ropes") or ($slaves[$i].clothes is "a nice maid outfit") or ($slaves[$i].clothes is "nice business attire") or ($slaves[$i].clothes is "a nice nurse outfit") or ($slaves[$i].clothes is "a kimono") or ($slaves[$i].clothes is "conservative clothing") or ($slaves[$i].clothes is "a military uniform") or ($slaves[$i].clothes is "no clothing")>>
+	<<elseif ($slaves[$i].clothes == "uncomfortable straps") or ($slaves[$i].clothes == "shibari ropes") or ($slaves[$i].clothes == "a nice maid outfit") or ($slaves[$i].clothes == "nice business attire") or ($slaves[$i].clothes == "a nice nurse outfit") or ($slaves[$i].clothes == "a kimono") or ($slaves[$i].clothes == "conservative clothing") or ($slaves[$i].clothes == "a military uniform") or ($slaves[$i].clothes == "no clothing")>>
 		Society accepts $possessive spartan clothing, seeing it as permissible under the new religious mores.
 	<<elseif ($slaves[$i].fuckdoll == 0)>>
 		Society @@.red;disapproves@@ of $possessive unnecessarily gaudy attire; this slows acceptance of a link between faith and sexual servitude.
@@ -3683,9 +3668,9 @@
 	Society @@.green;strongly approves@@ of $possessive faith in you as a companion to faith in God, seeing both as the model for righteous slaves of the future.
 	<<FSChangePorn "ChattelReligionist" 2>>
 	<</if>>
-	<<if ($slaves[$i].behavioralFlaw is "devout")>>
+	<<if ($slaves[$i].behavioralFlaw == "devout")>>
 	Society does not disapprove of $possessive devout adherence to an old world faith, having confidence that you'll bring $object around, and looking forward to seeing $object converted into a holy sex object.
-	<<elseif ($slaves[$i].behavioralQuirk is "sinful")>>
+	<<elseif ($slaves[$i].behavioralQuirk == "sinful")>>
 	Society @@.green;strongly approves@@ of $possessive eagerness to transgress against the old world religious mores $pronoun once held dear.
 	<<FSChangePorn "ChattelReligionist" 2>>
 	<</if>>
@@ -3695,15 +3680,15 @@
 
 <<if $slaves[$i].fuckdoll == 0>>
 <<if $slaves[$i].fetish != "mindbroken">>
-<<if typeof $slaves[$i].origin is "string">>
+<<if typeof $slaves[$i].origin == "string">>
 <<set $toSearch to $slaves[$i].origin>>
 <<if $toSearch.indexOf("Slave Shelter") != -1>>
-	<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club")>>
+	<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club")>>
 	<<if ($slaves[$i].health > -20) && ($slaves[$i].trust > 20) && ($slaves[$i].health > 40)>>
 	<<if $arcologies[0].FSPaternalist != "unset">>
 		Society @@.green;strongly approves@@ of how you've brought a shelter girl health and happiness.
 		<<FSChangePorn "Paternalist" 2>>
-	<<elseif $arcologies[0].FSDegradationist is "unset">>
+	<<elseif $arcologies[0].FSDegradationist == "unset">>
 		The public knows she's a shelter girl you took in, and is @@.green;touched@@ that she now seems happy and healthy.
 		<<set $repGain += 10>>
 	<</if>>
@@ -3718,14 +3703,14 @@
 
 <<if $slaves[$i].fuckdoll == 0>>
 <<if ($slaves[$i].brand != 0)>>
-	<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club")>>
+	<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club")>>
 		Since she is in public, your brand against the $slaves[$i].skin skin of her $slaves[$i].brandLocation @@.green;slightly increases your reputation@@ as a slaveowner.
 		<<set $repGain += 5>>
 	<</if>>
 	<<if $rep > 10000>>
-	The brand is considered a minor enhancement to her beauty since you are very well known.
+	The brand is considered a minor enhancement to her beauty since you are very well liked.
 	<<elseif $rep < 5000>>
-	The brand is considered a minor blemish on her beauty since you are not well known.
+	The brand is considered a minor blemish on her beauty since you are not well liked.
 	<</if>>
 <</if>>
 <</if>>
@@ -3740,7 +3725,7 @@
 	<<elseif $slaves[$i].devotion > 20>>
 		Since she's blind and on the cusp of devotion, she becomes slightly @@.hotpink;more reliant@@, but also begins to be @@.mediumaquamarine;less fearful@@ of what she can't see.
 		<<set $slaves[$i].devotion += 3,$slaves[$i].trust += 1>>
-	<<elseif $slaves[$i].assignment is "please you">>
+	<<elseif $slaves[$i].assignment == "please you">>
 		She may be blind, but she knows nobody would dare harm her under your watch, @@.mediumaquamarine;building her trust@@ in you.
 		<<set $slaves[$i].trust += 2>>
 	<<elseif $slaves[$i].devotion > -20>>
@@ -3756,7 +3741,7 @@
 	<<elseif $slaves[$i].devotion > 20>>
 		Since she's on the cusp of devotion, her blurred vision makes her @@.hotpink;slightly more submissive,@@ since she can't always see what's happening to her.
 		<<set $slaves[$i].devotion += 1>>
-	<<elseif ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment != "serve in the club") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel")>>
+	<<elseif ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment != "serve in the club") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel")>>
 		Her blurred vision @@.hotpink;reduces her distaste for her life slightly,@@ since her fuzzy vision allows her to ignore the details of everyone she's expected to fuck.
 		<<set $slaves[$i].devotion += 1>>
 	<<else>>
@@ -3765,13 +3750,13 @@
 	<</if>>
 	<</if>>
 <<elseif $slaves[$i].eyes is -2>>
-	<<if ($slaves[$i].eyewear is "blurring glasses") || ($slaves[$i].eyewear is "blurring contacts")>>
+	<<if ($slaves[$i].eyewear == "blurring glasses") || ($slaves[$i].eyewear == "blurring contacts")>>
 	<<if $slaves[$i].devotion > 50>>
 		She tolerates the annoyance of blurred vision induced by her eyewear.
 	<<elseif $slaves[$i].devotion > 20>>
 		Since she's on the cusp of devotion, the blurred vision induced by her eyewear actually makes her @@.hotpink;slightly more submissive.@@
 		<<set $slaves[$i].devotion += 1>>
-	<<elseif ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment != "serve in the club") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel")>>
+	<<elseif ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment != "serve in the club") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel")>>
 		The blurred vision induced by her eyewear actually @@.hotpink;reduces her distaste for her life slightly,@@ since her fuzzy vision allows her to ignore the details of everyone she's expected to fuck.
 		<<set $slaves[$i].devotion += 1>>
 	<<else>>
@@ -3784,7 +3769,7 @@
 <</if>>
 <</if>>
 
-<<if $slaves[$i].teeth is "straightening braces">>
+<<if $slaves[$i].teeth == "straightening braces">>
 	<<if $slaves[$i].fuckdoll == 0>>
 	<<if $slaves[$i].fetish != "mindbroken">>
 		<<if $slaves[$i].devotion <= 20>>
@@ -3802,7 +3787,7 @@
 	<</if>>
 	<<if random(1,10) == 1>>
 	Her braces @@.lime;straighten her teeth.@@ They can now be removed to leave her with a beautiful smile, or left on.
-	<<set $slaves[$i].teeth to "cosmetic braces">>
+	<<set $slaves[$i].teeth = "cosmetic braces">>
 	<</if>>
 <</if>>
 
@@ -4047,7 +4032,7 @@
 <<elseif ($slaves[$i].energy > 95)>>
 <<elseif ($slaves[$i].energy <= 5)>>
 <<elseif ($slaves[$i].devotion > 20)>>
-	<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club") || ($slaves[$i].assignment is "work a glory hole") || ($slaves[$i].assignment is "be confined in the arcade") || ($slaves[$i].assignment is "please you") || ($slaves[$i].assignment is "serve in the master suite") || ($slaves[$i].assignment is "be a subordinate slave")>>
+	<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club") || ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade") || ($slaves[$i].assignment == "please you") || ($slaves[$i].assignment == "serve in the master suite") || ($slaves[$i].assignment == "be a subordinate slave")>>
 		Her assignment constantly requires her to fuck. She obeys, but @@.red;her appetite for sex is reduced.@@
 		<<set $slaves[$i].energy -= 2>>
 	<<else>>
@@ -4055,7 +4040,7 @@
 		<<set $slaves[$i].energy -= 1>>
 	<</if>>
 <<elseif ($slaves[$i].devotion >= -20)>>
-	<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club") || ($slaves[$i].assignment is "work a glory hole") || ($slaves[$i].assignment is "be confined in the arcade") || ($slaves[$i].assignment is "please you") || ($slaves[$i].assignment is "serve in the master suite") || ($slaves[$i].assignment is "be a subordinate slave")>>
+	<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club") || ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade") || ($slaves[$i].assignment == "please you") || ($slaves[$i].assignment == "serve in the master suite") || ($slaves[$i].assignment == "be a subordinate slave")>>
 		Her assignment forces her to let herself get fucked constantly, @@.red;reducing her appetite for sex.@@
 		<<set $slaves[$i].energy -= 3>>
 	<<else>>
@@ -4063,7 +4048,7 @@
 		<<set $slaves[$i].energy -= 2>>
 	<</if>>
 <<else>>
-	<<if ($slaves[$i].assignment is "serve the public") || ($slaves[$i].assignment is "whore") || ($slaves[$i].assignment is "work in the brothel") || ($slaves[$i].assignment is "serve in the club") || ($slaves[$i].assignment is "work a glory hole") || ($slaves[$i].assignment is "be confined in the arcade") || ($slaves[$i].assignment is "please you") || ($slaves[$i].assignment is "serve in the master suite") || ($slaves[$i].assignment is "be a subordinate slave")>>
+	<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club") || ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade") || ($slaves[$i].assignment == "please you") || ($slaves[$i].assignment == "serve in the master suite") || ($slaves[$i].assignment == "be a subordinate slave")>>
 		Her assignment subjects her to constant rape, @@.red;rapidly reducing her appetite for sex.@@
 		<<set $slaves[$i].energy -= 5>>
 	<<else>>
@@ -4154,10 +4139,10 @@
 		<<if ($slaves[$i].drugs != "breast injections")>>
 		<<if ($slaves[$i].boobs > 10000+($slaves[$i].muscles*100))>>
 			Her breasts are larger than her body can possibly sustain without industrial intervention, and they @@.orange;naturally lose mass.@@
-			<<set $slaves[$i].boobs to Math.clamp($slaves[$i].boobs-25, 10000+($slaves[$i].muscles*100), 25000)>>
+			<<set $slaves[$i].boobs = Math.clamp($slaves[$i].boobs-25, 10000+($slaves[$i].muscles*100), 25000)>>
 		<<else>>
 			Her breasts are far, far beyond what her body can sustain without industrial intervention, and they @@.orange;naturally lose mass.@@
-			<<set $slaves[$i].boobs to Math.clamp($slaves[$i].boobs-50, 10000+($slaves[$i].muscles*100), 25000)>>
+			<<set $slaves[$i].boobs = Math.clamp($slaves[$i].boobs-50, 10000+($slaves[$i].muscles*100), 25000)>>
 		<</if>>
 		<</if>>
 		<</if>>
@@ -4234,10 +4219,10 @@
 	<<if $slaves[$i].age < random(10,200)>>
 	<<if $slaves[$i].boobShape == "perky">>
 		$possessiveCap @@.orange;breasts lose their perkiness@@ under their own titanic weight. Their nipples now point forward and $possessive boobs rest more heavily against the chest beneath them.
-		<<set $slaves[$i].boobShape to "torpedo-shaped">>
+		<<set $slaves[$i].boobShape = "torpedo-shaped">>
 	<<elseif $slaves[$i].boobShape != "saggy">>
 		$possessiveCap @@.orange;breasts become saggy@@ under their own titanic weight. Their nipples now point downward and $possessive bosom sways pendulously with $possessive every movement.
-		<<set $slaves[$i].boobShape to "saggy">>
+		<<set $slaves[$i].boobShape = "saggy">>
 	<</if>>
 	<</if>>
 <</if>>
@@ -4283,39 +4268,46 @@
 
 /* LANGUAGE */
 
-<<if $slaves[$i].fetish != "mindbroken">>
-<<if canTalk($slaves[$i])>>
-<<if $slaves[$i].accent > 0>>
-<<if $slaves[$i].speechRules is "restrictive">>
-	<<set $seed to 30>>
-<<elseif $slaves[$i].speechRules is "accent elimination">>
-	<<set $seed to 15>>
-<<else>>
-	<<set $seed to 20>>
-<</if>>
-<<if $slaves[$i].accent >= 3>>
-	<<if $week - $slaves[$i].weekAcquired > $seed - ($slaves[$i].intelligence*5)>>
-		<<set $slaves[$i].accent -= 1>>
-		She has managed to pick up enough $language that @@.green;she's now reasonably fluent in the language.@@ Her accent is quite heavy, but she can make herself understood.
+<<if ($slaves[$i].accent > 0) && ($slaves[$i].fetish != "mindbroken")>>
+	<<if $slaves[$i].speechRules == "restrictive">>
+		<<set _minweeks = 30 - ($slaves[$i].intelligence * 5)>>
+	<<elseif $slaves[$i].speechRules == "accent elimination">>
+		<<set _minweeks = 15 - ($slaves[$i].intelligence * 5)>>
+	<<else>>
+		<<set _minweeks = 20 - ($slaves[$i].intelligence * 5)>>
 	<</if>>
-<<elseif $slaves[$i].accent >= 2>>
-	<<if $week - $slaves[$i].weekAcquired > $seed - ($slaves[$i].intelligence*5) + 5>>
-		<<set $slaves[$i].accent -= 1>>
-		She has heard and spoken a great deal of $language as your slave. @@.green;Her accent has diminished from heavy to a pleasant exoticism.@@
+	<<if $slaves[$i].voice == 0 || $slaves[$i].lips > 95>> /* can't speak, but slowly picks up language */
+		<<set _minweeks += 30>>
+	<<elseif SlaveStatsChecker.checkForLisp($slaves[$i])>> /* moderate speech impediment */
+		<<set _minweeks += 15>>
 	<</if>>
-<<elseif $slaves[$i].accent >= 1>>
-	<<if $slaves[$i].speechRules is "accent elimination">>
-	<<if $week - $slaves[$i].weekAcquired > $seed - ($slaves[$i].intelligence*5) + 10>>
-		<<set $slaves[$i].accent -= 1>>
-		She does her best to speak proper, unaccented $language, as encouraged by the rules. @@.green;Her accent has diminished to imperceptibility.@@
+	<<if ($slaves[$i].accent >= 3)>>
+		<<if ($week - $slaves[$i].weekAcquired) > _minweeks>>
+			<<set $slaves[$i].accent -= 1>>
+			<<if $slaves[$i].voice == 0 || $slaves[$i].lips > 95>>
+				She has managed to pick up enough $language that @@.green;she's now able to understand most of what she hears.@@
+			<<else>>
+				She has managed to pick up enough $language that @@.green;she's now reasonably fluent in the language.@@ Her accent is quite heavy, but she can make herself understood.
+			<</if>>
+		<</if>>
+	<<elseif canTalk($slaves[$i])>>
+		<<if ($slaves[$i].accent == 2)>>
+			<<if ($week - $slaves[$i].weekAcquired) > (5 + _minweeks)>>
+				<<set $slaves[$i].accent -= 1>>
+				She has heard and spoken a great deal of $language as your slave. @@.green;Her accent has diminished to a pleasant exoticism.@@
+			<</if>>
+		<<elseif ($slaves[$i].accent == 1) && ($slaves[$i].speechRules == "accent elimination")>>
+			<<if ($week - $slaves[$i].weekAcquired) > (10 + _minweeks)>>
+		
+				<<set $slaves[$i].accent -= 1>>
+				She does her best to speak proper, unaccented $language, as encouraged by the rules. @@.green;Her accent has diminished to imperceptibility.@@
+			<</if>>
+		<</if>>
 	<</if>>
-	<</if>>
-<</if>>
-<</if>>
-<</if>>
 <</if>>
 
 /* PRESTIGE */
+
 <<if ($slaves[$i].prestige > 0)>>
 	Merely owning such a prestigious slave @@.green;helps your reputation.@@
 	<<set $repGain += (10*$slaves[$i].prestige)>>
@@ -4336,51 +4328,55 @@
 		<<set $slaves[$i].prestige to 3>>
 		@@.green;$pronounCap has become world famous for $possessive career in slave pornography!@@ Millions are now intimately familiar with
 		<<if $slaves[$i].fuckdoll > 0>>
-			<<set $slaves[$i].prestigeDesc to "It is world famous for its career in slave pornography. Millions are intimately familiar with the sight of it being used.">>
+			<<set $slaves[$i].prestigeDesc = "It is world famous for its career in slave pornography. Millions are intimately familiar with the sight of it being used.">>
 			the sight of it being used,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing it offering itself">>
 		<<elseif ($slaves[$i].devotion <= 20) && ($slaves[$i].analCount + $slaves[$i].vaginalCount > 0)>>
-			<<set $slaves[$i].prestigeDesc to "She is world famous for her career in slave pornography. Millions are intimately familiar with the sight of her being raped.">>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with the sight of her being raped.">>
 			the sight of her being raped,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her crying">>
-		<<elseif ($slaves[$i].sexualQuirk is "gagfuck queen")>>
-			<<set $slaves[$i].prestigeDesc to "She is world famous for her career in slave pornography. Millions are intimately familiar with the sounds she makes when being throatfucked.">>
+		<<elseif ($slaves[$i].sexualQuirk == "gagfuck queen")>>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with the sounds she makes when being throatfucked.">>
 			the sounds she makes when being throatfucked,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her getting facefucked">>
-		<<elseif ($slaves[$i].sexualQuirk is "painal queen") && ($slaves[$i].voice > 0)>>
-			<<set $slaves[$i].prestigeDesc to "She is world famous for her career in slave pornography. Millions are intimately familiar with her screams of anal pain.">>
+		<<elseif ($slaves[$i].sexualQuirk == "painal queen") && ($slaves[$i].voice > 0)>>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with her screams of anal pain.">>
 			her screams of anal pain,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her taking a brutal assfuck">>
-		<<elseif ($slaves[$i].sexualQuirk is "strugglefuck queen")>>
-			<<set $slaves[$i].prestigeDesc to "She is world famous for her career in slave pornography. Millions are intimately familiar with the sight of her being gagfucked.">>
+		<<elseif ($slaves[$i].sexualQuirk == "strugglefuck queen")>>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with the sight of her being gagfucked.">>
 			how she struggles when taking a fuck,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her screaming and struggling">>
-		<<elseif ($slaves[$i].sexualQuirk is "tease")>>
-			<<set $slaves[$i].prestigeDesc to "She is world famous for her career in slave pornography. Millions are intimately familiar with her lewd striptease.">>
+		<<elseif ($slaves[$i].sexualQuirk == "tease")>>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with her lewd striptease.">>
 			her lewd striptease,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her stripping">>
-		<<elseif ($slaves[$i].sexualQuirk is "romantic")>>
-			<<set $slaves[$i].prestigeDesc to "She is world famous for her career in slave pornography. Millions are intimately familiar with her authentic pleasure.">>
+		<<elseif ($slaves[$i].sexualQuirk == "romantic")>>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with her authentic pleasure.">>
 			her authentic pleasure,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her in ecstasy">>
-		<<elseif ($slaves[$i].sexualQuirk is "perverted")>>
-			<<set $slaves[$i].prestigeDesc to "She is world famous for her career in slave pornography. Millions are intimately familiar with her most perverted tendencies.">>
+		<<elseif ($slaves[$i].sexualQuirk == "perverted")>>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with her most perverted tendencies.">>
 			her most perverted tendencies,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her doing something perverted">>
-		<<elseif ($slaves[$i].sexualQuirk is "caring")>>
-			<<set $slaves[$i].prestigeDesc to "She is world famous for her career in slave pornography. Millions are intimately familiar with her devotion to her partners' pleasure.">>
+		<<elseif ($slaves[$i].sexualQuirk == "caring")>>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with her devotion to her partners' pleasure.">>
 			her devotion to her partners' pleasure,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her smiling genuinely">>
-		<<elseif ($slaves[$i].sexualQuirk is "unflinching")>>
-			<<set $slaves[$i].prestigeDesc to "She is world famous for her career in slave pornography. Millions are intimately familiar with her willingness to do things not repeated in polite company.">>
+		<<elseif ($slaves[$i].sexualQuirk == "unflinching")>>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with her willingness to do things not repeated in polite company.">>
 			her willingness to do things not repeated in polite company,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her doing something extreme">>
-		<<elseif ($slaves[$i].sexualQuirk is "size queen")>>
-			<<set $slaves[$i].prestigeDesc to "She is world famous for her career in slave pornography. Millions are intimately familiar with the sight of her holes stretched to their limits.">>
+		<<elseif ($slaves[$i].sexualQuirk == "size queen")>>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with the sight of her holes stretched to their limits.">>
 			the sight of her holes stretched to their limits,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her stuffed to her limit">>
+		<<elseif $slaves[$i].preg > 10>>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with growth of her belly and her pregnant pussy.">>
+			the sight of her rounded belly and pregnant pussy,
+			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her pregnant pussy getting pounded">>
 		<<else>>
-			<<set $slaves[$i].prestigeDesc to "She is world famous for her career in slave pornography. Millions are intimately familiar with the sight of her being fucked.">>
+			<<set $slaves[$i].prestigeDesc = "She is world famous for her career in slave pornography. Millions are intimately familiar with the sight of her being fucked.">>
 			the sight of her being fucked,
 			<<set $desc = "a framed shot from porn starring " + $slaves[$i].slaveName + " showing her getting fucked">>
 		<</if>>
@@ -4390,40 +4386,43 @@
 	<<set $slaves[$i].prestige to 2>>
 	@@.green;$pronounCap has become famous for $possessive recurring role in slave pornography!@@ Her many fans relish
 	<<if $slaves[$i].fuckdoll > 0>>
-		<<set $slaves[$i].prestigeDesc to "It is famous for her recurring role in slave pornography. Its many fans relish the sight of it being used.">>
+		<<set $slaves[$i].prestigeDesc = "It is famous for her recurring role in slave pornography. Its many fans relish the sight of it being used.">>
 		the sight of it being used,
 	<<elseif ($slaves[$i].devotion <= 20) && ($slaves[$i].analCount + $slaves[$i].vaginalCount > 0)>>
-		<<set $slaves[$i].prestigeDesc to "She is famous for her recurring role in slave pornography. Her many fans relish the sight of her being raped.">>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish the sight of her being raped.">>
 		the sight of her being raped,
-	<<elseif ($slaves[$i].sexualQuirk is "gagfuck queen")>>
-		<<set $slaves[$i].prestigeDesc to "She is famous for her recurring role in slave pornography. Her many fans relish the sounds she makes when being throatfucked.">>
+	<<elseif ($slaves[$i].sexualQuirk == "gagfuck queen")>>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish the sounds she makes when being throatfucked.">>
 		the sounds she makes when being throatfucked,
-	<<elseif ($slaves[$i].sexualQuirk is "painal queen") && ($slaves[$i].voice > 0)>>
-		<<set $slaves[$i].prestigeDesc to "She is famous for her recurring role in slave pornography. Her many fans relish her screams of anal pain.">>
+	<<elseif ($slaves[$i].sexualQuirk == "painal queen") && ($slaves[$i].voice > 0)>>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish her screams of anal pain.">>
 		her screams of anal pain,
-	<<elseif ($slaves[$i].sexualQuirk is "strugglefuck queen")>>
-		<<set $slaves[$i].prestigeDesc to "She is famous for her recurring role in slave pornography. Her many fans relish the sight of her being gagfucked.">>
+	<<elseif ($slaves[$i].sexualQuirk == "strugglefuck queen")>>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish the sight of her being gagfucked.">>
 		how she struggles when taking a fuck,
-	<<elseif ($slaves[$i].sexualQuirk is "tease")>>
-		<<set $slaves[$i].prestigeDesc to "She is famous for her recurring role in slave pornography. Her many fans relish her lewd striptease.">>
+	<<elseif ($slaves[$i].sexualQuirk == "tease")>>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish her lewd striptease.">>
 		her lewd striptease,
-	<<elseif ($slaves[$i].sexualQuirk is "romantic")>>
-		<<set $slaves[$i].prestigeDesc to "She is famous for her recurring role in slave pornography. Her many fans relish her authentic pleasure.">>
+	<<elseif ($slaves[$i].sexualQuirk == "romantic")>>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish her authentic pleasure.">>
 		her authentic pleasure,
-	<<elseif ($slaves[$i].sexualQuirk is "perverted")>>
-		<<set $slaves[$i].prestigeDesc to "She is famous for her recurring role in slave pornography. Her many fans relish her most perverted tendencies.">>
+	<<elseif ($slaves[$i].sexualQuirk == "perverted")>>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish her most perverted tendencies.">>
 		her most perverted tendencies,
-	<<elseif ($slaves[$i].sexualQuirk is "caring")>>
-		<<set $slaves[$i].prestigeDesc to "She is famous for her recurring role in slave pornography. Her many fans relish her devotion to her partners' pleasure.">>
+	<<elseif ($slaves[$i].sexualQuirk == "caring")>>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish her devotion to her partners' pleasure.">>
 		her devotion to her partners' pleasure,
-	<<elseif ($slaves[$i].sexualQuirk is "unflinching")>>
-		<<set $slaves[$i].prestigeDesc to "She is famous for her recurring in slave pornography. Her many fans relish her willingness to do things not repeated in polite company.">>
+	<<elseif ($slaves[$i].sexualQuirk == "unflinching")>>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring in slave pornography. Her many fans relish her willingness to do things not repeated in polite company.">>
 		her willingness to do things not repeated in polite company,
-	<<elseif ($slaves[$i].sexualQuirk is "size queen")>>
-		<<set $slaves[$i].prestigeDesc to "She is famous for her recurring in slave pornography. Her many fans relish the sight of her holes stretched to their limits.">>
+	<<elseif ($slaves[$i].sexualQuirk == "size queen")>>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring in slave pornography. Her many fans relish the sight of her holes stretched to their limits.">>
 		the sight of her holes stretched to their limits,
+	<<elseif $slaves[$i].preg > 10>>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish her rounded belly and pregnant pussy.">>
+		the sight of her rounded belly and pregnant pussy,
 	<<else>>
-		<<set $slaves[$i].prestigeDesc to "She is famous for her recurring role in slave pornography. Her many fans relish the sight of her being fucked.">>
+		<<set $slaves[$i].prestigeDesc = "She is famous for her recurring role in slave pornography. Her many fans relish the sight of her being fucked.">>
 		the sight of her being fucked,
 	<</if>>
 	so it is now very prestigious to own $object.
@@ -4431,40 +4430,43 @@
 	<<set $slaves[$i].prestige to 1>>
 	@@.green;$pronounCap has become well known from slave pornography!@@ Thousands have enjoyed
 	<<if $slaves[$i].fuckdoll > 0>>
-		<<set $slaves[$i].prestigeDesc to "It is well known from slave pornography. Its many fans relish the sight of it being used.">>
+		<<set $slaves[$i].prestigeDesc = "It is well known from slave pornography. Its many fans relish the sight of it being used.">>
 		the sight of it being used,
 	<<elseif ($slaves[$i].devotion <= 20) && ($slaves[$i].analCount + $slaves[$i].vaginalCount > 0)>>
-		<<set $slaves[$i].prestigeDesc to "She is well known from slave pornography. Thousands have enjoyed the sight of her being raped.">>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed the sight of her being raped.">>
 		the sight of her being raped,
-	<<elseif ($slaves[$i].sexualQuirk is "gagfuck queen")>>
-		<<set $slaves[$i].prestigeDesc to "She is well known from slave pornography. Thousands have enjoyed the sounds she makes when being throatfucked.">>
+	<<elseif ($slaves[$i].sexualQuirk == "gagfuck queen")>>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed the sounds she makes when being throatfucked.">>
 		the sounds she makes when being throatfucked,
-	<<elseif ($slaves[$i].sexualQuirk is "painal queen") && ($slaves[$i].voice > 0)>>
-		<<set $slaves[$i].prestigeDesc to "She is well known from slave pornography. Thousands have enjoyed her screams of anal pain.">>
+	<<elseif ($slaves[$i].sexualQuirk == "painal queen") && ($slaves[$i].voice > 0)>>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed her screams of anal pain.">>
 		her screams of anal pain,
-	<<elseif ($slaves[$i].sexualQuirk is "strugglefuck queen")>>
-		<<set $slaves[$i].prestigeDesc to "She is well known from slave pornography. Thousands have enjoyed the sight of her being gagfucked.">>
+	<<elseif ($slaves[$i].sexualQuirk == "strugglefuck queen")>>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed the sight of her being gagfucked.">>
 		how she struggles when taking a fuck,
-	<<elseif ($slaves[$i].sexualQuirk is "tease")>>
-		<<set $slaves[$i].prestigeDesc to "She is well known from slave pornography. Thousands have enjoyed her lewd striptease.">>
+	<<elseif ($slaves[$i].sexualQuirk == "tease")>>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed her lewd striptease.">>
 		her lewd striptease,
-	<<elseif ($slaves[$i].sexualQuirk is "romantic")>>
-		<<set $slaves[$i].prestigeDesc to "She is well known from slave pornography. Thousands have enjoyed her authentic pleasure.">>
+	<<elseif ($slaves[$i].sexualQuirk == "romantic")>>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed her authentic pleasure.">>
 		her authentic pleasure,
-	<<elseif ($slaves[$i].sexualQuirk is "perverted")>>
-		<<set $slaves[$i].prestigeDesc to "She is well known from slave pornography. Thousands have enjoyed her most perverted tendencies.">>
+	<<elseif ($slaves[$i].sexualQuirk == "perverted")>>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed her most perverted tendencies.">>
 		her most perverted tendencies,
-	<<elseif ($slaves[$i].sexualQuirk is "caring")>>
-		<<set $slaves[$i].prestigeDesc to "She is well known from slave pornography. Thousands have enjoyed her devotion to her partners' pleasure.">>
+	<<elseif ($slaves[$i].sexualQuirk == "caring")>>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed her devotion to her partners' pleasure.">>
 		her devotion to her partners' pleasure,
-	<<elseif ($slaves[$i].sexualQuirk is "unflinching")>>
-		<<set $slaves[$i].prestigeDesc to "She is well known from slave pornography. Thousands have enjoyed her willingness to do things not repeated in polite company.">>
+	<<elseif ($slaves[$i].sexualQuirk == "unflinching")>>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed her willingness to do things not repeated in polite company.">>
 		her willingness to do things not repeated in polite company,
-	<<elseif ($slaves[$i].sexualQuirk is "size queen")>>
-		<<set $slaves[$i].prestigeDesc to "She is well known from slave pornography. Thousands have enjoyed the sight of her holes stretched to their limits.">>
+	<<elseif ($slaves[$i].sexualQuirk == "size queen")>>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed the sight of her holes stretched to their limits.">>
 		the sight of her holes stretched to their limits,
+	<<elseif $slaves[$i].preg > 10>>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed the sight of her rounded belly and pregnant pussy.">>
+		the sight of her rounded belly and pregnant pussy,
 	<<else>>
-		<<set $slaves[$i].prestigeDesc to "She is well known from slave pornography. Thousands have enjoyed the sight of her being fucked.">>
+		<<set $slaves[$i].prestigeDesc = "She is well known from slave pornography. Thousands have enjoyed the sight of her being fucked.">>
 		the sight of her being fucked,
 	<</if>>
 	so it is now prestigious to own $object.
@@ -4476,7 +4478,7 @@
 <</if>>
 <</if>>
 
-<<if $seeAge == 1>>
+<<if $seeAge != 0>>
 <<if $slaves[$i].birthWeek >= 51>>
 	$possessiveCap birthday was this week; $pronoun turned <<print $slaves[$i].age+1>>.
 	<<if $slaves[$i].fuckdoll > 0>>


### PR DESCRIPTION
replaced to with = for sets, is with == for compares
indented code for improved readability and consolidated numerous if statements

lines 2019 and 2037 - energy < 80 instead of < 100 - clitPiercing XX/XY should not raise energy to nympho as side effect
line 2288 - $slaves[$i].cockfeeder -> $cockFeeder - wrong variable
line 2412 - births > 10 instead of > 1 - due to text
line 2413 - as instead of than - due to text
lines 2693, 2695, 2706 - chance of face hardening from muscles only while diet is set to muscle building and removed 'beautiful' from text since only face > 40 qualifies
line 2732 - removed redundant && clause (<= 10 + 0 or 20 is always <= 95)

reworked PREGNANCY AND FERTILITY section starting from line 2808:

rebalanced energy changes during pregnancy - a non-pregnancy fetishist cannot become a nympho due to pregnancy alone; a fetishist can
used switch instead of if/elseif for random flaw development starting at line 2881
separated late-pregnancy sagging breasts chance from small boobs check at lines 2931 and 2935 and added minimum pre-implanted size check of 800 cc
pronounCap instead of pronoun at lines 2948 and 2950

reworked CAN GET PREGNANT section starting from line 2986:

consolidated random rolls to a single roll at the beginning of the section
folded HGCum check into HG impregnation rule block after PC impregnation rule block
removed unnecessary slave array update for HeadGirl from PC impregnation rule block
added toyHole condition for master suite / fucktoy impregnation by PC
added chance of impregnation by other slaves in master suite
used switch instead of if/elseif for random impregnation block starting at line 3099
added text and health/trust impact for bitter rival rape impregnation
corrected random father search (condition "$m is $sourceSeed" was never true)

added pregType sanity check at line 3191

used canPenetrate widget at line 3439 to simplify checks
replaced 'known' with 'liked' at lines 3713 and 3715

reworked LANGUAGE section starting from line 4271:

removed top-level canTalk check since the widget returns false for accent > 2
added adjustments to time-to-improve for speech impediments (mute / huge lips / lisp)
allowed slaves that can't speak to improve language to level 3 but no better

added pregnancy-based porn prestige descriptions for slaves without other notable quirks