### PR TITLE
added a line to reset $Sweatshop to 0

### DIFF
--- a/src/uncategorized/buildingWidgets.tw
+++ b/src/uncategorized/buildingWidgets.tw
@@ -397,7 +397,7 @@ Selling this sector would relenquish a 4% interest in $arcologies[0].name. Such 
 <<else>>
 	<<set $AProsperityCap = 100>>
 <</if>>
-<<set $ACitizenLimit = 0, $ASlaveLimit = 0>>
+<<set $ACitizenLimit = 0, $ASlaveLimit = 0, $Sweatshops = 0>>
 <<for _i = 8; _i <= 19; _i++>>
 	<<if $sectors[_i].type == "DenseApartments">>
 		<<set $ACitizenLimit += 600, $ASlaveLimit += 1000, $AProsperityCap += 10>>


### PR DESCRIPTION
Previously $Sweatshop will get incremented every turn. So if you have 1 Sweatshop, by turn 10 the code thinks you have 10. Resetting it to 0 prior to actually counting how many Sweatshops actually exist makes sure $Sweatshop will be accurate.