### PR TITLE
CRITICAL: completely remove CRLF end-of-line setting from gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto eol=crlf
+* text=auto
 
 readme.md export-ignore
 *.patch export-ignore


### PR DESCRIPTION
Seems to be causing severe problems for other committers.