### PR TITLE
Multi-Implant fix

### DIFF
--- a/src/uncategorized/multiImplant.tw
+++ b/src/uncategorized/multiImplant.tw
@@ -122,7 +122,7 @@ You head down to your <<if $surgeryUpgrade == 1>>heavily upgraded and customized
 	<</for>>
 	<<if $slaves[_i].amp != 0>>
 	<<for _l = 0; _l < $limbs.length; _l++>>
-		<<if ($limbs[_l].ID == $slaves[_i].ID) && ($organs[_o].weeksToCompletion == 0)>>
+		<<if ($limbs[_l].ID == $slaves[_i].ID) && ($limbs[_l].weeksToCompletion == 0)>>
 			<<set $activeSlave = $slaves[_i]>>
 
 			<<switch $limbs[_l].type>>


### PR DESCRIPTION
Fixes the erroneous use of organs[_o] when checking if prosthetic limbs are complete.