### PR TITLE
Cascade purchase fix

### DIFF
--- a/src/uncategorized/slaveMarkets.tw
+++ b/src/uncategorized/slaveMarkets.tw
@@ -1,1087 +1,166 @@
 :: Slave Markets [nobr]
 
-
-
 <<set $nextButton = "Back", $nextLink = "Buy Slaves", $returnTo = "Buy Slaves", $showEncyclopedia = 1, $encyclopedia = "Kidnapped Slaves">>
-
-
-
-<<if $activeArcology != 0>>
-
-	<<set $slaveMarket = "neighbor", $direction = $activeArcology.direction, $slavesSeen += 1, $activeArcology = 0>>
-
+/* Multi-Purchase Support */
+<<if ndef $newSlaves>><<set $newSlaves = []>><</if>>
+<<if $newSlaves.length > 0>>
+	<<set $nextButton = "Continue", $nextLink = "Bulk Slave Intro", $returnTo = "Main", $newSlaveIndex = 0>>
 <</if>>
-
-
 
 You visit the slave markets off the arcology plaza. It's always preferable to examine merchandise in person.
 
-
-
 <<if $slaveMarket == "kidnappers">>
-
-
-
-You're in the area of the slave market populated by slave kidnappers, though of course they prefer more polite titles. The slaves here are cheap, and they look it. They're almost all recent catches from bad parts of the old world, and most of them have seen considerable abuse between the moment of their capture and entering your arcology.
-
-<<if $arcologies[0].FSPaternalistSMR == 1>>
-
-	Fortunately for them, such behavior is not permitted here. Though they remain frightened and angry, they are safe from rape, for now.
-
-<<else>>
-
-	<<set $seed = random(1,4)>>
-
-	There's more merchandise out of sight in the holding areas. To go by what you can hear,
-
-	<<if ($seed == 1) && (random(0,99) < $seeDicks)>>
-
-	muffled insistence that the speaker is not a girl followed by struggling and then shrieks as a resistant dickgirl takes anal rape,
-
-	<<elseif ($seed == 2) && (random(1,100) > $seeDicks)>>
-
-	muffled begging followed by struggling and then crying as a new slave learns how it feels to have a slave's cunt,
-
-	<<elseif ($seed == 3)>>
-
-	muffled gagging followed gasping and sobbing as a new slave tries to get her breath back after oral rape,
-
+	You're in the area of the slave market populated by slave kidnappers, though of course they prefer more polite titles. The slaves here are cheap, and they look it. They're almost all recent catches from bad parts of the old world, and most of them have seen considerable abuse between the moment of their capture and entering your arcology.
+	<<if $arcologies[0].FSPaternalistSMR == 1>>
+		Fortunately for them, such behavior is not permitted here. Though they remain frightened and angry, they are safe from rape, for now.
 	<<else>>
-
-	the unmistakable slap of flesh on flesh,
-
+		<<set $seed = random(1,4)>>
+		There's more merchandise out of sight in the holding areas. To go by what you can hear,
+		<<if ($seed == 1) && (random(0,99) < $seeDicks)>>
+		muffled insistence that the speaker is not a girl followed by struggling and then shrieks as a resistant dickgirl takes anal rape,
+		<<elseif ($seed == 2) && (random(1,100) > $seeDicks)>>
+		muffled begging followed by struggling and then crying as a new slave learns how it feels to have a slave's cunt,
+		<<elseif ($seed == 3)>>
+		muffled gagging followed gasping and sobbing as a new slave tries to get her breath back after oral rape,
+		<<else>>
+		the unmistakable slap of flesh on flesh,
+		<</if>>
+		at least one of the slavers is amusing himself<<if $arcologies[0].FSGenderFundamentalist == "unset">> (or herself)<</if>> back there.
 	<</if>>
-
-	at least one of the slavers is amusing himself<<if $arcologies[0].FSGenderFundamentalist == "unset">> (or herself)<</if>> back there.
-
-<</if>>
-
-
-
-<<include "Generate New Slave">>
-
-<<set $activeSlave.origin = "You bought her from the kidnappers' slave market, and was probably forced into slavery.">>
-
-<<set $activeSlave.devotion -= 5>>
-
-<<set $activeSlave.trust = random(-45,-25)>>
-
-<<set $activeSlave.intelligence = either(-2, -1, -1, 0, 0, 0, 1)>>
-
-<<set $activeSlave.health = random(-80,20)>>
-
-<<if $activeSlave.vagina > 1 && isFertile($activeSlave)>><<set $activeSlave.preg = either(-2, -1, -1, -1, -1, -1, -1, -1, 1, 20)>><</if>>
-
+	<<GenerateMarketSlave "kidnappers">>
 
 
 <<elseif $slaveMarket == "indentures">>
-
-
-
-You're in the area of the slave market that deals in indentured servants. The people sold here are slaves, but they are temporary slaves, and many of them have clauses in their indentures that prohibit some of the most severe practices. They exhibit a strange variety, with some looking more frightened than the most downtrodden slave and some looking almost cheerful.
-
-<<if $arcologies[0].FSPaternalistSMR == 1>>
-
-	The generous protections for slaves in your arcology lend this last group extra confidence.
-
-<<else>>
-
-	<<set $seed = random(1,4)>>
-
-	The area is crowded, and more indentured servants are packed together in the holding areas. To go by what you can hear,
-
-	<<if ($seed == 1) && (random(0,99) < $seeDicks)>>
-
-	the unmistakable mixed shrieks, sobs, and slaps of anal rape,
-
-	<<elseif ($seed == 2) && (random(1,100) > $seeDicks)>>
-
-	the characteristic crying and gasping of an unwilling girl giving up her cunt,
-
-	<<elseif ($seed == 3)>>
-
-	the gagging and expectoration of someone who has just gotten a mouthful of unwelcome cum,
-
+	You're in the area of the slave market that deals in indentured servants. The people sold here are slaves, but they are temporary slaves, and many of them have clauses in their indentures that prohibit some of the most severe practices. They exhibit a strange variety, with some looking more frightened than the most downtrodden slave and some looking almost cheerful.
+	<<if $arcologies[0].FSPaternalistSMR == 1>>
+		The generous protections for slaves in your arcology lend this last group extra confidence.
 	<<else>>
-
-	disconsolate sobbing interrupted by a gasp as something is stuffed inside someone's mouth, and followed by muffled screams,
-
+		<<set $seed = random(1,4)>>
+		The area is crowded, and more indentured servants are packed together in the holding areas. To go by what you can hear,
+		<<if ($seed == 1) && (random(0,99) < $seeDicks)>>
+		the unmistakable mixed shrieks, sobs, and slaps of anal rape,
+		<<elseif ($seed == 2) && (random(1,100) > $seeDicks)>>
+		the characteristic crying and gasping of an unwilling girl giving up her cunt,
+		<<elseif ($seed == 3)>>
+		the gagging and expectoration of someone who has just gotten a mouthful of unwelcome cum,
+		<<else>>
+		disconsolate sobbing interrupted by a gasp as something is stuffed inside someone's mouth, and followed by muffled screams,
+		<</if>>
+		one of them is learning exactly what her indenture allows.
 	<</if>>
-
-	one of them is learning exactly what her indenture allows.
-
-<</if>>
-
-
-
-<<include "Generate New Slave">>
-
-<<set $activeSlave.origin = "You purchased her indenture contract, making her yours for as long as it lasts.">>
-
-<<set $activeSlave.indentureRestrictions = either(0,1,1,2,2,2,2)>>
-
-<<if $activeSlave.indentureRestrictions >= 2>>
-
-	<<set $activeSlave.devotion = random(25,45)>>
-
-	<<set $activeSlave.trust = random(-20,20)>>
-
-<<elseif $activeSlave.indentureRestrictions == 1>>
-
-	<<set $activeSlave.devotion = random(-20,20)>>
-
-	<<set $activeSlave.trust = random(-45,-25)>>
-
-<<else>>
-
-	<<set $activeSlave.devotion = random(-45,-25)>>
-
-	<<set $activeSlave.trust = random(-75,-60)>>
-
-<</if>>
-
-<<set $activeSlave.indenture = either(26, 52, 104, 156, 208)>>
-
+	<<GenerateMarketSlave "indentures">>
 
 
 <<elseif $slaveMarket == "hunters">>
-
-
-
-You're in the area of the slave market populated by runaway slave catchers, a proud group. The slaves here know their way around Free Cities slavery already, and their eyes are watchful. Most of them probably harbor thoughts of another attempt at escape, though the slavers to their best to disabuse them of these notions.
-
-<<if $arcologies[0].FSPaternalistSMR == 1>>
-
-	Their methods are somewhat limited, as the rules in your arcology preclude the more effective methods of punishment.
-
-<<else>>
-
-	<<set $seed = random(1,4)>>
-
-	The slave catchers consider their catches fair game, though they usually confine their amusements to the holding areas out of sight. Not out of earshot, though; to go by what you can hear,
-
-	<<if ($seed == 1) && (random(0,99) < $seeDicks)>>
-
-	vehement insistence that the speaker is not a girl followed by a beating and then shrieks as a rebellious dickgirl takes anal rape,
-
-	<<elseif ($seed == 2) && (random(1,100) > $seeDicks)>>
-
-	vehement protestations followed by a beating and then crying as a slave's cunt takes her punishment for her,
-
-	<<elseif ($seed == 3)>>
-
-	struggling and gagging followed gasping and angry swearing as a rebellious slave tries to get her breath back after oral rape,
-
+	You're in the area of the slave market populated by runaway slave catchers, a proud group. The slaves here know their way around Free Cities slavery already, and their eyes are watchful. Most of them probably harbor thoughts of another attempt at escape, though the slavers to their best to disabuse them of these notions.
+	<<if $arcologies[0].FSPaternalistSMR == 1>>
+		Their methods are somewhat limited, as the rules in your arcology preclude the more effective methods of punishment.
 	<<else>>
-
-	struggling followed by the slap of flesh on flesh,
-
+		<<set $seed = random(1,4)>>
+		The slave catchers consider their catches fair game, though they usually confine their amusements to the holding areas out of sight. Not out of earshot, though; to go by what you can hear,
+		<<if ($seed == 1) && (random(0,99) < $seeDicks)>>
+		vehement insistence that the speaker is not a girl followed by a beating and then shrieks as a rebellious dickgirl takes anal rape,
+		<<elseif ($seed == 2) && (random(1,100) > $seeDicks)>>
+		vehement protestations followed by a beating and then crying as a slave's cunt takes her punishment for her,
+		<<elseif ($seed == 3)>>
+		struggling and gagging followed gasping and angry swearing as a rebellious slave tries to get her breath back after oral rape,
+		<<else>>
+		struggling followed by the slap of flesh on flesh,
+		<</if>>
+		at least one of the runaway hunters is amusing himself<<if $arcologies[0].FSGenderFundamentalist == "unset">> (or herself)<</if>> back there.
 	<</if>>
-
-	at least one of the runaway hunters is amusing himself<<if $arcologies[0].FSGenderFundamentalist == "unset">> (or herself)<</if>> back there.
-
-<</if>>
-
-
-
-<<include "Generate New Slave">>
-
-<<set $activeSlave.origin = "You bought her from the runaway hunters' slave market after they recaptured her and her original owner did not pay their fee.">>
-
-<<set $activeSlave.devotion = -20>>
-
-<<set $activeSlave.trust = random(-15,15)>>
-
-<<set $activeSlave.intelligence = either(0, 1, 2)>>
-
-<<set $activeSlave.intelligenceImplant = 1>>
-
-<<set $activeSlave.teeth = "normal">>
-
-<<set $activeSlave.health = random(-10,70)>>
-
-<<if $activeSlave.vagina > -1>>
-
-	<<set $activeSlave.preg = either(-2, -1, -1, -1, -1, -1, -1, -1, 1, 1)>>
-
-	<<set $activeSlave.vaginalSkill = random(15,100)>>
-
-	<<set $activeSlave.vagina = random(1,3)>>
-
-<</if>>
-
-<<if $activeSlave.balls > 0>>
-
-<<if random(1,3) == 1>>
-
-	<<set $activeSlave.balls = 0>>
-
-<</if>>
-
-<</if>>
-
-<<set $activeSlave.combatSkill = either(0, 0, 0, 0, 0, 1)>>
-
-<<set $activeSlave.entertainSkill = random(15,100)>>
-
-<<set $activeSlave.whoreSkill = random(15,100)>>
-
-<<set $activeSlave.oralSkill = random(15,100)>>
-
-<<set $activeSlave.analSkill = random(15,100)>>
-
-<<set $activeSlave.anus = random(1,3)>>
-
-<<set $activeSlave.weight = Math.clamp(-25, 25, $activeSlave.weight)>>
-
-<<set $activeSlave.behavioralFlaw = either("arrogant", "bitchy", "odd", "hates men", "hates women", "hates women", "anorexic", "gluttonous", "devout", "liberated")>>
-
-<<set $activeSlave.sexualFlaw = either("hates oral", "hates anal", "hates penetration", "repressed", "idealistic", "shamefast", "apathetic", "crude", "judgemental")>>
-
-<<if random(1,2) == 1>>
-
-	<<set $seed = random(2,8)*200>>
-
-	<<set $activeSlave.boobs += $seed>>
-
-	<<set $activeSlave.boobsImplant += $seed>>
-
-	<<set $seed = random(1,3)>>
-
-	<<set $activeSlave.butt += $seed>>
-
-	<<set $activeSlave.buttImplant += $seed>>
-
-	<<set $seed = either(10,20)>>
-
-	<<set $activeSlave.lips += $seed>>
-
-	<<set $activeSlave.lipsImplant += $seed>>
-
-	<<set $activeSlave.waist = Math.trunc($activeSlave.waist,-100,15)>>
-
-	<<if $activeSlave.face < 40>>
-
-	<<set $activeSlave.faceImplant = random(0,1)>>
-
-	<<set $activeSlave.face = Math.clamp($activeSlave.face+(20*$activeSlave.faceImplant),-100,100)>>
-
-	<</if>>
-
-	<<if $activeSlave.age >= 30>>
-
-	<<set $activeSlave.ageImplant += random(0,1)>>
-
-	<</if>>
-
-<</if>>
-
-<<if $arcologies[0].FSPaternalistSMR == 0>>
-
-	<<set $activeSlave.heels = 1>>
-
-<</if>>
-
+	<<GenerateMarketSlave "hunters">>
 
 
 <<elseif $slaveMarket == "raiders">>
-
-
-
-You're in the area of the slave market populated by girl raiders, that daredevil subset of slave kidnappers that specifically target old world schools, preparatory institutions, religious groups, and other sources of slaves that can soon be sold right after they reach their majorities. The extreme risk of these raids makes the slavers here aggressive and confident,
-
-<<if $arcologies[0].FSPaternalistSMR == 1>>
-
-	though they do obey the rules of your arcology that restrain them from abusing the girls.
-
-<<else>>
-
-	<<set $seed = random(1,4)>>
-
-	though they restrain themselves from reducing the value of their captures by taking virginities. They do have their fun, though; to go by what you can hear from the holding area where they keep slaves of age who can be sold,
-
-	<<if ($seed == 1) && (random(0,99) < $seeDicks)>>
-
-	a muffled but obviously sadistic description of feminization, and the desperate sobbing in response,
-
-	<<elseif ($seed == 2) && (random(1,100) > $seeDicks)>>
-
-	a muffled but obviously sadistic description of breeding, and the desperate sobbing in response,
-
-	<<elseif ($seed == 3)>>
-
-	faint struggling and crying that suggests that someone is being thoroughly groped and pinched,
-
+	You're in the area of the slave market populated by girl raiders, that daredevil subset of slave kidnappers that specifically target old world schools, preparatory institutions, religious groups, and other sources of slaves that can soon be sold right after they reach their majorities. The extreme risk of these raids makes the slavers here aggressive and confident,
+	<<if $arcologies[0].FSPaternalistSMR == 1>>
+		though they do obey the rules of your arcology that restrain them from abusing the girls.
 	<<else>>
-
-	the lewd, lubricated noise of someone giving a reluctant handjob,
-
+		<<set $seed = random(1,4)>>
+		though they restrain themselves from reducing the value of their captures by taking virginities. They do have their fun, though; to go by what you can hear from the holding area where they keep slaves of age who can be sold,
+		<<if ($seed == 1) && (random(0,99) < $seeDicks)>>
+		a muffled but obviously sadistic description of feminization, and the desperate sobbing in response,
+		<<elseif ($seed == 2) && (random(1,100) > $seeDicks)>>
+		a muffled but obviously sadistic description of breeding, and the desperate sobbing in response,
+		<<elseif ($seed == 3)>>
+		faint struggling and crying that suggests that someone is being thoroughly groped and pinched,
+		<<else>>
+		the lewd, lubricated noise of someone giving a reluctant handjob,
+		<</if>>
+		at least one of the raiders is amusing himself<<if $arcologies[0].FSGenderFundamentalist == "unset">> (or herself)<</if>> back there.
 	<</if>>
-
-	at least one of the raiders is amusing himself<<if $arcologies[0].FSGenderFundamentalist == "unset">> (or herself)<</if>> back there.
-
-<</if>>
-
-
-
-<<include "Generate New Slave">>
-
-<<set $activeSlave.origin = "You bought her from the girl raiders' slave market the week she reached her majority.">>
-
-<<set $activeSlave.trust -= 25>>
-
-<<set $activeSlave.health += 20>>
-
-<<set $activeSlave.age = 18>>
-
-<<set $activeSlave.career = "a student">>
-
-<<set $activeSlave.birthWeek = 0>>
-
-<<if $activeSlave.vagina != -1>>
-
-	<<if random(1,2) == 1>>
-
-	<<set $activeSlave.vaginalSkill = 0>>
-
-	<<set $activeSlave.vagina = 0>>
-
-	<<set $activeSlave.preg = 0>>
-
-	<</if>>
-
-<</if>>
-
-<<if random(1,2) == 1>>
-
-	<<set $activeSlave.analSkill = 0>>
-
-	<<set $activeSlave.anus = 0>>
-
-<</if>>
-
-<<if random(1,2) == 1>>
-
-	<<set $activeSlave.oralSkill = 0>>
-
-<</if>>
-
-<<set $activeSlave.whoreSkill = 0>>
-
+	<<GenerateMarketSlave "raiders">>
 
 
 <<elseif $slaveMarket == "neighbor">>
+	You're in the area of the slave market that specializes in slaves from within the Free City, viewing slaves from ''<<print "$arcologies["+$numArcology+"].name">>''. Some were trained there, specifically for sale, while others are simply being sold.
+	<<GenerateMarketSlave "neighbor">>
 
 
-
-<<for $i = 0; $i < $arcologies.length; $i++>>
-
-<<if $arcologies[$i].direction == $direction>>
-
-
-
-You're in the area of the slave market that specializes in slaves from within the Free City, viewing slaves from ''$arcologies[$i].name''. Some were trained there, specifically for sale, while others are simply being sold.
-
-
-<</if>>
-
-<<include "Generate New Slave">>
-
-<<set $activeSlave.origin = "You bought her from ">>
-
-<<set $activeSlave.origin += $arcologies[$i].name>>
-
-<<set $activeSlave.origin += ".">>
-
-<<set $activeSlave.devotion = -20 + Math.trunc($arcologies[$i].prosperity/10) + random(0,10)>>
-
-<<set $activeSlave.trust = -20 + Math.trunc($arcologies[$i].prosperity/10) + random(0,10)>>
-
-<<set $activeSlave.health = -50 + Math.trunc($arcologies[$i].prosperity/25) + random(0,5)>>
-
-<<if $activeSlave.vagina > 0>>
-
-	<<set $activeSlave.vaginalSkill += Math.clamp($arcologies[$i].prosperity/2, 15, 100)>>
-
-<</if>>
-
-<<if $activeSlave.anus > 0>>
-
-	<<set $activeSlave.analSkill += Math.clamp($arcologies[$i].prosperity/2, 15, 100)>>
-
-<</if>>
-
-<<set $activeSlave.oralSkill += Math.clamp($arcologies[$i].prosperity/2, 15, 100)>>
-
-<<set $activeSlave.attrKnown = 1>>
-
-<<set $activeSlave.fetishKnown = 1>>
-
-<<if $activeSlave.accent >= 3>>
-
-	<<if $arcologies[$i].prosperity > random(0,200)>>
-
-	<<set $activeSlave.accent -= 1>>
-
-	<</if>>
-
-<</if>>
-
-<<if $arcologies[$i].prosperity > random(0,200)>>
-
-	<<set $activeSlave.sexualFlaw = "none">>
-
-<</if>>
-
-<<if $arcologies[$i].prosperity > random(0,200)>>
-
-	<<set $activeSlave.behavioralFlaw = "none">>
-
-<</if>>
-
-
-
-<<if $arcologies[$i].FSSubjugationist > 20>>
-
-	They're universally $arcologies[$i].FSSubjugationistRace.
-
-	<<set $fixedRace = $arcologies[$i].FSSubjugationistRace>><<NationalityToRace $activeSlave>><<NationalityToName $activeSlave>><<NationalityToAccent $activeSlave>><<set $fixedRace = 0>>
-
-<</if>>
-
-<<if $arcologies[$i].FSGenderRadicalist > 50>>
-
-	They all show signs of intensive hormone therapy.
-
-	<<set $activeSlave.chem += random(10,100)>>
-
-	<<if $activeSlave.dick > 0>>
-
-	<<set $activeSlave.boobs += 100*random(0,4)>>
-
-	<<set $activeSlave.butt += random(0,2)>>
-
-	<<if $activeSlave.hips < 2>>
-
-		<<set $activeSlave.hips += random(0,1)>>
-
-	<</if>>
-
-	<<if $activeSlave.shoulders > -2>>
-
-		<<set $activeSlave.shoulders -= random(0,1)>>
-
-	<</if>>
-
-	<<if $activeSlave.face < 80>>
-
-		<<set $activeSlave.face += random(0,20)>>
-
-	<</if>>
-
-	<<if $activeSlave.faceShape == "masculine">>
-
-	<<if random(0,1) == 0>>
-
-		<<set $activeSlave.faceShape = "androgynous">>
-
-	<</if>>
-
-	<</if>>
-
-	<<if $activeSlave.dick > 2>>
-
-		<<set $activeSlave.dick -= random(0,2)>>
-
-	<</if>>
-
-	<<if $activeSlave.balls > 2>>
-
-		<<set $activeSlave.balls -= random(0,2)>>
-
-	<</if>>
-
+<<else>>
+	You're in the area of the slave market populated by slave trainers, easily the wealthiest vendors. The slaves here have received obedience training and medical care, and many have had some basic sexual skills forced on them.
+	<<if $arcologies[0].FSPaternalistSMR == 1>>
+		Though the rules of your arcology protected them from the worst excesses of the training profession, many of the slaves on sale have the haunted look of people still coming to terms with the idea that they no longer have any bodily autonomy.
 	<<else>>
-
-	<<set $activeSlave.boobs -= 100*random(0,2)>>
-
-	<<set $activeSlave.butt -= random(0,1)>>
-
-	<<if $activeSlave.hips > -2>>
-
-		<<set $activeSlave.hips -= random(0,1)>>
-
+		<<set $seed = random(1,4)>>
+		The trainers are a competitive bunch, and to go by what you can hear,
+		<<if ($seed == 1) && ($seeDicks != 0) && (random(0,100) > $seeDicks)>>
+		moaning interspersed with lewd, well-lubricated noises coming from both anal sex and vigorous masturbation,
+		<<elseif ($seed == 2) && ($seeDicks != 100) && (random(0,100) > $seeDicks)>>
+		moaning and the distinctive slap of feminine buttocks on thighs beneath them as a girl rides a dick,
+		<<elseif ($seed == 3)>>
+		the lush, lewd sounds of diligent oral sex,
+		<<else>>
+		the call-and-response of a trainer and a slave running through a memorized obedience exercise,
+		<</if>>
+		at least one of them is applying some last-minute training to a slave in the holding pens nearby.
 	<</if>>
-
-	<<if $activeSlave.shoulders < 2>>
-
-		<<set $activeSlave.shoulders += random(0,1)>>
-
-	<</if>>
-
-	<<if $activeSlave.face >= -80>>
-
-		<<set $activeSlave.face -= random(0,20)>>
-
-	<</if>>
-
-	<<if $activeSlave.faceShape != "androgynous">>
-
-	<<if random(0,1) == 0>>
-
-		<<set $activeSlave.faceShape = "androgynous">>
-
-	<</if>>
-
-	<</if>>
-
-	<<set $activeSlave.clit += random(0,2)>>
-
-	<<set $activeSlave.labia += random(0,1)>>
-
-	<<if $activeSlave.muscles <= 95>>
-
-		<<set $activeSlave.muscles += random(0,20)>>
-
-	<</if>>
-
-	<</if>>
-
-<<elseif $arcologies[$i].FSGenderFundamentalist > 50>>
-
-	Fertile slaves from there almost never appear without swollen bellies and sensitive nipples.
-
-	<<set $activeSlave.preg = 0>> /*removing contraception of default slave generation so isFertile can work right*/
-
-	<<if isFertile($activeSlave)>>
-
-	<<set $activeSlave.preg = random(1,35)>>
-
-	<<set $activeSlave.lactation = random(0,1)>>
-
-	<</if>>
-
-<</if>>
-
-<<if $arcologies[$i].FSPaternalist > 20>>
-
-	They're often gratifyingly devoted and trusting.
-
-	<<if $activeSlave.devotion < 10>>
-
-	<<set $activeSlave.devotion += random(0,8)>>
-
-	<</if>>
-
-	<<if $activeSlave.trust < 50>>
-
-	<<set $activeSlave.trust += random(0,8)>>
-
-	<</if>>
-
-<<elseif $arcologies[$i].FSDegradationist > 20>>
-
-	They can be depended upon to be terrified into abject submission.
-
-	<<if $activeSlave.trust > -10>>
-
-	<<set $activeSlave.trust -= random(0,10)>>
-
-	<</if>>
-
-	<<if random (1,100) > 90>>
-
-		<<set $activeSlave.eyes = -2>>
-
-	<</if>>
-
-<</if>>
-
-<<if $arcologies[$i].FSBodyPurist > 80>>
-
-	They're quite pristine, free of any genomic damage or addictions regardless of any transformations they've had.
-
-	<<set $activeSlave.chem = 0>>
-
-	<<set $activeSlave.addict = 0>>
-
-<<elseif $arcologies[$i].FSTransformationFetishist > 80>>
-
-	They vary in terms of what size their implants are, not whether they have them.
-
-	<<set $activeSlave.chem += random(10,100)>>
-
-	<<set $activeSlave.boobsImplant = 200*random(2,20)>>
-
-	<<set $activeSlave.boobs += $activeSlave.boobsImplant>>
-
-	<<set $activeSlave.buttImplant = random(2,5)>>
-
-	<<set $activeSlave.butt += $activeSlave.buttImplant>>
-
-	<<set $activeSlave.lipsImplant = either(10,20)>>
-
-	<<set $activeSlave.lips += $activeSlave.lipsImplant>>
-
-<</if>>
-
-<<if $arcologies[$i].FSYouthPreferentialist > 20>>
-
-	They're usually on the younger side.
-
-	<<if $activeSlave.age > 30>>
-
-	<<if random(0,1) == 0>>
-
-	<<set $activeSlave.age = random(18,25)>>
-
-	<<if $activeSlave.boobs > 400>>
-
-		<<set $activeSlave.boobs -= 100*random(0,2)>>
-
-	<</if>>
-
-	<<if $activeSlave.butt > 3>>
-
-		<<set $activeSlave.butt -= random(0,2)>>
-
-	<</if>>
-
-	<</if>>
-
-	<</if>>
-
-<<elseif $arcologies[$i].FSMaturityPreferentialist > 20>>
-
-	They're usually on the more mature side.
-
-	<<if $activeSlave.age < 30>>
-
-	<<if random(0,1) == 0>>
-
-	<<set $activeSlave.age = random(36,$retirementAge)>>
-
-	<<if $activeSlave.boobs < 400>>
-
-		<<set $activeSlave.boobs += 100*random(0,2)>>
-
-	<</if>>
-
-	<<if $activeSlave.butt < 3>>
-
-		<<set $activeSlave.butt += random(0,2)>>
-
-	<</if>>
-
-	<</if>>
-
-	<</if>>
-
-<</if>>
-
-<<if $arcologies[$i].FSSlimnessEnthusiast > 20>>
-
-	They're never overweight, and are often quite lithe.
-
-	<<if $activeSlave.boobs > 400>>
-
-	<<set $activeSlave.boobs -= 100*random(0,2)>>
-
-	<</if>>
-
-	<<if $activeSlave.butt > 3>>
-
-	<<set $activeSlave.butt -= random(0,2)>>
-
-	<</if>>
-
-	<<if $activeSlave.weight > 10>>
-
-	<<set $activeSlave.weight = random(-30,0)>>
-
-	<</if>>
-
-<<elseif $arcologies[$i].FSAssetExpansionist > 20>>
-
-	Their butts are usually imposing, but their tits are what's often most impressive.
-
-	<<set $activeSlave.chem += random(10,100)>>
-
-	<<if $activeSlave.boobs < 5000>>
-
-	<<set $activeSlave.boobs += 100*random(5,50)>>
-
-	<</if>>
-
-	<<if $activeSlave.butt < 6>>
-
-	<<set $activeSlave.butt += random(2,4)>>
-
-	<</if>>
-
-	<<if $activeSlave.weight < -10>>
-
-	<<set $activeSlave.weight += random(0,20)>>
-
-	<</if>>
-
-<</if>>
-
-<<if $arcologies[$i].FSPastoralist > 20>>
-
-	Lactation is nearly universal among them, sometimes in ludicrous quantities. They tend to have huge udders, as well.
-
-	<<set $activeSlave.chem += random(10,100)>>
-
-	<<if $activeSlave.boobs < 5000>>
-
-	<<set $activeSlave.boobs += 100*random(5,50)>>
-
-	<</if>>
-
-	<<if $activeSlave.lactation == 0>>
-
-	<<set $activeSlave.lactation = either(0,1,1,1,1,2)>>
-
-	<</if>>
-
-	<<if $activeSlave.weight < -10>>
-
-	<<set $activeSlave.weight += random(0,20)>>
-
-	<</if>>
-
-<</if>>
-
-<<if $arcologies[$i].FSPhysicalIdealist > 20>>
-
-	They're usually quite muscular, some to a truly imposing degree, and they're almost never unhealthy.
-
-	<<set $activeSlave.muscles = random(10,100)>>
-
-	<<if $activeSlave.health < 20>>
-
-	<<set $activeSlave.health += random(0,8)>>
-
-	<</if>>
-
-<</if>>
-
-<<if $arcologies[$i].FSChattelReligionist > 20>>
-
-	They're rarely anything but devoted, and sometimes present interesting peccadilloes.
-
-	<<if $activeSlave.devotion < 10>>
-
-	<<set $activeSlave.devotion += random(0,10)>>
-
-	<</if>>
-
-	<<if $activeSlave.devotion < 10>>
-
-	<<set $activeSlave.devotion += random(0,10)>>
-
-	<</if>>
-
-	<<if random(0,1) == 0>>
-
-	<<set $activeSlave.behavioralQuirk = "sinful">>
-
-	<</if>>
-
-<</if>>
-
-<<if $arcologies[$i].FSRomanRevivalist > 20>>
-
-	They've often seen things that drive any squeamishness out of them.
-
-	<<if random(0,1) == 0>>
-
-	<<set $activeSlave.sexualQuirk = "unflinching">>
-
-	<</if>>
-
-<<if $arcologies[$i].FSAztecRevivalist > 20>>
-	They've seen sights that will traumatize almost anyone.
-
-	<<if random(0,1) == 0>>
-
-	<<set $activeSlave.trust = -30>>
-
-	<</if>>
-
-<<elseif $arcologies[$i].FSEgyptianRevivalist > 20>>
-
-	They've often done things that give them a distinct appetite for perversion.
-
-	<<if random(0,1) == 0>>
-
-	<<set $activeSlave.sexualQuirk = "perverted">>
-
-	<</if>>
-
-<<elseif $arcologies[$i].FSEdoRevivalist > 20>>
-
-	They have frequently absorbed much culture there.
-
-	<<set $activeSlave.entertainSkill = Math.clamp($activeSlave.entertainSkill, 35, 100)>>
-
-<<elseif $arcologies[$i].FSArabianRevivalist > 20>>
-
-	They've often been part of large harems in which selflessness is prized.
-
-	<<if random(0,1) == 0>>
-
-	<<set $activeSlave.sexualQuirk = "caring">>
-
-	<</if>>
-
-<<elseif $arcologies[$i].FSChineseRevivalist > 20>>
-
-	They've all passed through a thorough and uncompromising educational system for slaves.
-
-	<<set $activeSlave.intelligenceImplant = 1>>
-
-	<<if $activeSlave.intelligence < 2>>
-
-	<<set $activeSlave.intelligence += random(0,2)>>
-
-	<</if>>
-
-<</if>>
-
-
-
-<<set $activeArcology = $arcologies[0]>>
-
-<<set $targetArcology = $arcologies[$i]>>
-
-<<include "Arcology Opinion">>
-
-<<set $opinion = Math.trunc($opinion/20)>>
-
-<<set $opinion = Math.clamp($opinion, -10, 10)>>
-
-
-
-<<if ($arcologies[0].FSDegradationist != "unset") && ($arcologies[$i].FSPaternalist != "unset")>>
-
-	<<set $activeSlave.devotion = random(-90,-60)>>
-
-	<<set $activeSlave.trust = -20>>
-
-	''$arcologies[$i].name'' is Paternalist, and your arcology is Degradationist. To its slaves, other niceties of social alignment are trivial. They view your arcology as a literal Hell on Earth.
-
-<<elseif ($arcologies[0].FSDegradationist != "unset") && ($arcologies[$i].FSPaternalist != "unset")>>
-
-	<<set $activeSlave.devotion = random(60,90)>>
-
-	<<set $activeSlave.trust = 20>>
-
-	''$arcologies[$i].name'' is Degradationist, and your arcology is Paternalist. To its slaves, other niceties of social alignment are trivial. They view your arcology as a promised land.
-
-<<elseif $opinion != 0>>
-
-	<<set $activeSlave.devotion += $opinion>>
-
-	<<set $activeSlave.trust += $opinion>>
-
-	<<set $activeSlave.devotion = Math.clamp($activeSlave.devotion, -100, 75)>>
-
-	<<set $activeSlave.trust = Math.clamp($activeSlave.trust, -100, 75)>>
-
-	<<if $opinion > 2>>
-
-		Your arcology's close social alignment with ''$arcologies[$i].name'' makes its slaves more accepting of the prospect of life in your arcology, and willing to trust that they'll know how to survive there.
-
-	<<elseif $opinion < -2>>
-
-		Your arcology's very different culture from ''$arcologies[$i].name'''s makes its slaves unhappy with the prospect of life in your arcology, and afraid of what will happen to them there.
-
-	<</if>>
-
-<</if>>
-
+	<<GenerateMarketSlave "trainers">>
 
 
 <</if>>
-
-<</for>>
-
-
-
-<<else>>
-
-
-
-You're in the area of the slave market populated by slave trainers, easily the wealthiest vendors. The slaves here have received obedience training and medical care, and many have had some basic sexual skills forced on them.
-
-<<if $arcologies[0].FSPaternalistSMR == 1>>
-
-	Though the rules of your arcology protected them from the worst excesses of the training profession, many of the slaves on sale have the haunted look of people still coming to terms with the idea that they no longer have any bodily autonomy.
-
-<<else>>
-
-	<<set $seed = random(1,4)>>
-
-	The trainers are a competitive bunch, and to go by what you can hear,
-
-	<<if ($seed == 1) && ($seeDicks != 0) && (random(0,100) > $seeDicks)>>
-
-	moaning interspersed with lewd, well-lubricated noises coming from both anal sex and vigorous masturbation,
-
-	<<elseif ($seed == 2) && ($seeDicks != 100) && (random(0,100) > $seeDicks)>>
-
-	moaning and the distinctive slap of feminine buttocks on thighs beneath them as a girl rides a dick,
-
-	<<elseif ($seed == 3)>>
-
-	the lush, lewd sounds of diligent oral sex,
-
-	<<else>>
-
-	the call-and-response of a trainer and a slave running through a memorized obedience exercise,
-
-	<</if>>
-
-	at least one of them is applying some last-minute training to a slave in the holding pens nearby.
-
-<</if>>
-
-
-
-<<include "Generate New Slave">>
-
-<<set $activeSlave.origin = "You bought her from the trainers' slave market after they put her through basic training.">>
-
-<<set $activeSlave.devotion += 40>>
-
-<<set $activeSlave.trust += 40>>
-
-<<set $activeSlave.health += 30>>
-
-<<if $activeSlave.vagina != -1>>
-
-	<<set $activeSlave.vaginalSkill += 15>>
-
-<<else>>
-
-	<<set $activeSlave.vaginalSkill = 0>>
-
-	<<set $activeSlave.clit = 0>>
-
-<</if>>
-
-<<if $activeSlave.vagina == 0>>
-
-	<<set $activeSlave.vagina += 1>>
-
-<</if>>
-
-<<if $activeSlave.anus == 0>>
-
-	<<set $activeSlave.anus += 1>>
-
-<</if>>
-
-<<set $activeSlave.oralSkill += 15>>
-
-<<set $activeSlave.analSkill += 15>>
-
-<<set $activeSlave.fetishKnown = 1>>
-
-<<if $activeSlave.accent >= 3>>
-
-	<<set $activeSlave.accent -= 1>>
-
-<</if>>
-
-<<if random(1,100) > 50>>
-
-	<<set $activeSlave.sexualFlaw = "none">>
-
-<</if>>
-
-<<if random(1,100) > 50>>
-
-	<<set $activeSlave.behavioralFlaw = "none">>
-
-<</if>>
-
-
-
-<</if>>
-
-
 
 <br><br>
-
-
 
 <<slaveCost $activeSlave>>
-
 <<if $slavesSeen > $slaveMarketLimit>><<set $slaveCost += $slaveCost*(($slavesSeen-$slaveMarketLimit)*0.1)>><</if>>
 
-
-
 <<if $slaveMarket == "neighbor">>
-
 	<<for $i = 0; $i < $arcologies.length; $i++>>
-
 	<<if $arcologies[$i].direction == $direction>>
-
 	<<if $opinion != 0>>
-
 		<<set $slaveCost -= Math.trunc($slaveCost*$opinion*0.05)>>
-
 		<<if $opinion > 2>>
-
 			Your cultural ties with ''$arcologies[$i].name'' helps keep the price reasonable.
-
 		<<elseif $opinion < -2>>
-
 			Your social misalignment with ''$arcologies[$i].name'' drives up the price.
-
 		<</if>>
-
 	<</if>>
-
 	<</if>>
-
 	<</for>>
-
 <</if>>
-
-
 
 <<set $slaveCost = 500*Math.trunc($slaveCost/500)>>
-
 The offered price is ¤<<print $slaveCost>>.<<if $slavesSeen > $slaveMarketLimit>> You have cast such a wide net for slaves this week that it is becoming more expensive to find more for sale. Your reputation helps determine your reach within the slave market.<</if>>
 
-<br>
-
 <<if $cash >= $slaveCost>>
-
-	[[Buy her slave contract|New Slave Intro][$cash -= $slaveCost,$nextButton = "Continue",$nextLink = "AS Dump",$returnTo = "Main"]]
-
+	<br>[[Buy her and check out other slaves to order|Slave Markets][$cash -= $slaveCost, $newSlaves.push($activeSlave), $introType = "multi", $slavesSeen+=1]]
+	<<if $newSlaves.length == 0>>
+		<br>[[Buy her slave contract|New Slave Intro][$cash -= $slaveCost,$nextButton = "Continue",$nextLink = "AS Dump",$returnTo = "Main"]]
+	<<else>>
+		<br>[[Buy her and Finish your order of slaves|Bulk Slave Intro][$cash -= $slaveCost, $newSlaves.push($activeSlave)]]
+	<</if>>
 <<else>>
-
 	//You lack the necessary funds to buy this slave.//
-
 <</if>>
-
-<br>
-
-[[Decline to purchase her and check out another slave|Slave Markets][$slavesSeen += 1]]
-
-
+<br>[[Decline to purchase her and check out another slave|Slave Markets][$slavesSeen += 1]]
+<<if $newSlaves.length > 0>>
+	<br>[[Finish your order of slaves|Bulk Slave Intro]]
+<</if>>
 
 <br><br>
-
 <<if $slaveMarket != "indentures">>
-
 	<<set $applyLaw = 1>>
-
 <</if>>
-
 <<set $saleDescription = 1>><<include "Long Slave Description">><<set $saleDescription = 0>>

--- a/src/utility/slaveCreationWidgets.tw
+++ b/src/utility/slaveCreationWidgets.tw
@@ -2302,6 +2302,11 @@
 		<<if random(0,1) == 0>>
 			<<set $activeSlave.sexualQuirk = "unflinching">>
 		<</if>>
+	<<if $arcologies[_market].FSAztecRevivalist > 20>>
+		They've seen sights that will traumatize almost anyone.
+		<<if random(0,1) == 0>>
+			<<set $activeSlave.trust = -30>>
+		<</if>>
 	<<elseif $arcologies[_market].FSEgyptianRevivalist > 20>>
 		They've often done things that give them a distinct appetite for perversion.
 		<<if random(0,1) == 0>>


### PR DESCRIPTION
Re-enables the Cascade bulk purchase option for a number of slave markets.  Was lost to a conflict with one of the Aztec Revivalist updates.

Markets affected are: Kidnappers, Indentures, Hunters, Raiders, Trainers and the markets of Neighbor arcologies.