### PR TITLE
New Future Society Events Framework

### DIFF
--- a/src/uncategorized/REFS.tw
+++ b/src/uncategorized/REFS.tw
@@ -1,0 +1,196 @@
+:: REFS [nobr]
+
+<<set $nextButton = "Continue", $nextLink = "AS Dump", $returnTo = "Next Week">>
+
+<<set $REFSevent = $REFSevent.random()>>
+
+<<SlaveTitle $activeSlave>>
+<<Enunciate $activeSlave>>
+
+<<switch $REFSevent>>
+
+<<case "transformation fetishism encounter">>
+
+As a result of $arcologies[0].name's adoption of transformation fetishism, a number of plastic surgery clinics, cosmetic surgeries and other transformative businesses have begun to crop up around the arcology's various promenades and shopping districts. Largely, the citizens of $arcologies[0].name have taken to the idea of altering their bodies with a gusto - though not all are so quick to adopt the trend, just because it's in vogue.
+<br><br>
+On one particular outing, you come across a female citizen outside a surgery clinic staring pensively up at a poster advertising the variety of cosmetic procedures on offer in the institution. The citizen's expression is wistful, if somewhat grave, and at odds with the display above her lit up with silicone breasts, plump bee-stung lips and fake asses. From her unaltered appearance and simple garments, it is likely that she is not one of the arcology's wealthier denizens and thus is unable to shape her body to her heart's desire.
+
+<<case "body purism encounter">>
+
+As a result of $arcologies[0].name's adoption of body purism, a number of restorative spas, implant removal clinics and other cleansing businesses have begun to crop up around the arcology's various promenades and shopping districts. Largely, the citizens of $arcologies[0].name have taken to the idea of treating their bodies with sanctity - though not all are so quick to adopt the trend, just because it's in vogue.
+<br><br>
+On one particular outing, you come across a female citizen outside a famous health spa staring pensively up at a poster advertising the variety of purification procedures on offer in the institution. The citizen's expression is wistful, if somewhat grave, and at odds with the display above her lit up with pure unadulterated bodies, expensive health treatments and a plethora of natural cosmetic procedures. The citizens clothes are ragged and sheer, revealing a number of implant scars around her bust and rear, likely from a costly attempt to render herself fashionable by having her prior implants removed. As a result, it is unlikely that she is among one of the arcology's wealthier denizens, having paid the price to return her body to it's natural, unimplanted state.
+
+<<case "youth preferentialist encounter">>
+
+Your excursions out of your penthouse and into the arcology as a whole often put you in close proximity with citizens from all levels of the social strata. After all, they themselves have their own lives to live within the walls of $arcologies[0].name. 
+<br><br>
+On this particular outing you happen to cross paths with a nubile young woman, accompanied by her father. From her plain clothes and rudimentary makeup, it is readily apparent that she is not one of the arcology's well to do inhabitants. She recognizes you quickly and dips her head in deference to your high status, <<if ($PC.age == 3)>>her cheeks flushed in embarrassment and delight at an aged arcology owner's interest in a young girl like her<<else>>her expression awestruck by the presence of an arcology owner before her<</if>>.
+
+<<case "maturity preferentialist encounter">>
+
+Your excursions out of your penthouse and into the arcology as a whole often put you in close proximity with citizens from all levels of the social strata. After all, they themselves have their own lives to live within the walls of $arcologies[0].name. 
+<br><br>
+On this particular outing you happen to cross paths with a comely female citizen and her two adult sons. From her plain clothes and conspicuous lack of makeup, it is readily apparent that she is not one of the arcology's well to do inhabitants. She recognizes you quickly and dips her head in deference to your high status, <<if ($PC.age == 1)>>her cheeks flushed in embarrassment and confusion at a young arcology owner's interest in an old lady like her<<else>>her expression awestruck by the presence of an arcology owner before her<</if>>.
+
+<<default>>
+	ERROR: bad event
+<</switch>>
+
+<br><br>
+<span id="result">
+<<switch $REFSevent>>
+
+<<case "transformation fetishism encounter">>
+
+<span id="result">
+<<link "Keep walking">>
+	<<replace "#result">>
+	It's unfortunate that this citizen is unable to realize her dreams, but that's the way of the Free Cities. There are winners, and there are losers.
+	<</replace>>
+<</link>>
+<<if $cash >= 1000>>
+<br><<link "Pay for her treatment">>
+	<<replace "#result">>
+	It takes a moment for you to convince the woman that you aren't playing some cruel joke on her, but once you do she practically squeels with joy as you take her through the doors of the clinic and announce your intent to pay to give your loyal citizen the absolute transformative works. When you next see her it's on a gurney as she's wheeled out of the surgery, her patient's gown jutting out from her chest due to the size of her new rack. Through swollen lips she gushes to you about how great she feels to finally be a veritable bimbo, and how she's going to tell every citizen she fucks in the $arcologies[0].name @@.green;that they have you to thank for her new body@@.
+	<<set $rep += 1000>>
+	<</replace>>
+<</link>> // The treatment will cost ¤1000.//
+<</if>>
+<br><<link "Offer to enhance her in your remote surgery in exchange for a fuck">>
+	<<replace "#result">>
+	You make your presence known to citizen, and once the usual shock and disbelief have worn off the citizen rapidly agrees to your proposal. She follows you back to the penthouse where you inform $assistantName that the citizen is to be given the works in the remote surgery. As the citizen passes through the doors to the surgery, she turns and blows you a kiss of gratitude.
+	<br><br>
+	When the citizen is later delivered to your private suite to uphold her end of the bargain, she does so as the veritable image of a perfect bimbo slut. In her rush to come thank you for transforming her from her plain and plebian appearance she has evidently neglected to clothe herself, so you can admire her new firm tits, plump ass and bee-stung lips from the moment she enters the room. Despite being fresh from surgery, she's an exquisite fuck and an enthusiastic partner - citizens like her often are, given that penetration from a slave would be a social suicide.
+	<br><br><span id="result2">
+	<<link "Enslave her afterwards">>
+	<<replace "#result2">>
+	As your new playmate lays slumbering in bed, you consult with $assistantName as to the cost of the surgery conducted today. Together, with some creative account, you are able to charge the citizen in excess of her financial means for the surgery conducted on her today. When she awakes, though she will retain her new bimbo body, she will be just another slave in your penthouse.
+	<<display "Generate New Slave">>
+	<<set $activeSlave.origin = "She was enslaved by you when you overcharged her for surgery">>
+	<<set $activeSlave.devotion = random(-70,-55)>>
+	<<set $activeSlave.trust = random(-45,-25)>>
+	<<set $activeSlave.age = random(18,22)>>
+	<<set $activeSlave.health = random(10,20)>>
+	<<set $activeSlave.boobs += 600>>
+	<<set $activeSlave.boobsImplant = 600>>
+	<<set $activeSlave.butt += 1>>
+	<<set $activeSlave.buttImplant = 1>>
+	<<set $activeSlave.lips += 10>>
+	<<set $activeSlave.lipsImplant = 10>>
+	<<AddSlave $activeSlave>>
+	<</replace>>
+	<</link>>
+	</span>
+	<</replace>>
+	<</link>>
+
+
+<<case "body purism encounter">>
+
+<span id="result">
+<<link "Keep walking">>
+	<<replace "#result">>
+	It's unfortunate that this citizen is unable to realize her dreams, but that's the way of the Free Cities. There are winners, and there are losers.
+	<</replace>>
+<</link>>
+<<if $cash >= 1000>>
+<br><<link "Pay for a day of treatment for her">>
+	<<replace "#result">>
+	It takes a moment for you to convince the woman that you aren't playing some cruel joke on her, but once you do she practically squeals with joy as you take her through the doors of the spa and announce your intent to pay for a day of cleansing, pampering and luxury. When you next see her it's on a wallscreen television at your penthouse praising you profusely. The rejuvenated young woman has clearly spread word of your generosity @@.green;across $arcologies[0].name@@.
+	<<set $rep += 1000>>
+	<</replace>>
+<</link>> // The treatment will cost ¤1000.//
+<</if>>
+<<if ($Attendant != 0)>>
+<br><<link "Give her a day of pampering with your attendant at your spa">>
+	<<replace "#result">>
+	You make your prescence known to citizen, and once the usual shock and disbelief have worn off it takes a moment to convince her that your offer of a cleansing experience in your spa is neither a cruel joke nor an underhanded attempt to enslave her. She follows you back to the penthouse where you inform your attendant that the citizen is to be sequestered in the spa for a day of pampering, cleansing and rejuvenation. As the citizen passes through the doors to the spa, she turns and blows you a kiss of gratitude.
+	<br><br>
+	When you stop by the spa later in the day, you spot the citizen luxuriating in a hot bath with a number of colorful health products spread across every visible surface of her nude skin. From where you stand it is clear her eyes are closed in immense contentment, while her body floats relaxed and carefree in the bubbling water. When the citizen finally departs at the end of the a long day of purification in the spa, she thanks you profusely and promises to tell everyone she can of your @@.green;generosity@@.
+	<<set $rep += 300>>
+	<</replace>>
+<</link>>
+<</if>>
+</span>
+
+<<case "youth preferentialist encounter">>
+
+<span id="result">
+<<link "Let them pass">>
+	<<replace "#result">>
+	You step aside gracefully and bow your head, while signifying to the girl that you intend to allow her to pass you. She seems taken aback by your geniality, especially given the gulf in social standing between the two of you, and has to be chaperoned from your presence by her father. Nonetheless, she is struck by her chance encounter with you and cannot stop recounting the story to all her friends, soon @@.green;the anecdote has seized the imaginations of $arcologies[0].name's youthful, femalze citizens@@. 
+	<<set $rep += 100>>
+	<</replace>>
+<</link>>
+<br><<link "Fuck her over dinner">>
+	<<replace "#result">>
+	It takes a moment for you to convince the young girl and her father that you aren't playing some cruel joke on them, but once you do she enthusiastically agrees to be your companion for the evening. With a pretty young thing on your arm for the rest of the night, and her father trailing behind the two of you at a respectful distance, you take $arcologies[0].name by storm amidst a flurry of speculative whispers and contemplative rumors. Later that night, you conclude your date with a pleasant meal at one of $arcologies[0].name's choicest restaurants with fine dining and even finer conversation. To the credit of her father, they politely continue eating their dinner without batting an eye when you <<if $PC.dick == 0>>don a strap-on and <</if>>take their daughter over the dinner table. When you part ways, the young girl is clearly smitten with you - so it's no wonder that by the next day the story of your encounter has @@.green;spread across $arcologies[0].name like wildfire@@.
+	<<set $rep += 500>>
+	<</replace>>
+<</link>>
+<br><<link "Manipulate her into having sex with you">>
+	<<replace "#result">>
+	It only takes a moment for $assistantName to uncover the father's financial records and the copious debt therein, and only another moment for you to browbeat the terrified father into allowing his daughter to sleep with you under threat of purchasing all their debt and summarily enslaving her. 
+	<br><br>
+	Once you both retire to your private suite, you peel the girl's clothes off as easily as one might shed a gift of it's wrapping. In the nude her body is tastefully youthful, with narrow hips, firm breasts, and a delicate blush across her shamefaced, rosy cheeks. Despite the circumstances of your sexual conquest of her, she seems to enjoy the fuck well enough by the sounds of her frenzied moans - citizens like her often do since sexual submission to a slave would be a crippling scandal to a prominent citizen, let alone one of her diminished social stature.
+	<br><br><span id="result2">
+	<<link "Enslave her afterwards">>
+	<<replace "#result2">>
+	After she regains her bearings from your sexual encounter, the girl slips on her simple clothes and attempts to slink away from your private suite unobtrusively. She makes it out the door before being confronted by a glowing array of wallscreen monitors, each displaying a visual representation of your purchase of her father's considerable debt and subsequent enslavement of her on the basis of that debt. Tears begin to stream down her cheeks as she sinks to her knees, her hopes of a long life without enslavement now dashed. 
+	<<display "Generate New Slave">>
+	<<set $activeSlave.origin = "She was enslaved by you when you purchased her debt">>
+	<<set $activeSlave.devotion = random(-70,-55)>>
+	<<set $activeSlave.trust = random(-45,-25)>>
+	<<set $activeSlave.age = random(18,22)>>
+	<<set $activeSlave.health = random(10,20)>>
+	<<AddSlave $activeSlave>>
+	<</replace>>
+	<</link>>
+	</span>
+	<</replace>>
+	<</link>>
+
+<<case "maturity preferentialist encounter">>
+
+<span id="result">
+<<link "Let them pass">>
+	<<replace "#result">>
+	You step aside gracefully and bow your head, while signifying to the older woman that you intend to allow her to pass you. She seems taken aback by your geniality, especially given the gulf in social standing between the two of you, and seems disproportionately flustered by your small show of civility. Nonetheless, she is struck by her chance encounter with you and cannot stop recounting the story to all her friends, soon @@.green;the anecdote has seized the imaginations of $arcologies[0].name's mature, female citizens@@. 
+	<<set $rep += 100>>
+	<</replace>>
+<</link>>
+<br><<link "Fuck her over dinner">>
+	<<replace "#result">>
+	It takes a moment for you to convince the older woman and her sons that you aren't playing some cruel joke on them, but once you do she enthusiastically agrees to be your companion for the evening. With a mature lady on your arm for the rest of the night, and her sons trailing behind the two of you at a respectful distance, you take $arcologies[0].name by storm amidst a flurry of speculative whispers and contemplative rumors. Later that night, you conclude your date with a pleasant meal at one of $arcologies[0].name's choicest restaurants with fine dining and even finer conversation. To the credit of her sons, they politely continue eating their dinner without batting an eye when you <<if $PC.dick == 0>>don a strap-on and <</if>>take their mother over the dinner table. When you part ways, the older woman is clearly smitten with you - so it's no wonder that by the next day the story of your encounter has @@.green;spread across $arcologies[0].name like wildfire@@.
+	<<set $rep += 500>>
+	<</replace>>
+<</link>>
+<br><<link "Manipulate her into having sex with you">>
+	<<replace "#result">>
+	It only takes a moment for $assistantName to uncover the citizen's financial records and the copious debt therein, and only another moment for you to browbeat the terrified older women into sleeping with you under threat of purchasing all her debt and summarily enslaving her. Her sons, frightened into obedience by the possibility of losing their dear mother, take their cue to make themselves scarce during the encounter.
+	<br><br>
+	Once you both retire to your private suite, you peel the mature citizen's clothes off as easily as one might shed a gift of it's wrapping. In the nude her body is tastefully plush, with wide hips, firm motherly breasts, and a delicate blush across her shamefaced, plump cheeks. Despite the circumstances of your sexual conquest of her, she seems to enjoy the fuck well enough by the sounds of her frenzied moans - citizens like her often do since sexual submission to a slave would be a crippling scandal to a prominent citizen, let alone one of her diminished social stature.
+	<br><br><span id="result2">
+	<<link "Enslave her afterwards">>
+	<<replace "#result2">>
+	After she regains her bearings from your sexual encounter, the older woman slips on her simple clothes and attempts to slink away from your private suite unobtrusively. She makes it out the door before being confronted by a glowing array of wallscreen monitors, each displaying a visual representation of your purchase of her considerable debt and subsequent enslavement of her on the basis of that debt. Tears begin to stream down her weathered cheeks as she sinks to her knees, her hopes of making it through the breadth of her long life without enslavement now dashed. 
+	<<display "Generate New Slave">>
+	<<set $activeSlave.origin = "She was enslaved by you when you purchased her debt">>
+	<<set $activeSlave.devotion = random(-70,-55)>>
+	<<set $activeSlave.trust = random(-45,-25)>>
+	<<set $activeSlave.age = random(36,42)>>
+	<<set $activeSlave.health = random(10,20)>>
+	<<AddSlave $activeSlave>>
+	<</replace>>
+	<</link>>
+	</span>
+	<</replace>>
+	<</link>>
+
+<<default>>
+	ERROR: bad event
+<</switch>>
+
+
+

--- a/src/uncategorized/randomNonindividualEvent.tw
+++ b/src/uncategorized/randomNonindividualEvent.tw
@@ -17,7 +17,7 @@
 <<else>>
 <<silently>>
 /* initialize event lists as arrays [], not objects {} */
-<<set $events = [], $RecETSevent = [], $REFIevent = [], $PESSevent = [], $PETSevent = [], $activeSlave = 0, $groomSlave = 0, $brideSlave = 0>>
+<<set $events = [], $RecETSevent = [], $REFIevent = [], $PESSevent = [], $PETSevent = [], $REFSevent = [], $activeSlave = 0, $groomSlave = 0, $brideSlave = 0>>
 
 <<set $seed = 0>>
 
@@ -930,6 +930,21 @@
 	<<set $REM = -1>>
 <</if>>
 
+/* FUTURE SOCIETY EVENTS */
+
+	<<if $arcologies[0].FSBodyPurist > random(1,100)>>
+		<<set $REFSevent.push("body purism encounter")>>
+	<</if>>
+	<<if $arcologies[0].FSTransformationFetishist > random(1,100)>>
+		<<set $REFSevent.push("transformation fetishism encounter")>>
+	<</if>>
+	<<if $arcologies[0].FSYouthPreferentialist > random(1,100)>>
+		<<set $REFSevent.push("youth preferentialist encounter")>>
+	<</if>>
+	<<if $arcologies[0].FSMaturityPreferentialist > random(1,100)>>
+		<<set $REFSevent.push("maturity preferentialist encounter")>>
+	<</if>>
+
 /* EVENT RANDOMIZATION */
 
 <<for $i = 0; $i < $RecETSevent.length; $i++>>
@@ -943,6 +958,9 @@
 <</for>>
 <<for $i = 0; $i < $PETSevent.length; $i++>>
   <<set $events.push("PETS")>>
+<</for>>
+<<for $i = 0; $i < $REFSevent.length; $i++>>
+  <<set $events.push("REFS")>>
 <</for>>
 <<if $cheatMode == 1>>
 	<<goto "random event select">>


### PR DESCRIPTION
New Random Non-Individual Events involving the arcology owner and citizens of the arcology, themed around a future society. Hopefully these events provide a more slice of life insight into arcology life. For now, I have only provided events for transformation/body purism and youth/maturity preference, but the framework is there to add events to flesh out the other FS. It's set up to be the same as the existing RESS, PETS etc system.

The events have been tested in game and seem to fire correctly.