### PR TITLE
Changed minimum rep to lose rep from not hosting parties to 1500

### DIFF
--- a/src/uncategorized/persBusiness.tw
+++ b/src/uncategorized/persBusiness.tw
@@ -167,7 +167,7 @@
 <</if>>
 <</if>>
 <<if $rep <= 18000>>
-<<if $rep > 100>>
+<<if $rep > 1500>>
 <<if $RegularParties != 1>>
 	Your @@.red;reputation is damaged@@ by your not hosting regular social events for your leading citizens.
 	<<set $rep -= 100>>


### PR DESCRIPTION
It makes sense that nobody wants to go to a resented person's parties anyway, and it prevents players from getting stuck in a rep hole from being unable to host parties because they don't have enough rep to start hosting parties.