### PR TITLE
gingering and acquisition fixes

### DIFF
--- a/src/npc/removeActiveSlave.tw
+++ b/src/npc/removeActiveSlave.tw
@@ -1,4 +1,4 @@
-:: Remove activeSlave [silently]
+:: Remove activeSlave [silently nobr]
 
 <<set _ID = $activeSlave.ID, _SL = $slaves.length>>
 

--- a/src/npc/removeActiveSlave.tw
+++ b/src/npc/removeActiveSlave.tw
@@ -39,7 +39,10 @@
 	/% Remove from facility array or leadership role, if needed %/
 	<<removeJob $activeSlave $activeSlave.assignment>>
 
-	<<set $slavesOriginal.delete(_ID)>>
+	<<set _y = $slavesOriginal.findIndex(function(s) { return s.ID == _ID; })>>
+	<<if _y != -1>>
+		<<set $slavesOriginal.deleteAt(_y)>>
+	<</if>>
 
 	<<set _dump = $slaves.deleteAt(_x), _SL--, $activeSlave = 0>>
 <</if>>

--- a/src/uncategorized/RESS.tw
+++ b/src/uncategorized/RESS.tw
@@ -7040,7 +7040,7 @@ She's obviously @@.mediumaquamarine;becoming more comfortable@@ playing the part
 		<<set $activeSlave.attrXY = random(60,90)>>
 		<<set $activeSlave.attrXX = random(10,20)>>
 		<<set $activeSlave.behavioralFlaw = either("bitchy", "arrogant")>>
-		<<AddSlave $activeSlave>>
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 	<</for>>
 	<<set $fixedNationality = 0>>
 	<br><br><span id="result2">

--- a/src/uncategorized/REroyalblood.tw
+++ b/src/uncategorized/REroyalblood.tw
@@ -1,23 +1,26 @@
 :: RE royal blood [nobr]
 
-<<set $nextButton = "Continue", $nextLink = "RIE Eligibility Check">>
+<<set $nextButton = "Continue", $nextLink = "RIE Eligibility Check", $returnTo = "RIE Eligibility Check">>
 
 One unfortunate consequence of existing in a global world is that business opportunities continue to crop up unabated by the onset of night in one corner of the world or another, an inconsiderate phenomenon for arcology owners who happen to be asleep when an event of importance takes place outside the walls of their arcology. This particular evening you are awoken by an alert from $assistantName, unusually intense for this late hour. 
 <<if $assistant > 0>>
-	"<<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Master<<else>>Mistress<</if>>, there is a time sensitive enslavement opportunity available if you're interested." She pauses before continuing. "You're going to want to see this one <<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Master<<else>>Mistress<</if>>.
+	"<<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Master<<else>>Mistress<</if>>, there is a time sensitive enslavement opportunity available if you're interested." She pauses before continuing. "You're going to want to see this one <<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Master<<else>>Mistress<</if>>."
 <<else>>
 	It informs you that there is a time sensitive enslavement opportunity for you to peruse, and that it has calculated the potential rewards are worthy of your consideration even in the middle of the night. 
 <</if>>
 <br><br>
 A convenient video feed is brought up, displaying a quick visual summary of the opportunity at hand.
-<br><br>
+
 It seems a bastion of the old world has fallen, a royal family of ancient blood and reputation has been overthrown by a local populist leader and his fellow revolutionaries. Furthermore, the leader of the revolution has designs to transform the outmoded monarchy into an arcology of his own, and has transmitted a request for aid to his new peers in the Free Cities.
-<br><br>
+
 Of course, nothing in the Free Cities is free and international aid is no exception. This new arcology owner is no fool, however, and has outlined a number of rewards to be delivered to his most generous benefactors.
-<br><br>
+
 Though the king himself is dead, murdered in his bed by bloodthirsty revolutionaries, the rest of his family and the majority of his court have been captured and enslaved by their former subjects. The new arcology owner, having decided that a large injection of credits or a shipment of goods is superior to deflowering a royal pussy or asshole, has directed his followers to slake their lust and vengeance on the king's wife and court rather than his children, though they too are past the age of majority.
+
 <br><br>
+
 Time is short, but you are well placed to acquire some choice slaves. With an adequate donation, of course. 
+
 <br><br>
 
 <span id="result">
@@ -26,16 +29,16 @@ Time is short, but you are well placed to acquire some choice slaves. With an ad
 	You inform your personal assistant that you aren't planning to take any action. It's not every day that a monarchy collapses in the Old World, but it's also not particularly uncommon either. 
 	<</replace>>
 <</link>>
-<br><br>
 <<if ($cash >= 50000) and ($rep >= 2000)>>
 <br><<link "Leverage your reputation and credits to aid the new arcology in exchange for a pretty princess">>
 	<<replace "#result">>
-	You seize a tablet and practically roll out of your bed, working furiously and using every feature of $assistantName to the utmost. It's not easy, but you call in a number of favors and grease a handful of palms, and soon a flight of VTOLs are landing in the new arcology laden with goods. When they take off again they have the princess aboard clad in chains, and make a direct course towards your waiting penthouse.
-<br><br>
-	Eventually she arrives in your penthouse, the perfect image of a demure yet composed princess. Her clearly practiced facade of poise and grace fades under scrutiny, however. The slightest trembling of her balled up fists, the minute tremors that mar her immaculate posture, her inability to meet your eyes with her own, all signs that she is still a scared girl despite all her royal trappings. Nonetheless, though the princess's court training is unlikely to be very beneficial to her in her new life in the penthouse, it does stand in stark contrast to her more common slave peers.
-	<<set $cash -= 50000>>
-	<<set $rep -= 2000>>
-		<<include "Generate New Slave">>
+		You seize a tablet and practically roll out of your bed, working furiously and using every feature of $assistantName to the utmost. It's not easy, but you call in a number of favors and grease a handful of palms, and soon a flight of VTOLs are landing in the new arcology laden with goods. When they take off again they have the princess aboard clad in chains, and make a direct course towards your waiting penthouse.
+		<br><br>
+		Eventually she arrives in your penthouse, the perfect image of a demure yet composed princess. Her clearly practiced facade of poise and grace fades under scrutiny, however. The slightest trembling of her balled up fists, the minute tremors that mar her immaculate posture, her inability to meet your eyes with her own, all signs that she is still a scared girl despite all her royal trappings. Nonetheless, though the princess's court training is unlikely to be very beneficial to her in her new life in the penthouse, it does stand in stark contrast to her more common slave peers.
+		<br><br>
+		<<set $cash -= 50000>>
+		<<set $rep -= 2000>>
+		<<include "Generate XX Slave">>
 		<<set _origin = "She was a princess of a royal kingdom, till her family was overthrown and she was sold to you in exchange for aid.">>
 		<<set $activeSlave.origin = _origin>>
 		<<set $activeSlave.career = "a princess">>
@@ -65,25 +68,24 @@ Time is short, but you are well placed to acquire some choice slaves. With an ad
 		<<set $activeSlave.analSkill = 0>>
 		<<set $activeSlave.oralSkill = 0>>
 		<<set $activeSlave.whoreSkill = 0>>
-		<<set $activeSlave.whoreSkill = 0>>
+		<<set $activeSlave.recruiter = 0>>
 		<<set $activeSlave.health = random(30,60)>>
 		<<set $activeSlave.behavioralFlaw = either("bitchy", "arrogant")>>
 		<<include "New Slave Intro">>
-	<br><br>
-<</replace>>
+	<</replace>>
 <</link>> // You will need to utilize a portion of your reputation and ¤50000 to enslave her.//
 <<else>>
 	//You lack the necessary funds and reputation to enslave a princess.//
 <</if>>
-<br><br>
 <<if $cash >= 35000>>
 <br><<link "Dispatch a sizeable amount of aid in exchange for the crown prince">>
 	<<replace "#result">>
-	You seize a tablet and practically roll out of your bed, working vigorously and using every feature of $assistantName to the utmost. It's not easy, but your credits pave your way to sending a flight of VTOLs laden with goods to the new arcology. They take off again with the crown prince aboard and in chains, where he rails against the uncaring metal walls of the VTOL for the breadth of his journey to your penthouse.
-<br><br>
-	When he arrives in your penthouse, the former prince is beside himself with rage. When he is brought to be modified in the remote surgery, he breaks free and attempts to fight his way out of your penthouse. His attempt at freedom is futile, however, and he is soon overwhelmed by your guards and dragged back to the remote surgery. It doesn't take long for the valiant prince to become a new dickgirl, though his submission to life as a slave is another question entirely.
-	<<set $cash -= 35000>>
-		<<include "Generate New Slave">>
+		You seize a tablet and practically roll out of your bed, working vigorously and using every feature of $assistantName to the utmost. It's not easy, but your credits pave your way to sending a flight of VTOLs laden with goods to the new arcology. They take off again with the crown prince aboard and in chains, where he rails against the uncaring metal walls of the VTOL for the breadth of his journey to your penthouse.
+		<br><br>
+		When he arrives in your penthouse, the former prince is beside himself with rage. When he is brought to be modified in the remote surgery, he breaks free and attempts to fight his way out of your penthouse. His attempt at freedom is futile, however, and he is soon overwhelmed by your guards and dragged back to the remote surgery. It doesn't take long for the valiant prince to become a new dickgirl, though his submission to life as a slave is another question entirely.
+		<br><br>
+		<<set $cash -= 35000>>
+		<<include "Generate XY Slave">>
 		<<set _origin = "She was the crown prince of a royal kingdom, till her family was overthrown and she was sold to you in exchange for aid.">>
 		<<set $activeSlave.origin = _origin>>
 		<<set $activeSlave.career = "a prince">>
@@ -92,7 +94,6 @@ Time is short, but you are well placed to acquire some choice slaves. With an ad
 		<<set $activeSlave.age to random(20,21)>>
 		<<set $activeSlave.devotion = random(-80,-60)>>
 		<<set $activeSlave.trust = random(-50,-60)>>
-		<<set $activeSlave.boobs = either(100, 150)>>
 		<<set $activeSlave.boobs = 150>>
 		<<set $activeSlave.vagina = -1>>
 		<<set $activeSlave.clit = 0>>
@@ -100,6 +101,7 @@ Time is short, but you are well placed to acquire some choice slaves. With an ad
 		<<set $activeSlave.preg = 0>>
 		<<set $activeSlave.dick = random(3,5)>>
 		<<set $activeSlave.balls = random(2,4)>>
+		<<set $activeSlave.scrotum = $activeSlave.balls>>
 		<<set $activeSlave.anus = 0>>
 		<<set $activeSlave.weight = 0>>
 		<<set $activeSlave.muscles = 50>>
@@ -111,72 +113,72 @@ Time is short, but you are well placed to acquire some choice slaves. With an ad
 		<<set $activeSlave.oralSkill = 0>>
 		<<set $activeSlave.whoreSkill = 0>>
 		<<set $activeSlave.combatSkill = 1>>
+		<<set $activeSlave.recruiter = 0>>
 		<<set $activeSlave.health = random(30,60)>>
 		<<set $activeSlave.behavioralFlaw = either("bitchy", "arrogant")>>
 		<<include "New Slave Intro">>
-	<br><br>
-<</replace>>
+	<</replace>>
 <</link>> // Purchasing the goods and hiring the VTOLs will cost about ¤35000.//
 <<else>>
 	//You lack the necessary funds to enslave a crown prince.//
 <</if>>
-<br><br>
 <<if $cash >= 25000>>
 <br><<link "Transfer a respectable quantity of credits for a handful of court ladies">>
 	<<replace "#result">>
-	You take a tablet and peruse the various court ladies on offer by the fledgling arcology. You single out a few interesting individuals for purchase that might suit your tastes, but the slapdash descriptions provided for each slave by the revolutionaries make it likely that any similarities to your aesthetic leanings will be coincidental. Once you are satisfied with your selection, you electronically transfer the credits to the new arcology and soon receive a receipt for your donation and an estimated delivery schedule.
-<br><br>
-	When the ladies arrives at your penthouse, they seem almost relieved at the opulence of their new surroundings. Though they still retain much of their aristocratic arrogance, they each submit to biometric scanning with relative obedience. It seems likely that their obedience is borne out of a delusional rationalization that enslavement by one wealthy master is better than enslavement by the unwashed masses they once lorded over.
-	<<set $cash -= 25000>>
-	<<for $i to 0; $i < 3; $i++>>
-		<<include "Generate New Slave">>
-		<<set _origin = "She was a member of the court in an ancient kingdom, till it was overthrown and she was sold to you in exchange for credits.">>
-		<<set $activeSlave.origin = _origin>>
-		<<set $activeSlave.career = "a lady courtier">>
-		<<set $activeSlave.prestige = 1>>
-		<<set $activeSlave.prestigeDesc = "She was once a lady of the court of an ancient kingdom.">>
-		<<set $activeSlave.age to random(21,$retirementAge-2)>>
-		<<set $activeSlave.face = random(25,76)>>
-		<<set $activeSlave.devotion = random(10,20)>>
-		<<set $activeSlave.trust = random(-20,-30)>>
-		<<set $activeSlave.boobs = random(3,10)*100>>
-		<<set $activeSlave.vagina = 1>>
-		<<set $activeSlave.dick to 0>>
-		<<set $activeSlave.foreskin to 0>>
-		<<set $activeSlave.balls = 0>>
-		<<set $activeSlave.ovaries = 1>>
-		<<set $activeSlave.pubicHStyle = "waxed">>
-		<<set $activeSlave.height = random(120,180)>>
-		<<set $activeSlave.shoulders = random(-1,1)>>
-		<<set $activeSlave.hips = 1>>
-		<<set $activeSlave.butt = 1>>
-		<<set $activeSlave.anus = 0>>
-		<<set $activeSlave.weight = 0>>
-		<<set $activeSlave.intelligence = either(-1, 1, 2)>>
-		<<set $activeSlave.intelligenceImplant = 1>>
-		<<set $activeSlave.entertainSkill = 25>>
-		<<set $activeSlave.whoreSkill = 0>>
-		<<set $activeSlave.health = random(30,60)>>
-		<<set $activeSlave.behavioralFlaw = either("bitchy", "arrogant")>>
-		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+		You take a tablet and peruse the various court ladies on offer by the fledgling arcology. You single out a few interesting individuals for purchase that might suit your tastes, but the slapdash descriptions provided for each slave by the revolutionaries make it likely that any similarities to your aesthetic leanings will be coincidental. Once you are satisfied with your selection, you electronically transfer the credits to the new arcology and soon receive a receipt for your donation and an estimated delivery schedule.
+		<br><br>
+		When the ladies arrives at your penthouse, they seem almost relieved at the opulence of their new surroundings. Though they still retain much of their aristocratic arrogance, they each submit to biometric scanning with relative obedience. It seems likely that their obedience is borne out of a delusional rationalization that enslavement by one wealthy master is better than enslavement by the unwashed masses they once lorded over.
+		<br><br>
+		<<set $cash -= 25000>>
+		<<for $i = 0; $i < 3; $i++>>
+			<<include "Generate XX Slave">>
+			<<set _origin = "She was a member of the court in an ancient kingdom, till it was overthrown and she was sold to you in exchange for credits.">>
+			<<set $activeSlave.origin = _origin>>
+			<<set $activeSlave.career = "a lady courtier">>
+			<<set $activeSlave.prestige = 1>>
+			<<set $activeSlave.prestigeDesc = "She was once a lady of the court of an ancient kingdom.">>
+			<<set $activeSlave.age to random(21,$retirementAge-2)>>
+			<<set $activeSlave.face = random(25,76)>>
+			<<set $activeSlave.devotion = random(10,20)>>
+			<<set $activeSlave.trust = random(-20,-30)>>
+			<<set $activeSlave.boobs = random(3,10)*100>>
+			<<set $activeSlave.vagina = 1>>
+			<<set $activeSlave.dick = 0>>
+			<<set $activeSlave.foreskin = 0>>
+			<<set $activeSlave.balls = 0>>
+			<<set $activeSlave.ovaries = 1>>
+			<<set $activeSlave.pubicHStyle = "waxed">>
+			<<set $activeSlave.height = random(120,180)>>
+			<<set $activeSlave.shoulders = random(-1,1)>>
+			<<set $activeSlave.hips = 1>>
+			<<set $activeSlave.butt = 1>>
+			<<set $activeSlave.anus = 0>>
+			<<set $activeSlave.weight = 0>>
+			<<set $activeSlave.intelligence = either(-1, 1, 2)>>
+			<<set $activeSlave.intelligenceImplant = 1>>
+			<<set $activeSlave.entertainSkill = 25>>
+			<<set $activeSlave.whoreSkill = 0>>
+			<<set $activeSlave.health = random(30,60)>>
+			<<set $activeSlave.recruiter = 0>>
+			<<set $activeSlave.behavioralFlaw = either("bitchy", "arrogant")>>
+			<<AddSlave $activeSlave>> /* skip New Slave Intro */
 		<</for>>
-	<br><br>
-<</replace>>
+	<</replace>>
 <</link>> // It will cost about ¤25000 to enslave them.//
 <<else>>
 	//You lack the necessary funds to enslave a handful of court ladies.//
 <</if>>
-<br><br>
 <<if $cash >= 15000>>
 <br><<link "Transfer a modest quantity of credits for the Queen herself">>
 	<<replace "#result">>
-	You take a tablet and transmit a communication request to the new arcology owner. It doesn't take long for him to accept but when his video feed connects on your screen, you find yourself staring at the pained expression of the Queen herself. It becomes abundantly clear that someone is mounting her from behind as her body shakes and spasms from the intensity of their thrusts. You note that the Queen appears to be getting fucked on an extravagant, yet bloodstained, four-poster bed, likely the site of her former husband's demise. The mysterious individual unsurprisingly turns out to be the new arcology owner, revealing himself by shoving the Queen's face down against the stained bedsheets as he lowers his own face into frame. "How can I help you?"
-<br><br>
-	The man seems somewhat surprised that you want to purchase the Queen, given the breadth and quality of his other merchandise available, but not unduly so. Soon enough negotiations begin and a short time later an equitable price is agreed upon. Your new peer even throws in a slight discount, in exchange for allowing him to use the Queen himself for the remainder of the night. 
-<br><br>
-	When the Queen arrives at your penthouse, she seems almost relieved and almost basks in the opulence of her new surroundings. Yet, it seems likely that her relief has more to do with saving her from a lifetime of gang rape at the mercy of her former subjects, than it does the familiar luxury. She submits to biometric scanning obediently and without fuss, during which you discover to her surprise that she is pregnant. Since she hasn't begun to show yet, it's unclear whether the child is the former King's or the new arcology owner's. You don't have the means to discern the father of the child, but you notice she cradles her flat stomach protectively nonetheless.
-	<<set $cash -= 15000>>
-		<<include "Generate New Slave">>
+		You take a tablet and transmit a communication request to the new arcology owner. It doesn't take long for him to accept but when his video feed connects on your screen, you find yourself staring at the pained expression of the Queen herself. It becomes abundantly clear that someone is mounting her from behind as her body shakes and spasms from the intensity of their thrusts. You note that the Queen appears to be getting fucked on an extravagant, yet bloodstained, four-poster bed, likely the site of her former husband's demise. The mysterious individual unsurprisingly turns out to be the new arcology owner, revealing himself by shoving the Queen's face down against the stained bedsheets as he lowers his own face into frame. "How can I help you?"
+		<br><br>
+		The man seems somewhat surprised that you want to purchase the Queen, given the breadth and quality of his other merchandise available, but not unduly so. Soon enough negotiations begin and a short time later an equitable price is agreed upon. Your new peer even throws in a slight discount, in exchange for allowing him to use the Queen himself for the remainder of the night. 
+		<br><br>
+		When the Queen arrives at your penthouse, she seems almost relieved and almost basks in the opulence of her new surroundings. Yet, it seems likely that her relief has more to do with saving her from a lifetime of gang rape at the mercy of her former subjects, than it does the familiar luxury. She submits to biometric scanning obediently and without fuss, during which you discover to her surprise that she is pregnant. Since she hasn't begun to show yet, it's unclear whether the child is the former King's or the new arcology owner's. You don't have the means to discern the father of the child, but you notice she cradles her flat stomach protectively nonetheless.
+		<br><br>
+		<<set $cash -= 15000>>
+		<<include "Generate XX Slave">>
 		<<set _origin = "She was the Queen of a royal kingdom, till her husband was overthrown and she was sold to you in exchange for credits.">>
 		<<set $activeSlave.origin = _origin>>
 		<<set $activeSlave.career = "a Queen">>
@@ -205,12 +207,14 @@ Time is short, but you are well placed to acquire some choice slaves. With an ad
 		<<set $activeSlave.entertainSkill = 45>>
 		<<set $activeSlave.whoreSkill = 0>>
 		<<set $activeSlave.health = random(30,60)>>
+		<<set $activeSlave.births = 2>>
+		<<set $activeSlave.recruiter = 0>>
 		<<set $activeSlave.behavioralFlaw = either("bitchy", "arrogant")>>
 		<<include "New Slave Intro">>
-	<br><br>
-<</replace>>
+	<</replace>>
 <</link>> // It will cost about ¤15000 to enslave her.//
 <<else>>
 	//You lack the necessary funds to enslave a queen.//
 <</if>>
 </span>
+

--- a/src/uncategorized/REroyalblood.tw
+++ b/src/uncategorized/REroyalblood.tw
@@ -68,7 +68,7 @@ Time is short, but you are well placed to acquire some choice slaves. With an ad
 		<<set $activeSlave.whoreSkill = 0>>
 		<<set $activeSlave.health = random(30,60)>>
 		<<set $activeSlave.behavioralFlaw = either("bitchy", "arrogant")>>
-		<<AddSlave $activeSlave>>
+		<<include "New Slave Intro">>
 	<br><br>
 <</replace>>
 <</link>> // You will need to utilize a portion of your reputation and ¤50000 to enslave her.//
@@ -113,7 +113,7 @@ Time is short, but you are well placed to acquire some choice slaves. With an ad
 		<<set $activeSlave.combatSkill = 1>>
 		<<set $activeSlave.health = random(30,60)>>
 		<<set $activeSlave.behavioralFlaw = either("bitchy", "arrogant")>>
-		<<AddSlave $activeSlave>>
+		<<include "New Slave Intro">>
 	<br><br>
 <</replace>>
 <</link>> // Purchasing the goods and hiring the VTOLs will cost about ¤35000.//
@@ -158,7 +158,7 @@ Time is short, but you are well placed to acquire some choice slaves. With an ad
 		<<set $activeSlave.whoreSkill = 0>>
 		<<set $activeSlave.health = random(30,60)>>
 		<<set $activeSlave.behavioralFlaw = either("bitchy", "arrogant")>>
-		<<AddSlave $activeSlave>>
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 		<</for>>
 	<br><br>
 <</replace>>
@@ -206,7 +206,7 @@ Time is short, but you are well placed to acquire some choice slaves. With an ad
 		<<set $activeSlave.whoreSkill = 0>>
 		<<set $activeSlave.health = random(30,60)>>
 		<<set $activeSlave.behavioralFlaw = either("bitchy", "arrogant")>>
-		<<AddSlave $activeSlave>>
+		<<include "New Slave Intro">>
 	<br><br>
 <</replace>>
 <</link>> // It will cost about ¤15000 to enslave her.//

--- a/src/uncategorized/bulkSlaveIntro.tw
+++ b/src/uncategorized/bulkSlaveIntro.tw
@@ -67,8 +67,10 @@
 	<</if>>
 	<<goto $returnTo>>
 <<else>>
-	/* DEPRECATED: If looking at 2nd slave, push the induction changes for the prior slave to the newSlave array */
-	/* Not needed because New Slave Intro takes care of adding the new slave by setting nextLink to AS Dump */
+	/* If looking at 2nd slave, push the induction changes for the prior slave to the newSlave array */
+	<<if $newSlaveIndex > 0>>
+		<<AddSlave $activeSlave>>
+	<</if>>
 	<<if $newSlaves.length > 1>>
 		Showing new slave <<print $newSlaveIndex+1>> of <<print $newSlaves.length>>:
 	<</if>>
@@ -85,8 +87,11 @@
 	<br>
 	
 	/* Use existing New Slave Intro */
-	<<set $nextLink = "AS Dump", $returnTo = "Bulk Slave Intro">> /* add new slave and return here after New Slave Intro */
 	<<include "New Slave Intro">> /* calls <<RemoveGingering>> if needed */
+	
+	/* Override nextButton setting from New Slave Intro */
+	<<set $nextButton = "Continue">>
+	<<set $nextLink = "Bulk Slave Intro">>
 	
 	/* Add an option = goto the next slave below the New Slave Intro section */
 	<br><br>

--- a/src/uncategorized/bulkSlaveIntro.tw
+++ b/src/uncategorized/bulkSlaveIntro.tw
@@ -67,10 +67,8 @@
 	<</if>>
 	<<goto $returnTo>>
 <<else>>
-	/* If looking at 2nd slave, push the induction changes for the prior slave to the newSlave array */
-	<<if $newSlaveIndex > 0>>
-		<<AddSlave $activeSlave>>
-	<</if>>
+	/* DEPRECATED: If looking at 2nd slave, push the induction changes for the prior slave to the newSlave array */
+	/* Not needed because New Slave Intro takes care of adding the new slave by setting nextLink to AS Dump */
 	<<if $newSlaves.length > 1>>
 		Showing new slave <<print $newSlaveIndex+1>> of <<print $newSlaves.length>>:
 	<</if>>
@@ -87,11 +85,8 @@
 	<br>
 	
 	/* Use existing New Slave Intro */
+	<<set $nextLink = "AS Dump", $returnTo = "Bulk Slave Intro">> /* add new slave and return here after New Slave Intro */
 	<<include "New Slave Intro">> /* calls <<RemoveGingering>> if needed */
-	
-	/* Override nextButton setting from New Slave Intro */
-	<<set $nextButton = "Continue">>
-	<<set $nextLink = "Bulk Slave Intro">>
 	
 	/* Add an option = goto the next slave below the New Slave Intro section */
 	<br><br>

--- a/src/uncategorized/genericPlotEvents.tw
+++ b/src/uncategorized/genericPlotEvents.tw
@@ -2,7 +2,7 @@
 
 /* GENERIC PLOT EVENTS */
 
-<<set $nextButton = "Continue", $nextLink = "Random Nonindividual Event", $returnTo = "RIE Eligibility Check">>
+<<set $nextButton = "Continue", $nextLink = "Random Nonindividual Event", $returnTo = "Random Nonindividual Event">>
 
 <<switch $Event>>
 <<case "bad curatives">>
@@ -480,7 +480,6 @@ A screen opposite your desk springs to life, <<if $assistant == 0>>showing your 
 <<if $PStrip != 3>>
 	<<if $cash >= $contractCost>>
 	<<link "Enslave her">>
-		<<AddSlave $activeSlave>>
 		<<set $cash -= $contractCost>>
 		<<replace "#result">>
 		<<if $PStrip == 1>>
@@ -488,7 +487,6 @@ A screen opposite your desk springs to life, <<if $assistant == 0>>showing your 
 		<<else>>
 			She smiles with gratitude as the biometric scanners scrupulously record her every particular as belonging not to a person but to a piece of human property. She's seen what Free Cities life is, and she seems to have come to the conclusion that being a slave in the penthouse is better than being a free whore on the lower levels.
 		<</if>>
-		<<set $nextLink = "AS Dump">>
 		<<include "New Slave Intro">>
 		<</replace>>
 	<</link>>
@@ -565,7 +563,6 @@ A screen opposite your desk springs to life, <<if $assistant == 0>>showing your 
 <<case "shoot result">>
 
 <<set $PShoot = 0>>
-<<set $nextLink = "AS Dump">>
 <<include "Generate New Slave">>
 <<set $activeSlave.origin = "You won her at a shotgun match against other arcology owners.">>
 <<set $activeSlave.butt = either(1, 2, 2, 3, 3, 4)>>
@@ -608,7 +605,7 @@ A screen opposite your desk springs to life, <<if $assistant == 0>>showing your 
 	<<set $activeSlave.fetish = "none">>
 	<<set $activeSlave.behavioralFlaw = "arrogant">>
 	<<set $activeSlave.sexualFlaw = "idealistic">>
-	<<AddSlave $activeSlave>>
+	<<AddSlave $activeSlave>> /* skip New Slave Intro */
 	<</replace>>
 <</link>>
 <br><<link "Hit the plush older slave lagging behind">>
@@ -638,7 +635,7 @@ A screen opposite your desk springs to life, <<if $assistant == 0>>showing your 
 	<<set $activeSlave.fetish to "none">>
 	<<set $activeSlave.behavioralFlaw to "bitchy">>
 	<<set $activeSlave.sexualFlaw to "hates anal">>
-	<<AddSlave $activeSlave>>
+	<<AddSlave $activeSlave>> /* skip New Slave Intro */
 	<</replace>>
 <</link>>
 <br><<link "Hit the slave with the tits, pussy and impressive dick">>
@@ -676,7 +673,7 @@ A screen opposite your desk springs to life, <<if $assistant == 0>>showing your 
 	<<set $activeSlave.fetish to "none">>
 	<<set $activeSlave.behavioralFlaw to "none">>
 	<<set $activeSlave.behavioralFlaw to "odd">>
-	<<AddSlave $activeSlave>>
+	<<AddSlave $activeSlave>> /* skip New Slave Intro */
 	<</replace>>
 <</link>>
 
@@ -719,7 +716,7 @@ A screen opposite your desk springs to life, <<if $assistant == 0>>showing your 
 <br><<link "Enslave them all">>
 	<<replace "#result">>
 	<<for $i = 0; $i < _newSlaves.length; $i++>>
-		<<AddSlave _newSlaves[$i]>>
+		<<AddSlave _newSlaves[$i]>> /* skip New Slave Intro - TODO: use Bulk Slave Intro */
 	<</for>>
 	You simply enslave all of the escapees yourself. These slaves will more than make up for the costs you expended, in the long run.
 	<</replace>>

--- a/src/uncategorized/jeSlaveDispute.tw
+++ b/src/uncategorized/jeSlaveDispute.tw
@@ -203,13 +203,11 @@
 	<</replace>>
 	<</link>>
 	<<link "Offer to buy out the contract">>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= $contractCost>>
 	<<replace "#result">>
 	You offer to simply buy out the contract, taking the slave for yourself, letting the slave trader out of her side of the deal, and providing for the daughter's medical care. The trader lets it be known amongst her peers that you will make things right no matter the cost to yourself, @@.green;increasing prosperity.@@ The story of the mother willing to be enslaved gets around quickly, @@.green;capturing the hearts@@ of more romantic citizens. The mother, meanwhile, presents herself for enslavement, @@.hotpink;very grateful@@ that you've saved her daughter's life.
 	<<set $arcologies[0].prosperity += 5>>
 	<<set $rep += 500>>
-	<<set $nextLink = "AS Dump">>
 	<<include "New Slave Intro">>
 	<</replace>>
 	<</link>> //This will cost ¤$contractCost and give you the slave//
@@ -236,13 +234,11 @@
 	<</replace>>
 	<</link>>
 	<<link "Offer to buy out the deal">>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= $contractCost>>
 	<<replace "#result">>
 	You offer to simply buy out the deal, paying the trainer and taking the slave yourself, and letting the buyer out of the payment. The trainer, on the other hand, lets it be known that you support businessmen, who can trust you to ensure they don't come out second best, @@.green;increasing prosperity.@@ The buyer lets you know privately that he recently had a business deal go bad, so he's in a tough cash situation right now; he's so grateful for your assistance in this embarrassing situation that he talks @@.green;effusively@@ for days to anyone who will listen about your discreet administration of the arcology. The slave, meanwhile, arrives at your penthouse, @@.hotpink;rather hopeful@@ that she's going to a good master.
 	<<set $arcologies[0].prosperity += 5>>
 	<<set $rep += 500>>
-	<<set $nextLink = "AS Dump">>
 	<<include "New Slave Intro">>
 	<</replace>>
 	<</link>> //This will cost ¤$contractCost and give you the slave//
@@ -269,13 +265,11 @@
 	<</replace>>
 	<</link>>
 	<<link "Compromise on the compensation and offer to buy out the deal">>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= $contractCost>>
 	<<replace "#result">>
 	You offer to buy out the deal, paying the school and taking the slave yourself, and compromising on the demanded compensation. The citizen was looking forward to using the slave in question for breeding stock; like many breeders he cares deeply about his stable and is mollified by the moderate payment, and speaks @@.green;kindly@@ in public about how you helped an innocent breeder protect his prize bloodlines. The school sends a @@.green;positive note@@ around the industry to the effect that schools trading with your arcology can expect to have excessive claims sensibly reduced.
 	<<set $arcologies[0].prosperity += 3>>
 	<<set $rep += 300>>
-	<<set $nextLink = "AS Dump">>
 	<<include "New Slave Intro">>
 	<</replace>>
 	<</link>> //This will cost ¤$contractCost and give you the slave//
@@ -302,13 +296,11 @@
 	<</replace>>
 	<</link>>
 	<<link "Buy out the contract and enslave her">>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= $contractCost>>
 	<<replace "#result">>
 	You quietly contact the trader and suggest an alternative method of settling the dispute. He is surprised, but agrees readily, chuckling at how the "recalcitrant bitch" is going to be dealt with. To her horror, she finds that your near-total power over deals made in your arcology has been employed to saddle her with additional debts that, under her indentured servitude, she cannot hope to repay. It is then the work of ten minutes to demand payment, and when she cannot pay, demand her body for enslavement. The story of your cunning @@.green;impresses@@ the slave traders, but is @@.red;booed@@ by fairer-minded citizens.
 	<<set $arcologies[0].prosperity += 5>>
 	<<set $rep -= 100>>
-	<<set $nextLink = "AS Dump">>
 	<<include "New Slave Intro">>
 	<</replace>>
 	<</link>> //This will cost ¤$contractCost and give you the slave//
@@ -335,11 +327,9 @@
 	<</replace>>
 	<</link>>
 	<<link "Offer to buy out the contract">>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= $contractCost>>
 	<<replace "#result">>
 	You offer to simply buy out the contract, taking the slave for yourself. This lets the buyer out of buying her, and the slaveowner gets his money; but it soon becomes apparent that what both of them were really looking for is an opportunity to put one over on the other. Neither is pleased to be denied a petty victory, but they both have the sense to keep their mouths shut. The poor slave, meanwhile, appears in the penthouse entryway, @@.hotpink;hopeful@@ that she's been lucky enough to end up in a less abusive situation.
-	<<set $nextLink = "AS Dump">>
 	<<include "New Slave Intro">>
 	<</replace>>
 	<</link>> //This will cost ¤$contractCost and give you the slave//

--- a/src/uncategorized/newSlaveIntro.tw
+++ b/src/uncategorized/newSlaveIntro.tw
@@ -1,6 +1,10 @@
 :: New Slave Intro [nobr]
 
-<<set $showEncyclopedia = 0>>
+<<set $nextButton = "Continue", $showEncyclopedia = 0>>
+
+<<if $nextLink != "AS Dump">>
+	<<set $returnTo = $nextLink, $nextLink = "AS Dump">>
+<</if>>
 
 <<SlaveTitle $activeSlave>>
 
@@ -38,7 +42,7 @@ The legalities completed, ''__@@.pink;$activeSlave.slaveName@@__'' <<if ($active
 	looking shyly at you and blushing.
 <</if>>
 
-<<if $gingering != 0>>
+<<if $gingering != 0 && $beforeGingering != 0 && $beforeGingering.ID == $activeSlave.ID>> /* extra checks to ensure gingering state is not left over from a different slave that was inspected but not purchased */
 	<<set _seed = "sale">>
 	<<if $gingeringDetected == 1>>
 		<<if $gingeringDetection == "slaver">>

--- a/src/uncategorized/newSlaveIntro.tw
+++ b/src/uncategorized/newSlaveIntro.tw
@@ -2,7 +2,7 @@
 
 <<set $nextButton = "Continue", $showEncyclopedia = 0>>
 
-<<if $nextLink != "AS Dump">>
+<<if $nextLink != "AS Dump" && passage() != "Bulk Slave Intro">>
 	<<set $returnTo = $nextLink, $nextLink = "AS Dump">>
 <</if>>
 

--- a/src/uncategorized/pCoupAttempt.tw
+++ b/src/uncategorized/pCoupAttempt.tw
@@ -112,9 +112,10 @@ You are awakened in the middle of the night by a jolt that shakes the entire arc
 <<if $traitor != 0>>
 	$traitor.slaveName was captured and has been returned to you.
 	<<set $traitor.assignmentVisible = 1>>
-	<<set $traitor.assignment = "rest">>
+	<<set $traitor.assignment = "stay confined">>
 	<<set $traitor.health = random(-80,-60)>>
 	<<set $traitor.origin = "She was your slave, but you freed her, which she repaid by participating in a coup attempt against you. It failed, and she is again your chattel.">>
+	<<set $traitor.recruiter = 0>> /* disable relative recruitment event for traitor since we don't have the traitor's original stats */
 	<<AddSlave $traitor>> /* skip New Slave Intro */
 <</if>>
 

--- a/src/uncategorized/pCoupAttempt.tw
+++ b/src/uncategorized/pCoupAttempt.tw
@@ -123,7 +123,7 @@ You are awakened in the middle of the night by a jolt that shakes the entire arc
 	<<set $traitor.assignment = "rest">>
 	<<set $traitor.health = random(-80,-60)>>
 	<<set $traitor.origin = "She was your slave, but you freed her, which she repaid by participating in a coup attempt against you. It failed, and she is again your chattel.">>
-	<<AddSlave $traitor>>
+	<<AddSlave $traitor>> /* skip New Slave Intro */
 <</if>>
 
 <br><br>
@@ -150,7 +150,7 @@ You are awakened in the middle of the night by a jolt that shakes the entire arc
 <br><<link "Enslave all of your prisoners">>
 	<<replace "#result">>
 	<<for $i = 0; $i < _newSlaves.length; $i++>>
-		<<AddSlave _newSlaves[$i]>>
+		<<AddSlave _newSlaves[$i]>> /* skip New Slave Intro */
 	<</for>>
 	You simply enslave all of the prisoners yourself. You will make them pay for attacking your arcology.
 	<</replace>>

--- a/src/uncategorized/pCoupAttempt.tw
+++ b/src/uncategorized/pCoupAttempt.tw
@@ -63,14 +63,6 @@ You are awakened in the middle of the night by a jolt that shakes the entire arc
 	<<set $cash -= Math.trunc($cash*0.2)>>
 	<<set $arcologies[0].prosperity = Math.trunc($arcologies[0].prosperity*0.7)>>
 	<<set $rep += 2000>>
-	<<if $traitor != 0>>
-		<<set $activeSlave = $traitor>>
-		<<set $activeSlave.assignmentVisible = 1>>
-		<<set $activeSlave.assignment = "rest">>
-		<<set $activeSlave.health = random(-80,-60)>>
-		<<set $activeSlave.origin = "She was your slave, but you freed her, which she repaid by participating in a coup attempt against you. It failed, and she is again your chattel.">>
-		<<set _newSlaves.push($activeSlave)>>
-	<</if>>
 	<<for $i = 0; $i < 8; $i++>>
 		<<if random(0,99) < $seeDicks>>
 			<<include "Generate XY Slave">>

--- a/src/uncategorized/pHostageAcquisition.tw
+++ b/src/uncategorized/pHostageAcquisition.tw
@@ -1,13 +1,10 @@
 :: P hostage acquisition [nobr]
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "AS Dump">>
-<<set $returnTo = "RIE Eligibility Check">>
+<<set $nextButton = "Continue", $nextLink = "RIE Eligibility Check", $returnTo = "RIE Eligibility Check">>
 
 <<set $hostageRescued = 0>>
 <<set $activeSlave = $hostage>>
 <<set $activeSlave.ID += 55555>>
-<<AddSlave $activeSlave>>
 
 $activeSlave.slaveName, once
 <<switch $PC.career>>

--- a/src/uncategorized/pInvasion.tw
+++ b/src/uncategorized/pInvasion.tw
@@ -103,7 +103,7 @@ The loose militia lately organized by the arcology owners has been called out to
 <br><<link "Enslave all of your prisoners">>
 	<<replace "#result">>
 	<<for $i = 0; $i < _newSlaves.length; $i++>>
-		<<AddSlave _newSlaves[$i]>>
+		<<AddSlave _newSlaves[$i]>> /* skip New Slave Intro */
 	<</for>>
 	You simply enslave all of your prisoners yourself. These slaves will regret attacking your arcology.
 	<</replace>>

--- a/src/uncategorized/pRaidResult.tw
+++ b/src/uncategorized/pRaidResult.tw
@@ -67,7 +67,7 @@ Out ahead of the main body of refugees there is a small knot moving quickly and 
 <br><<link "Enslave all of the refugees">>
 	<<replace "#result">>
 	<<for $i = 0; $i < _newSlaves.length; $i++>>
-		<<AddSlave _newSlaves[$i]>>
+		<<AddSlave _newSlaves[$i]>> /* skip New Slave Intro */
 	<</for>>
 	You simply enslave all of the refugees yourself. They would have been worse off had you not intervened.
 	<</replace>>

--- a/src/uncategorized/pRivalInitiation.tw
+++ b/src/uncategorized/pRivalInitiation.tw
@@ -4,6 +4,12 @@
 
 <<set $activeSlave = $slaves.find(function(s) { return s.prestigeDesc == "You bankrupted and enslaved her in revenge for her part in the attack on your arcology by the Daughters of Liberty."; })>>
 
+<<if ndef $activeSlave>> /* rival slave is gone */
+
+	<<goto $returnTo>>
+
+<<else>>
+
 This is a special week, the week of your victory. <span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink = passage(), $eventDescription = 1]]">></span> awaits your pleasure. You could certainly do to her anything and everything you usually do to your chattel. You could also do something special to mark the occasion.
 
 <br><br>
@@ -47,4 +53,6 @@ This is a special week, the week of your victory. <span id="name"><<print "[[$ac
 	<</link>>
 <</if>>
 </span>
+
+<</if>> /* def $activeSlave */
 

--- a/src/uncategorized/pRivalryVictory.tw
+++ b/src/uncategorized/pRivalryVictory.tw
@@ -341,7 +341,6 @@ For the first time, you receive a direct call from your rival. You pictured the 
 	<<set $activeSlave.age = random(25,42)>>
 	<<if $activeSlave.age > 35>><<set $activeSlave.ageImplant = 1>><</if>>
 	<<set $activeSlave.pubicHStyle = "waxed">>
-	<<AddSlave $activeSlave>>
 	<<include "New Slave Intro">>
 	<</replace>>
 <</link>>

--- a/src/uncategorized/pRivalryVictory.tw
+++ b/src/uncategorized/pRivalryVictory.tw
@@ -39,7 +39,7 @@ For the first time, you receive a direct call from your rival. You pictured the 
 <br><<link "Refuse">>
 	<<set $nextButton = "Continue">><<UpdateNextButton>> /* unlock Continue button */
 	<<replace "#result">>
-	You coldly decline. "That was a mistake," your rival replies, entering computer command.
+	You coldly decline. "That was a mistake," your rival replies, entering a computer command.
 	<<if $rivalSet != 0>>
 		"All my remaining liquid assets have just been @@.red;carefully dispersed to deny you control of my arcology.@@ You'll get nothing from me." It's true. The financial self-destruction ensures that the fiscal wreckage goes to the arcology's citizens, not you.
 		<<for _prv = 0; _prv < $arcologies.length; _prv++>>
@@ -74,7 +74,7 @@ For the first time, you receive a direct call from your rival. You pictured the 
 	<<set $nextButton = "Continue">><<UpdateNextButton>> /* unlock Continue button */
 	<<replace "#result">>
 	<<set $nextLink = "AS Dump">>
-	You coldly decline. "That was a mistake," your rival replies, entering computer command.
+	You coldly decline. "That was a mistake," your rival replies, entering a computer command.
 	<<if $rivalSet != 0>>
 		"All my remaining liquid assets have just been @@.red;carefully dispersed to deny you control of my arcology.@@ You'll get nothing from me." It's true. The financial self-destruction ensures that the fiscal wreckage goes to the arcology's citizens, not you.
 		<<for _prv = 0; _prv < $arcologies.length; _prv++>>

--- a/src/uncategorized/pSlaveMedic.tw
+++ b/src/uncategorized/pSlaveMedic.tw
@@ -1,8 +1,6 @@
 :: P slave medic [nobr]
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "Random Nonindividual Event">>
-<<set $returnTo = "Random Nonindividual Event">>
+<<set $nextButton = "Continue", $nextLink = "Random Nonindividual Event", $returnTo = "Random Nonindividual Event">>
 
 <<set $slaveMedic = 0>>
 
@@ -52,9 +50,9 @@ When you enter the lounge of their <<if $barracks>>barracks<<else>>main living a
 <</link>>
 <br><<link "Offer a very generous ¤25000 for her">>
 	<<replace "#result">>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= 25000>>
 		"Huh," says the mercenary. "She's popular, but for that we could probably buy two of her. Might be fun to train a couple of new nurses. Let me ask the boys and girls." He speaks into his helmet for a few minutes, and then turns back to you. "Sold. Enjoy, she's a good fuck."
+		<<include "New Slave Intro">>
 	<</replace>>
 <</link>>
 </span>

--- a/src/uncategorized/pSnatchAndGrabResult.tw
+++ b/src/uncategorized/pSnatchAndGrabResult.tw
@@ -2,10 +2,7 @@
 
 <<nobr>>
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "Random Nonindividual Event">>
-
-<<set $PSnatch = 0>>
+<<set $nextButton = "Continue", $nextLink = "Random Nonindividual Event", $returnTo = "Random Nonindividual Event", $PSnatch = 0>>
 
 <<include "Generate XX Slave">>
 <<set $activeSlave.origin = "She is your share of a raid on an illegal laboratory by your mercenaries.">>
@@ -67,9 +64,6 @@ The case prompts you for a handprint code; your hand works just fine. It contain
 
 When you state that, apparently, you are, she climbs out of the case, prostrates herself in the hall before you, and says reverentially into the floor, "I love you, <<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Master<<else>>Mistress<</if>>."
 
-<<set $saleDescription = 0>>\
-<<include "Long Slave Description">>\
-	<<AddSlave $activeSlave>>\
-	<<set $nextLink = "AS Dump">>\
-	<<set $returnTo = "Random Nonindividual Event">>\
+<<set $saleDescription = 0, $applyLaw = 0>>\
+	<<include "Long Slave Description">>\
 	<<include "New Slave Intro">>

--- a/src/uncategorized/peConcubineInterview.tw
+++ b/src/uncategorized/peConcubineInterview.tw
@@ -2,12 +2,7 @@
 
 <<nobr>>
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "AS Dump">>
-<<set $returnTo = "RIE Eligibility Check">>
-
-<<set $activeSlave = $Concubine>>
-<<set $oldRep = $rep>>
+<<set $nextButton = "Continue", $nextLink = "AS Dump", $returnTo = "RIE Eligibility Check", $activeSlave = $Concubine, $oldRep = $rep>>
 
 <</nobr>>\
 \

--- a/src/uncategorized/reAWOL.tw
+++ b/src/uncategorized/reAWOL.tw
@@ -1,6 +1,6 @@
 :: RE AWOL [nobr]
 
-<<set $nextButton = "Continue", $nextLink = "RIE Eligibility Check">>
+<<set $nextButton = "Continue", $nextLink = "RIE Eligibility Check", $returnTo = "RIE Eligibility Check">>
 
 Human soldiers are superior to drones in a number of ways - they have the capability for suspicion, the ability to understand human interactions, and are impervious to the ever-present threat of cyber-warfare. That said, a crucial failing of any sentient warrior is their agency.
 
@@ -86,7 +86,6 @@ Your window of opportunity to act is closing. If you have plans for punishing th
 									<<set $activeSlave.sexualFlaw = "hates men">>
 									<<set $activeSlave.hStyle = "shaved into a mohawk">>
 									<<set $activeSlave.customTat = "She has a number of tattoos from a variety of mercenary companies.">>
-									<<AddSlave $activeSlave>>
 									<<include "New Slave Intro">>
 									<<set $cash -= 5000>>
 								<</replace>>

--- a/src/uncategorized/reFSAcquisition.tw
+++ b/src/uncategorized/reFSAcquisition.tw
@@ -2,10 +2,7 @@
 
 <<nobr>>
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "RIE Eligibility Check">>
-<<set $returnTo = "RIE Eligibility Check">>
-<<set $showEncyclopedia = 1>><<set $encyclopedia = "Enslaving People">>
+<<set $nextButton = "Continue", $nextLink = "RIE Eligibility Check", $returnTo = "RIE Eligibility Check", $showEncyclopedia = 1, $encyclopedia = "Enslaving People">>
 
 <<set $FSAcquisition = $FSAcquisitionEvents.random()>>
 
@@ -527,7 +524,6 @@ The call comes in from an office, and you suppress the urge to check whether $as
 <span id="result">
 <<if $cash >= $contractCost>>\
 <<link "Enslave her">>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= $contractCost>>
 	<<replace "#result">>
 	<<switch $FSAcquisition>>\
@@ -572,13 +568,11 @@ The call comes in from an office, and you suppress the urge to check whether $as
 	<<case "Chinese Revivalist">>\
 	She arrives in a simple, sturdy suit, which she obviously wore in the correct anticipation of immediately removing and never seeing again. She cooperates with the enslavement process as best she can, her glance confident and watchful. She's obviously calculating how to get ahead within this new place, and she pays particularly close attention as the ebb and flow of business through your office brings your various slaves into her view for the first time.
 	<</switch>>\
-	<<set $nextLink = "AS Dump">>\
 	<<include "New Slave Intro">>
 	<</replace>>
 <</link>> //This will cost ¤$contractCost//
 <<link "Sell her immediately">>
 	<<set $cash += $slaveCost>>
-	<<include "Remove activeSlave">>
 	<<replace "#result">>
 	<<switch $FSAcquisition>>\
 	<<case "Pastoralist">>\

--- a/src/uncategorized/reMalefactor.tw
+++ b/src/uncategorized/reMalefactor.tw
@@ -1,11 +1,6 @@
 :: RE malefactor [nobr]
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "RIE Eligibility Check">>
-<<set $returnTo = "RIE Eligibility Check">>
-<<set $showEncyclopedia = 1>><<set $encyclopedia = "Free Cities Justice">>
-
-<<set $applyLaw = 0>>
+<<set $nextButton = "Continue", $nextLink = "RIE Eligibility Check", $returnTo = "RIE Eligibility Check", $showEncyclopedia = 1, $encyclopedia = "Free Cities Justice", $applyLaw = 0>>
 
 <<if $malefactor == "addict">>
 
@@ -193,7 +188,6 @@
 <span id="result">
 <<if $cash >= $contractCost>>
 	<<link "Enslave her">>
-		<<AddSlave $activeSlave>>
 		<<set $cash -= $contractCost>>
 		<<replace "#result">>
 		<<if $malefactor == "addict">>
@@ -209,7 +203,6 @@
 		<<else>>
 			You complete the legalities and biometric scanning quickly and cautiously. Though the would-be liberator is of course restrained, disarmed, and still sedated, she could awake at any time. Based on the drone logs, she is likely to be violent when she does.
 		<</if>>
-		<<set $nextLink = "AS Dump">>
 		<<include "New Slave Intro">>
 		<</replace>>
 	<</link>>
@@ -224,7 +217,6 @@
 				<<set $activeSlave.preg = 1>>
 			<</if>>
 		<</if>>
-		<<AddSlave $activeSlave>>
 		<<set $cash -= $contractCost>>
 		<<replace "#result">>
 		<<if $malefactor == "addict">>
@@ -242,15 +234,14 @@
 		<</if>>
 		<<set $rep += 100>>
 		<<set $arcologies[0].prosperity += 2>>
-		<<set $nextLink = "AS Dump">>
 		<<include "New Slave Intro">>
 		<</replace>>
 	<</link>>
 	<<if $arcade > 0>>
 	<br><<link "Enslave her and sentence her to a month in the arcade">>
+		<<assignJob $activeSlave "be confined in the arcade">>
 		<<set $activeSlave.choosesOwnAssignment = 0>>
 		<<set $activeSlave.sentence = 4>>
-		<<AddSlave $activeSlave>>
 		<<set $cash -= $contractCost>>
 		<<replace "#result">>
 		<<if $malefactor == "addict">>
@@ -267,8 +258,7 @@
 			You complete the legalities and biometric scanning quickly and cautiously. Though the would-be liberator is of course restrained, disarmed, and still sedated, she could awake at any time. It would be best to have her restrained for public use in the arcade first. The public @@.green;looks forward@@ to seeing her there.
 		<</if>>
 		<<set $rep += 50>>
-		<<set $nextLink = "AS Dump">>
-		<<include "New Slave Intro">>
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 		<</replace>>
 	<</link>>
 	<</if>>
@@ -276,7 +266,6 @@
 	<<if $dairyRestraintsSetting > 1>>
 	<br><<link "Enslave her and send her straight to the industrial dairy">>
 		<<assignJob $activeSlave "work in the dairy">>
-		<<AddSlave $activeSlave>>
 		<<set $cash -= $contractCost>>
 		<<replace "#result">>
 		<<if $malefactor == "addict">>
@@ -293,7 +282,7 @@
 			You complete the legalities and biometric scanning quickly and cautiously. The condemned resists installation in $dairyName with energy born of desperation. The public @@.green;accepts@@ this as an appropriate punishment, especially when you release footage of the criminal's <<if ($dairyPregSetting > 1) && ($activeSlave.vagina > 0)>>discomfort as her pussy adapts to industrial reproduction<<elseif $dairyStimulatorsSetting > 1>>discomfort as her anus adapts to accommodate rectal dildo hydration<<else>>breasts as they are roughly milked<</if>>, together with a report on the likely productivity of such a fit body capable of withstanding the stress of high throughput.
 		<</if>>
 		<<set $rep += 50>>
-		<<set $nextLink = "AS Dump">>
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 		<</replace>>
 	<</link>>
 	<</if>>
@@ -304,7 +293,6 @@
 		<<set $activeSlave.amp = 1>>
 		<<set $activeSlave.heels = 0>>
 		<<set $activeSlave.behavioralFlaw = "odd">>
-		<<AddSlave $activeSlave>>
 		<<set $cash -= $contractCost>>
 		<<replace "#result">>
 		<<if $malefactor == "addict">>
@@ -321,7 +309,6 @@
 			An example must be made. Slave ownership is the cornerstone of the society you're building in your arcology, and this woman attempted to undermine it. The protesting malefactor is stripped and stuffed into your remote surgery on public video feed. She begs and pleads until she sees her doom in the form of the surgical machinery, at which point she switches to fighting vainly to escape. Of course, @@.red;her health is affected@@ and the horrible experience has left her @@.red;acting oddly.@@ Then it's off to the penthouse for basic slave induction. The public @@.green;approves of this harshness,@@ since she will scarcely be able to liberate anyone without arms or legs.
 		<</if>>
 		<<set $rep += 100>>
-		<<set $nextLink = "AS Dump">>
 		<<include "New Slave Intro">>
 		<</replace>>
 	<</link>>
@@ -331,12 +318,12 @@
 		<<set $activeSlave.balls = 0>>
 		<<set $activeSlave.devotion -= 25>>
 		<<set $activeSlave.trust -= 25>>
-		<<AddSlave $activeSlave>>
 		<<set $cash -= $contractCost>>
 		<<replace "#result">>
 		Video feeds from your remote surgery are made public as the protesting criminal is strapped down and gelded. She is so utterly broken by this turn of events that you complete the legalities and biometric scanning without fuss. The condemned sobs weakly throughout the process until you grow tired of the whining and apply punishment. Then it's off to the penthouse for basic slave induction. The public @@.green;approves of this harshness,@@ which increases your arcology's prosperity by @@.green;giving it a reputation for swift and terrible justice.@@
 		<<set $rep += 100>>
 		<<set $arcologies[0].prosperity += 10>>
+		<<include "New Slave Intro">>
 		<</replace>>
 	<</link>>
 	<</if>>
@@ -360,7 +347,6 @@
 		An example must be made. Slave ownership is the cornerstone of the society you're building in your arcology, and this woman attempted to undermine it. The protesting bitch is stripped and flogged on the promenade before being escorted bleeding from the arcology. The public @@.green;approves of this harshness.@@
 	<</if>>
 	<<set $rep += 100>>
-	<<set $nextLink = "RIE Eligibility Check">>
 	<</replace>>
 <</link>>
 <<if $malefactor == "liberator">>

--- a/src/uncategorized/reMilfTourist.tw
+++ b/src/uncategorized/reMilfTourist.tw
@@ -2,9 +2,7 @@
 
 <<nobr>>
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "AS Dump">>
-<<set $returnTo = "Next Week">>
+<<set $nextButton = "Continue", $nextLink = "RIE Eligibility Check", $returnTo = "RIE Eligibility Check">>
 
 <<set $subSlave = $eventSlave>>
 

--- a/src/uncategorized/reRecruit.tw
+++ b/src/uncategorized/reRecruit.tw
@@ -1,11 +1,6 @@
 :: RE recruit [nobr]
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "RIE Eligibility Check">>
-<<set $returnTo = "RIE Eligibility Check">>
-<<set $showEncyclopedia = 1>><<set $encyclopedia = "Enslaving People">>
-
-<<set $applyLaw = 0>>
+<<set $nextButton = "Continue", $nextLink = "RIE Eligibility Check", $returnTo = "RIE Eligibility Check", $showEncyclopedia = 1, $encyclopedia = "Enslaving People">>
 
 <<set $recruit = $recruit.random()>>
 
@@ -1427,7 +1422,7 @@ Your desk flags a video message as having potential. It's a desperate refugee fr
 
 <br><br>
 
-<<set $saleDescription = 1>>
+<<set $saleDescription = 1, $applyLaw = 0>>
 <<include "Long Slave Description">>
 <<set $saleDescription = 0>>
 
@@ -1436,7 +1431,6 @@ Your desk flags a video message as having potential. It's a desperate refugee fr
 <span id="result">
 <<if $cash >= $contractCost>>
 <<link "Enslave her">>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= $contractCost>>
 	<<replace "#result">>
 	<<if $recruit == "female recruit">>
@@ -1514,7 +1508,6 @@ Your desk flags a video message as having potential. It's a desperate refugee fr
 	<<else>>
 	She comes immediately from the immigration center to your arcology. You patiently explain the realities of the situation to her. She isn't too bright and it takes a while for things to sink in. The scanners finally do it, though. She sobs as the biometric scanners scrupulously record her every particular as belonging not to a person but to a piece of human property. She tries to resist placing her biometric signature in testament to the truth of her debt, but when you observe that the alternative is death, she complies. The process is completed with a distinct anticlimax: she is one of your slaves now.
 	<</if>>
-	<<set $nextLink = "AS Dump">>
 	<<include "New Slave Intro">>
 	<</replace>>
 <</link>>
@@ -1538,7 +1531,6 @@ Your desk flags a video message as having potential. It's a desperate refugee fr
 <<else>>
 <br><<link "Sell her immediately">>
 	<<set $cash += $slaveCost>>
-	<<include "Remove activeSlave">>
 	<<replace "#result">>
 	<<if $recruit == "female recruit">>
 	You complete the legalities and biometric scanning quickly and without fuss. $activeSlave.slaveName bounces nervously on her heels. Finally she works up her courage and asks, <<if $HeadGirl.clothes != "no clothing">>"Can I have <<if $HeadGirl.clothes == "choosing her own clothes">>a cute outfit<<else>>$HeadGirl.clothes<</if>> like $HeadGirl.slaveName?"<<else>>"Can I work with $HeadGirl.slaveName?"<</if>> Your answer appears in the form of a purchasing agent, here to take her away. As he restrains the disbelieving girl, you tell her she's been purchased by a brothel, so she's going to be fucked about 70,000 times before she gets to be too old and is retired, so she can be sure she won't be bored. She releases a wail of utter despair, quickly cut off by a sturdy bag being fastened over her head.

--- a/src/uncategorized/reRelativeRecruiter.tw
+++ b/src/uncategorized/reRelativeRecruiter.tw
@@ -244,11 +244,9 @@ You look up the $activeSlave.relation. She costs ¤$slaveCost, a bargain, but yo
 	/* update $slaves[$i] (eventSlave) before calling any widgets */
 	<<set $slaves[$i].relation = relationTargetWord($activeSlave)>>
 	<<set $slaves[$i].relationTarget = $activeSlave.ID>>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= $slaveCost>>
 	<<SlaveTitle $eventSlave>>
 	You complete the legalities and biometric scanning quickly and without fuss. $activeSlave.slaveName arrives shortly. The two slaves remember each other only dimly - they parted a long time ago - but they embrace. The devoted $desc explains the situation and encourages her $activeSlave.relation to be a good slave to you. $activeSlave.slaveName looks a little fearful but clearly realizes that she's lucky to be here.
-	<<set $nextLink = "AS Dump">>
 	<<include "New Slave Intro">>
 	<</replace>>
 <</link>>

--- a/src/uncategorized/reShelterInspection.tw
+++ b/src/uncategorized/reShelterInspection.tw
@@ -67,12 +67,10 @@ Not waiting to be greeted, the inspector looks up at the nearest camera and dema
 
 <span id="result">
 <<link "Amusing. Enslave her">>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= $contractCost>>
 	<<replace "#result">>
 	<<if $assistantName == "your personal assistant">>Your personal assistant<<else>>$assistantName<</if>> ushers her into your penthouse and keeps her busy for the few minutes you need to circumvent the Shelter's various legal and contractual defenses to prevent slaveowners from doing exactly what you're doing. Fortunately, you're cleverer and richer than most, and you succeed. You have her brought into your office, and you are pleased to see her. She's not young and she's not pretty, but her suit cannot disguise her big bottom, and she's using the tablet she has clasped protectively against her chest to conceal a huge pair of mature breasts. She knows exactly what's happened, and fixes you with a gimlet stare. "In a couple of months," she says with venom, "when you've filled me full of hormones and drugs and training, and I'm begging you to <<if $PC.dick == 1>>stick your tiny little dick up<<else>>fist<</if>> my asshole, remember this. It'll be conditioning and self-preservation and Stockholm Syndrome talking, not me. I think you're a <<if $PC.title == 1>>sad bastard<<else>>vile cunt<</if>>, and I always will."
 	<<set $shelterAbuse += 10>>
-	<<set $nextLink = "AS Dump">>
 	<<include "New Slave Intro">>
 	<</replace>>
 <</link>> //This will cost ¤$contractCost//
@@ -80,12 +78,11 @@ Not waiting to be greeted, the inspector looks up at the nearest camera and dema
 <br><<link "The slave is attached to a milking machine, and so will be the inspector">>
 	<<assignJob $activeSlave "work in the dairy">>
 	<<set $activeSlave.clothes = "no clothing">>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= $contractCost/2>>
 	<<replace "#result">>
 	$subSlave.slaveName is attached to a milking machine, so it would be extremely unwise to let the inspector report on $subSlave.slaveName's industrial fate in all its gorgeous productivity. So, you greet her politely, and bring her down to $dairyName to show her $subSlave.slaveName. The inspector has a single moment to stiffen in shock at the sight before she stiffens involuntarily due to the security drone tazing her unconscious. It takes a few credits here and there to circumvent the Shelter's various legal and contractual defenses to prevent slaveowners from doing exactly what you're doing, but you finish the day richer by one more big-boobed milk producer. You leave the inspector's drug dosage low to start, so she can appreciate her situation for a while. When the inspector awakes, her visor is set to show an overhead view of her bay in $dairyName. She sees her breasts, already larger than she remembers, gently swaying with the pumping of the milkers.<<if $dairyFeedersSetting > 1>> She sees the huge phallus occupying her mouth, and feels nutrition sliding down her throat.<</if>><<if $dairyPregSetting > 1>> She sees her vagina drooling as it's fucked in preparation for pregnancy.<</if>><<if $dairyPregSetting > 1>> She sees a massive piston moving slowly back and forth beneath her buttocks, and understands what the ache of impossible fullness in her bottom is.<</if>> Her hands ball into fists.
 	<<set $shelterAbuse += 10>>
-	<<set $nextLink = "AS Dump">>
+	<<AddSlave $activeSlave>> /* skip New Slave Intro */
 	<</replace>>
 <</link>> //This will cost ¤<<print $contractCost/2>>//
 <</if>>

--- a/src/uncategorized/reShippingContainer.tw
+++ b/src/uncategorized/reShippingContainer.tw
@@ -52,7 +52,7 @@ For now, the crowd around you is looking at the helpless human cargo with
 <br><<link "Keep them">>
 	<<replace "#result">>
 	<<for $i = 0; $i < _newSlaves.length; $i++>>
-		<<AddSlave _newSlaves[$i]>>
+		<<AddSlave _newSlaves[$i]>> /* skip New Slave Intro */
 	<</for>>
 	You announce that the shipment is in violation of shipping and slave market regulations, and is being confiscated. There's a certain @@.red;disappointment@@ in the crowd that nothing more interesting came of it, but it's minor when compared to the chattel you just seized.
 	<<set $rep -= 50>>
@@ -65,7 +65,7 @@ For now, the crowd around you is looking at the helpless human cargo with
 		<<if _newSlaves[$i].vagina > -1>><<set _newSlaves[$i].vagina = 3>><</if>>
 		<<set _newSlaves[$i].anus = 3>>
 		<<set _newSlaves[$i].health -= 20>>
-		<<AddSlave _newSlaves[$i]>>
+		<<AddSlave _newSlaves[$i]>> /* skip New Slave Intro */
 	<</for>>
 	You use the container handling systems to segregate the obvious menials from the those with any potential as sex slaves. The menials go into a different container, which is whisked off, leaving a little shivering knot of frightened bodies, vulnerable and naked. The crowd watched all this with good humor, and there's silence enough that everyone hears your quiet announcement. You announce that the shipment is in violation of shipping and slave market regulations, and is being confiscated; however, you don't expect to see these particular slaves delivered to your penthouse for a couple of hours. Then you turn your back and walk away. The crowd gives a kind of @@.green;appreciative howl@@ which, understandably, produces a wail of terror from the slaves. As you head off, the sobbing turns into screaming. It sounds like your new slaves might be a bit stretched out, here and there.
 	<<set $rep += 200>>

--- a/src/uncategorized/resFailure.tw
+++ b/src/uncategorized/resFailure.tw
@@ -74,7 +74,7 @@
 		<<set $activeSlave.behavioralFlaw = either("none")>>
 		<<set $activeSlave.hStyle = "tails">>
 		<<set $activeSlave.customTat = "She has the simple logo of the corporation that operates The Slavegirl School tattooed on her left cheek.">>
-		<<AddSlave $activeSlave>>
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 	<</for>>
 <<elseif $RESFailure == "GRI">>
 	<<set $GRI.schoolPresent = 0>>
@@ -122,7 +122,7 @@
 		<<set $activeSlave.hStyle = "shaved">>
 		<<set $activeSlave.hLength = 0>>
 		<<set $activeSlave.customTat = "She has a barcode that identified her when she was a test subject at the Growth Research Institute tattooed on her left cheek.">>
-		<<AddSlave $activeSlave>>
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 	<</for>>
 <<elseif $RESFailure == "SCP">>
 	<<set $SCP.schoolPresent = 0>>
@@ -188,7 +188,7 @@
 		<<if $activeSlave.race != "white">><<set $activeSlave.race = "surgically altered to look white">><</if>>
 		<<set $activeSlave.skin = "tanned">>
 		<<set $activeSlave.customTat = "She has the coat of arms of St. Claver Preparatory tattooed on her left cheek.">>
-		<<AddSlave $activeSlave>>
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 	<</for>>
 <<elseif $RESFailure == "LDE">>
 	<<set $LDE.schoolPresent = 0>>
@@ -246,7 +246,7 @@
 		<<set $activeSlave.hStyle = "tails">>
 		<<set $activeSlave.hLength = 100>>
 		<<set $activeSlave.customTat = "She has the buttock-shaped symbol of the École des Enculées that created her tattooed on her left cheek.">>
-		<<AddSlave $activeSlave>>
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 	<</for>>
 <<elseif $RESFailure == "TGA">>
 	<<set $TGA.schoolPresent = 0>>
@@ -297,7 +297,7 @@
 		<<set $activeSlave.hStyle = "short">>
 		<<set $activeSlave.hLength = 2>>
 		<<set $activeSlave.customTat = "She has the baroque crest of the Gymnasium-Academy that trained her branded into her left cheek.">>
-		<<AddSlave $activeSlave>>
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 	<</for>>
 <<else>>
 	<<set $TFS.schoolPresent = 0>>
@@ -450,7 +450,7 @@
 		<<set $activeSlave.hLength = 150>>
 		<<set $activeSlave.customTat = "She has a simple pink heart tattooed on her right temple.">>
 		<<set $REFutaSisterCheckinIDs.push($activeSlave.ID)>>
-		<<AddSlave $activeSlave>>
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 	<</for>>
 	<<include "Generate XY Slave">>
 	<<set $activeSlave.origin to "She was the leader of your arcology's Futanari Sisters until you engineered her community's failure and enslavement.">>
@@ -517,7 +517,7 @@
 	<<set $activeSlave.hStyle = "neat">>
 	<<set $activeSlave.hLength = 150>>
 	<<set $activeSlave.customTat = "She has a simple pink heart tattooed on her right temple.">>
-	<<AddSlave $activeSlave>>
+	<<AddSlave $activeSlave>> /* skip New Slave Intro */
 <</if>>
 
 <<if $RESFailure == "TSS">>
@@ -564,6 +564,7 @@ The failure of a prominent organization within your arcology has @@.red;affected
 	<<replace "#result">>
 	<<nobr>>
 	<<for $i = 0; $i < $slaves.length; $i++>>
+	<<set $activeSlave = $slaves[$i]>>
 	<<if $RESFailure == "TSS">>
 		<<if ($slaves[$i].origin == "She was given to you by a failed branch campus of The Slavegirl School right after her majority.") || ($slaves[$i].origin == "She was given to you by a failed branch campus of The Slavegirl School after she was retrained as a slave girl.")>>
 		<<slaveCost $slaves[$i]>>

--- a/src/uncategorized/seCoursing.tw
+++ b/src/uncategorized/seCoursing.tw
@@ -580,7 +580,7 @@ You place your hand on the leash's quick release and whisper your direction into
 	<</if>>
 	<<set $Lurcher.penetrativeCount += 1>>
 	<<set $penetrativeTotal += 1>>
-	<<AddSlave $activeSlave>>
+	<<AddSlave $activeSlave>> /* skip New Slave Intro */
 <<else>>
 	<<if $Lurcher.devotion > 50>>
 	She makes her way back to you dejectedly, hanging her head.
@@ -891,7 +891,7 @@ You place your hand on the leash's quick release and whisper your direction into
 	<</if>>
 	<<set $Lurcher.penetrativeCount += 1>>
 	<<set $penetrativeTotal += 1>>
-	<<AddSlave $activeSlave>>
+	<<AddSlave $activeSlave>> /* skip New Slave Intro */
 <<else>>
 	<<if $Lurcher.devotion > 50>>
 	She makes her way back to you dejectedly, hanging her head.
@@ -1202,7 +1202,7 @@ You place your hand on the leash's quick release and whisper your direction into
 	<</if>>
 	<<set $Lurcher.penetrativeCount += 1>>
 	<<set $penetrativeTotal += 1>>
-	<<AddSlave $activeSlave>>
+	<<AddSlave $activeSlave>> /* skip New Slave Intro */
 <<else>>
 	<<if $Lurcher.devotion > 50>>
 	She makes her way back to you dejectedly, hanging her head.

--- a/src/uncategorized/seCustomSlaveDelivery.tw
+++ b/src/uncategorized/seCustomSlaveDelivery.tw
@@ -2,10 +2,7 @@
 
 <<nobr>>
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "Scheduled Event">>
-<<set $returnTo = "Scheduled Event">>
-<<set $showEncyclopedia = 1>><<set $encyclopedia = "Enslaving People">>
+<<set $nextButton = "Continue", $nextLink = "Scheduled Event", $returnTo = "Scheduled Event", $showEncyclopedia = 1, $encyclopedia = "Enslaving People">>
 
 <<set $customSlaveOrdered = 0>>
 
@@ -95,8 +92,6 @@ Her price is ¤<<print $slaveCost>>.
 	<<set $cash -= $slaveCost>>
 	<<replace "#result">>
 	She has been reasonably broken by the dealer that offered her to you. She has also picked up on the fact that she was specially selected, and is a little hopeful that this means she may be treated well. She is now awaiting your instructions.
-	<<set $nextLink = "AS Dump">>\
-	<<set $returnTo = "Random Nonindividual Event">>\
 	<<include "New Slave Intro">>
 	<</replace>>
 <</link>>

--- a/src/uncategorized/seRecruiterSuccess.tw
+++ b/src/uncategorized/seRecruiterSuccess.tw
@@ -2,13 +2,7 @@
 
 <<nobr>>
 
-<<set $nextButton = "Continue">>
-<<set $nextLink = "Scheduled Event">>
-<<set $returnTo = "Scheduled Event">>
-<<set $showEncyclopedia = 1>><<set $encyclopedia = "Enslaving People">>
-<<set $recruiterProgress = 0>>
-
-<<set $applyLaw = 0>>
+<<set $nextButton = "Continue", $nextLink = "Scheduled Event", $returnTo = "Scheduled Event", $showEncyclopedia = 1, $encyclopedia = "Enslaving People", $recruiterProgress = 0>>
 
 <<if $recruiterTarget == "young migrants">>
 
@@ -187,24 +181,20 @@ Your recruiter $Recruiter.slaveName has succeeded; she's convinced a desperate o
 <</nobr>>\
 \
 
-<<set $saleDescription = 1>>\
+<<set $saleDescription = 1, $applyLaw = 0>>\
 <<include "Long Slave Description">>\
 <<set $saleDescription = 0>>\
 
 <span id="result">
 <<if $cash >= $contractCost>>\
 <<link "Enslave her">>
-	<<AddSlave $activeSlave>>
 	<<set $cash -= $contractCost>>
 	<<replace "#result">>
-	<<set $nextLink = "AS Dump">>\
-	<<set $returnTo = "Nonrandom Event">>\
 	<<include "New Slave Intro">>
 	<</replace>>
 <</link>> //This will cost ¤$contractCost//
 <<link "Sell her immediately">>
 	<<set $cash += $slaveCost>>
-	<<include "Remove activeSlave">>
 	<<replace "#result">>
 	$activeSlave.slaveName accepts being resold without much fuss. She's merely exchanged one unknown owner for another. For all she knows her new buyer will be less abusive than you would have been. She would be less complacent if she knew who her buyers are; she'll be immured in an arcade within the hour.
 	<</replace>>

--- a/src/uncategorized/slaveMarkets.tw
+++ b/src/uncategorized/slaveMarkets.tw
@@ -127,18 +127,14 @@ You visit the slave markets off the arcology plaza. It's always preferable to ex
 <<if $slavesSeen > $slaveMarketLimit>><<set $slaveCost += $slaveCost*(($slavesSeen-$slaveMarketLimit)*0.1)>><</if>>
 
 <<if $slaveMarket == "neighbor">>
-	<<for $i = 0; $i < $arcologies.length; $i++>>
-	<<if $arcologies[$i].direction == $direction>>
 	<<if $opinion != 0>>
 		<<set $slaveCost -= Math.trunc($slaveCost*$opinion*0.05)>>
 		<<if $opinion > 2>>
-			Your cultural ties with ''$arcologies[$i].name'' helps keep the price reasonable.
+			Your cultural ties with ''$arcologies[$numArcology].name'' helps keep the price reasonable.
 		<<elseif $opinion < -2>>
-			Your social misalignment with ''$arcologies[$i].name'' drives up the price.
+			Your social misalignment with ''$arcologies[$numArcology].name'' drives up the price.
 		<</if>>
 	<</if>>
-	<</if>>
-	<</for>>
 <</if>>
 
 <<set $slaveCost = 500*Math.trunc($slaveCost/500)>>

--- a/src/utility/slaveCreationWidgets.tw
+++ b/src/utility/slaveCreationWidgets.tw
@@ -114,8 +114,10 @@
 	Called from newSlaveIntro, lawCompliance
 %/
 <<widget "RemoveGingering">>
-	<<if $gingering != 0>>
+	<<if $gingering != 0 && $beforeGingering != 0 && $activeSlave != 0 && $beforeGingering.ID == $activeSlave.ID>> /* extra checks to ensure gingering state is not left over from a different slave that was inspected but not purchased */
 		<<set $activeSlave = $beforeGingering, $beforeGingering = 0>>
+	<<else>>
+		<<set $gingering = 0, $beforeGingering = 0>> /* clear left over state from a different slave without modifying activeSlave */
 	<</if>>
 <</widget>>
 


### PR DESCRIPTION
fixed gingering state carrying over to different slaves when a gingered slave is inspected but not purchased (slaveCreationWidgets + newSlaveIntro); also changed New Slave Intro to set nextLink to AS Dump if not already set (New Slave Intro will first set returnTo to nextLink to preserve original passage sequence - this ensures that New Slave Intro's changes to slave stats will not be lost, as was happening in several events that called AddSlave first - however this breaks Bulk Slave Intro's dependency on $returnTo being unchanged, so New Slave Intro will check passage() and avoid setting nextLink/returnTo if it is Bulk Slave Intro as a special case); no changes to Bulk Slave Intro itself; cleaned up various occurrences of (now unnecessary) setting nextLink to AS Dump / calling AddSlave / including New Slave Intro for consistency and to avoid losing New Slave Intro stat changes; corrected dangerous nextLink = "Next Week" in reMilfTourist (which appears to be an unused event); added New Slave Intro to RE Royal Blood event for single-slave acquisitions only; added New Slave Intro to P slave medic event; also corrected some misuse of "Remove activeSlave" (RES Failure - did not set $activeSlave before removing) (reFSAcquisition - the slave being removed hadn't been added yet); fixed a couple of places where scheduled events were not looping back to scheduled event again, so if you have a recruitment success plus special slave order in the same week, for example, you will now see both results in the same week