### PR TITLE
activeSlave.recruiter bugfixes

### DIFF
--- a/src/uncategorized/newSlaveIntro.tw
+++ b/src/uncategorized/newSlaveIntro.tw
@@ -100,7 +100,7 @@ The legalities completed, ''__@@.pink;$activeSlave.slaveName@@__'' <<if ($active
 	<<set $activeSlave.recruiter = "daughter">>
 <<elseif ($activeSlave.age < 43) && (random(1,100) <= 20)>>
 	<<set $activeSlave.recruiter = "older sister">>
-<<elseif ($activeSlave.age < 25) && ($activeSlave.age > 18) && (random(1,100) <= 20)>>
+<<elseif ($activeSlave.age < 25) && (random(1,100) <= 20)>>
 	<<set $activeSlave.recruiter = "young sister">>
 <</if>>
 <</if>>

--- a/src/uncategorized/newSlaveIntro.tw
+++ b/src/uncategorized/newSlaveIntro.tw
@@ -98,7 +98,7 @@ The legalities completed, ''__@@.pink;$activeSlave.slaveName@@__'' <<if ($active
 	<<set $activeSlave.recruiter = "mother">>
 <<elseif ($activeSlave.age < 24) && (random(1,100) <= 40)>>
 	<<set $activeSlave.recruiter = "daughter">>
-<<elseif ($activeSlave.age < 43) && (random(1,100) <= 20)>>
+<<elseif ($activeSlave.age < 43) && ($activeSlave.age > 18) && (random(1,100) <= 20)>>
 	<<set $activeSlave.recruiter = "older sister">>
 <<elseif ($activeSlave.age < 25) && (random(1,100) <= 20)>>
 	<<set $activeSlave.recruiter = "young sister">>

--- a/src/uncategorized/reRelativeRecruiter.tw
+++ b/src/uncategorized/reRelativeRecruiter.tw
@@ -26,9 +26,9 @@ $eventSlave.slaveName requests an interview with you. She's a devoted slave, and
 <<case "daughter">>
 	her mother has been enslaved. She was free the last $eventSlave.slaveName knew of her, but now she's heard a rumor through other slaves that her mother will go up for sale soon.
 <<case "older sister">>
-	her older sister is being sold. She was likely to be enslaved the last $eventSlave.slaveName knew of her, and now she's heard a rumor through other slaves that her big sister is going to be sold to a new owner.
+	her younger sister is being sold. She was likely to be enslaved the last $eventSlave.slaveName knew of her, and now she's heard a rumor through other slaves that her big sister is going to be sold to a new owner.
 <<case "young sister">>
-	her younger sister is being sold. She was likely to be enslaved the last $eventSlave.slaveName knew of her, and now she's heard a rumor through other slaves that her little sister is going to be sold to a new owner.
+	her older sister is being sold. She was likely to be enslaved the last $eventSlave.slaveName knew of her, and now she's heard a rumor through other slaves that her little sister is going to be sold to a new owner.
 <<default>>
 	she has a twin sister, who was still free the last $eventSlave.slaveName knew of her. She's heard a rumor through other slaves that her twin has finally been enslaved, and will soon go up for sale.
 <</switch>>
@@ -151,17 +151,17 @@ She waits anxiously for your decision.
 <<case "older sister">>
 	<<set $activeSlave.origin = "She was recruited into your service by her older sister.">>
 	<<if $activeSlave.ovaries == 1>>
-		<<set $activeSlave.boobs += 200>>
-		<<set $activeSlave.butt += 1>>
-	<</if>>
-	<<set $activeSlave.age = $activeSlave.age+2>>
-<<case "young sister">>
-	<<set $activeSlave.origin = "She was recruited into your service by her younger sister.">>
-	<<if $activeSlave.ovaries == 1>>
 		<<set $activeSlave.boobs = Math.trunc($activeSlave.boobs-200,0,25000)>>
 		<<set $activeSlave.butt = Math.trunc($activeSlave.butt-1,0,10)>>
 	<</if>>
 	<<set $activeSlave.age = $activeSlave.age-2>>
+<<case "young sister">>
+	<<set $activeSlave.origin = "She was recruited into your service by her younger sister.">>
+	<<if $activeSlave.ovaries == 1>>
+		<<set $activeSlave.boobs += 200>>
+		<<set $activeSlave.butt += 1>>
+	<</if>>
+	<<set $activeSlave.age = $activeSlave.age+2>>
 <<default>>
 	<<set $activeSlave.origin = "She was recruited into your service by her twin sister.">>
 <</switch>>


### PR DESCRIPTION
activeSlave.recruiter bugfixes for consistency.

Previously the coders seem to waffle on what $activeSlave.recruiter == young sister means. Sometimes it's treated as if the activeSlave is the younger sister, sometimes it's treated as if the recruited slave is the younger sister. Now the code should be consistent. If $activeSlave.recruiter is young sister, then it is the $activeSlave who is the younger sister. If $activeSlave.recruiter is older sister, then $activeSlave is the older sister.

Also, in newSlaveIntro, moved the check for age > 18 to older sister. It doesn't make sense for the age check to happen for the young sister value.