### PR TITLE
removed doubled entries

### DIFF
--- a/src/uncategorized/toychest.tw
+++ b/src/uncategorized/toychest.tw
@@ -83,8 +83,6 @@
 	She's wearing a slutty schoolgirl outfit, and looks ready to do whatever it takes to improve her grades.
 <<elseif ($slaves[$i].clothes == "a kimono")>>
 	She's wearing a kimono, lending your office an air of elegance, though she lacks some of the air of the true yamato nadeshiko.
-<<elseif ($slaves[$i].clothes == "a slutty qipao")>>
-	She's wearing a qipao, lending your office the elegance of an imperial court.
 <<elseif ($slaves[$i].clothes == "a hijab and abaya")>>
 	She's wearing a modest hijab and abaya, lending your office a certain air of conservatism.
 <<elseif ($slaves[$i].clothes == "battledress")>>


### PR DESCRIPTION
There were two entries for slutty qipao. The second one will never get called. I suspect that originally the author intended to have normal qipao and slutty qipao, but ended up only implementing the slutty qipao. Have removed the first entry since it seems to be for a normal one.