### PR TITLE
Nicaea Council effects bugfix

### DIFF
--- a/src/uncategorized/reputation.tw
+++ b/src/uncategorized/reputation.tw
@@ -17,7 +17,7 @@ On formal occasions, you are announced as $PCTitle.
 		<<elseif $slaves.length > 20>>
 			@@.green;approve@@ of the good
 			<<FSChange "ChattelReligionist" 2>>
-		<<elseif $slaves.length > 20>>
+		<<else>>
 			are not impressed by the
 		<</if>>
 		number of people you're giving the honor of sexual servitude.
@@ -28,7 +28,7 @@ On formal occasions, you are announced as $PCTitle.
 		<<elseif $averageDevotion > 50>>
 			@@.green;approve@@ of the devotion
 			<<FSChange "ChattelReligionist" 2>>
-		<<elseif $slaves.length > 20>>
+		<<else>>
 			are not impressed by the devotion
 		<</if>>
 		of your slaves.
@@ -39,7 +39,7 @@ On formal occasions, you are announced as $PCTitle.
 		<<elseif $averageTrust > 20>>
 			@@.green;approve@@ of the trust your slaves place in you.
 			<<FSChange "ChattelReligionist" 2>>
-		<<elseif $slaves.length > 20>>
+		<<else>>
 			are not impressed by fear many of your slaves feel towards you.
 		<</if>>
 	<</if>>


### PR DESCRIPTION
The elseif condition when the arcology doesn't match the Nicaea Council policy is incorrect. If the number of slaves is <= 20 then they never gets called. It should be a plain else.