### PR TITLE
Corrected the space reserved for .lrgImg

### DIFF
--- a/src/gui/css/mainStyleSheet.tw
+++ b/src/gui/css/mainStyleSheet.tw
@@ -37,10 +37,10 @@
 }
 
 .lrgImg {
-    height: 600px;
-    width: 600px;
-	margin-right: -100px;
-	margin-left: -100px;
+    height: 531px;
+    width: 531px;
+	margin-right: -50px;
+	margin-left: 3px;
     float: right;
 }
 


### PR DESCRIPTION
Changed the space for large image from 600x600 pixels with -100 margins to 531x531 with smaller margins. The margin change stops the rendered image from overlapping with text while the size change saves space. It's probably easier to see the difference by compiling both, turning rendered image on, and comparing how they look like side by side.