### PR TITLE
Initialization of rude titles for hateful slaves to refer to the player.

### DIFF
--- a/src/init/storyInit.tw
+++ b/src/init/storyInit.tw
@@ -1014,6 +1014,9 @@
 
 <<set $badWords = ["fuck", "shit", "ass", "cock", "piss", "dick", "slut", "cum", "whore", "butt", "boob", "cunt", "cunny", "pussy", "junk", "trash", "slave"]>>
 
+<<set $badNames = 0>> /* I have issues getting arrays to initialize otherwise, remove me if uneeded */
+<<set $badNames = ["Dipshit", "Asshole", "Cunt", "Whore", "Dick", "Pussy", "Slaver", "Assfucker", "Sodomite", "Rapist", "Spoiler", "Ruiner", "Ass", "Fucker", "Trash", "Traitor", "Cocksucker", "Dicksucker", "Ass Kisser", "Ass Licker", "Bitch", "Jerk", "Fuckface", "Prick", "Creep", "Retard", "Dumbass", "DumbFuck", "Douchebag"]>>
+
 <<set $modestClothes = ["conservative clothing", "a toga", "a huipil", "a slutty qipao", "restrictive latex", "cutoffs and a t-shirt", "battledress", "a penitent nuns habit", "a slave gown", "slutty business attire", "nice business attire", "a comfortable bodysuit", "a leotard", "a bunny outfit", "a nice nurse outfit", "a slutty nurse outfit", "a schoolgirl outfit", "a hijab and abaya", "a kimono", "a nice maid outfit", "a slutty maid outfit", "a ball gown", "a halter top dress", "a mini dress", "a latex catsuit", "a military uniform"]>>
 
 <<set $niceWeather = []>>

--- a/src/uncategorized/BackwardsCompatibility.tw
+++ b/src/uncategorized/BackwardsCompatibility.tw
@@ -1225,6 +1225,10 @@ Setting missing global variables:
 <<set $fakeBellies to ["a small empathy belly", "a medium empathy belly", "a large empathy belly", "a huge empathy belly"]>> /* lets fake bellies be separated from other .bellyAccessory */
 <</if>>
 
+<<if ndef $badNames>>
+	<<set $badNames = ["Dipshit", "Asshole", "Cunt", "Whore", "Dick", "Pussy", "Slaver", "Assfucker", "Sodomite", "Rapist", "Spoiler", "Ruiner", "Ass", "Fucker", "Trash", "Traitor", "Cocksucker", "Dicksucker", "Ass Kisser", "Ass Licker", "Bitch", "Jerk", "Fuckface", "Prick", "Creep", "Retard", "Dumbass", "DumbFuck", "Douchebag"]>>
+<</if>>
+
 <<if ($ver.includes("0.6") == true) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true) || ($ver == "0.9")>>
 	<<if $seeDicks == 2>>
 		<<set $seeDicks = 100>>

--- a/src/uncategorized/pRivalryVictory.tw
+++ b/src/uncategorized/pRivalryVictory.tw
@@ -1,6 +1,6 @@
 :: P rivalry victory [nobr]
 
-<<set $nextButton = "Continue", set $nextLink = "RIE Eligibility Check", $returnTo = "RIE Eligibility Check", $rivalOwner = 0, $rivalryPower = 0, _num = random(1,99)>>
+<<set $nextButton = "Continue", $nextLink = "RIE Eligibility Check", $returnTo = "RIE Eligibility Check", $rivalOwner = 0, $rivalryPower = 0, _num = random(1,99)>>
 
 For the first time, you receive a direct call from your rival. You pictured the moment as feeling grander than this, sitting at your desk as usual looking into <<if _num < $seeDicks>>his<<else>>her<</if>> downcast face. You're the victor in a new form of warfare in which bankruptcy has replaced surrender. If the world survives in its present state, you may one day be remembered as an innovator in the evolution of (nearly) bloodless war. Today, your reputation has @@.green;greatly improved.@@ But today all you have that's tangible is a view of a still-dignified arcology owner, self-possessed despite the situation.
 <br><br>

--- a/src/uncategorized/seBirth.tw
+++ b/src/uncategorized/seBirth.tw
@@ -320,7 +320,7 @@ Since $possessive vagina was spared from childbirth, @@.lime;it retained its tig
 		and a complete turn on to $object. $possessiveCap humiliation fetish @@.lightcoral;strengthens@@ as $pronoun eagerly fantasizes about giving birth in public again.
 		<<set $slaves[$i].fetishStrength += 4>>
 	<<elseif $slaves[$i].fetish == "none" || $slaves[$i].fetishStrength <= 60>>
-		and a curious experience to $object. <<if random(1,5) == 1>>@@.lightcoral;$possessiveCap has developed a humiliation fetish.@@<<set $slaves[$i].fetish = "humiliation">><<else>>$pronounCap hopes to never repeat it.<</if>>
+		and a curious experience to $object. <<if random(1,5) == 1>>@@.lightcoral;$pronounCap has developed a humiliation fetish.@@<<set $slaves[$i].fetish = "humiliation">><<else>>$pronounCap hopes to never repeat it.<</if>>
 	<<elseif $slaves[$i].devotion <= 20>>
 		and completely devastating to $possessive image of herself. The experience @@.hotpink;habituates $object@@ to cruelties of slavery.
 		<<set $slaves[$i].devotion += 5>>


### PR DESCRIPTION
Continuation of previous update (custom titles).  Hoping to get the setting slipped in before 10.3.0 proper to make it seamless.  Slaves will choose a rude title to refer to you if they are below -50 devotion after the initial block of new slave intro dev/trust checks.  Also no gags?  That may need to be corrected, make more use out of canTalk() to deal with rebellious slaves.

The list could always use more names, so feel free to add away.  Though keeping them away from the PC's sex, background and rumors would be best, due to the point of initialization needing to be changed to handle it.  Though insinuating things may be worthwhile.