### PR TITLE
Paraphilia acquisition maxes out fetishstrength

### DIFF
--- a/src/uncategorized/saLongTermEffects.tw
+++ b/src/uncategorized/saLongTermEffects.tw
@@ -2235,6 +2235,7 @@
 		<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club") || ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade")>>
 			Serving as a sex worker drives her deeper and deeper into submission, and she pays less and less attention to her own pleasure. @@.yellow;She's become sexually self neglectful,@@ and only cares about getting others off.
 			<<set $slaves[$i].sexualFlaw = "neglectful">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 	<</if>>
@@ -2243,6 +2244,7 @@
 		<<if $slaves[$i].addict > 2>>
 			Her aphrodisiac addiction makes her dependent on submission. @@.yellow;She's become sexually self neglectful,@@ and only cares about getting others off.
 			<<set $slaves[$i].sexualFlaw = "neglectful">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 	<</if>>
@@ -2251,9 +2253,11 @@
 		<<if $slaves[$i].diet == "cum">>
 			In addition to being an orally fixated cumslut, she eats ejaculate in her food, making the taste omnipresent for her. @@.yellow;She's become psychologically addicted to cum.@@
 			<<set $slaves[$i].sexualFlaw = "cum addict">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<<elseif $cockFeeder != 0>>
 			In addition to being an orally fixated cumslut, she eats by sucking dick. @@.yellow;She's become psychologically addicted to cum.@@
 			<<set $slaves[$i].sexualFlaw = "cum addict">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 	<</if>>
 	<<if $slaves[$i].sexualFlaw != "cum addict">>
@@ -2261,6 +2265,7 @@
 		<<if $slaves[$i].addict > 2>>
 			Her aphrodisiac addiction makes her dependent on oral stimulation. @@.yellow;She's become psychologically addicted to cum.@@
 			<<set $slaves[$i].sexualFlaw = "cum addict">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 	<</if>>
@@ -2271,9 +2276,11 @@
 		<<if $slaves[$i].prostate > 0>>
 			She has a powerful sex drive, and constantly coming to prostate stimulation drives her ever deeper into her identity as a helpless anal slut. @@.yellow;She's become psychologically addicted to getting assfucked.@@
 			<<set $slaves[$i].sexualFlaw = "anal addict">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<<elseif $slaves[$i].vaginalAccessory == "chastity belt">>
 			She has a powerful sex drive, and since her pussy's off limits, she sinks ever deeper into her identity as a helpless anal slut. @@.yellow;She's become psychologically addicted to getting assfucked.@@
 			<<set $slaves[$i].sexualFlaw = "anal addict">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 		<</if>>
@@ -2283,6 +2290,7 @@
 		<<if $slaves[$i].addict > 2>>
 			Her aphrodisiac addiction makes her dependent on constant buttsex. @@.yellow;She's become psychologically addicted to getting assfucked.@@
 			<<set $slaves[$i].sexualFlaw = "anal addict">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 	<</if>>
@@ -2291,6 +2299,7 @@
 		<<if ($slaves[$i].assignment == "serve the public") || ($slaves[$i].assignment == "whore") || ($slaves[$i].assignment == "work in the brothel") || ($slaves[$i].assignment == "serve in the club")>>
 			Serving as a public sex worker gives her plenty of delicious humiliation, and she cares less and less about sex itself and more about making people blush. @@.yellow;She's become an attention whore.@@
 			<<set $slaves[$i].sexualFlaw = "attention whore">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 	<</if>>
 	<<if $slaves[$i].sexualFlaw != "attention whore">>
@@ -2298,6 +2307,7 @@
 		<<if $slaves[$i].addict > 2>>
 			Her aphrodisiac addiction makes her dependent on stares to get off. @@.yellow;She's become an attention whore.@@
 			<<set $slaves[$i].sexualFlaw = "attention whore">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 	<</if>>
@@ -2306,9 +2316,11 @@
 		<<if $slaves[$i].drugs == "breast injections">>
 			She loves her tits, and feeling them respond to drug injections starts to hold more fascination for her than mere sex. @@.yellow;Her sexual identity is now dominated by her swelling boobs.@@
 			<<set $slaves[$i].sexualFlaw = "breast growth">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<<elseif ($slaves[$i].hormones > 0) && ($slaves[$i].boobs < 1000)>>
 			She loves her tits, and feeling them grow under female hormone treatments starts to hold more fascination for her than mere sex. @@.yellow;Her sexual identity is now dominated by her swelling boobs.@@
 			<<set $slaves[$i].sexualFlaw = "breast growth">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 	<</if>>
 	<<if $slaves[$i].sexualFlaw != "breast growth">>
@@ -2316,6 +2328,7 @@
 		<<if $slaves[$i].addict > 2>>
 			Her aphrodisiac addiction makes her dependent on her tits for relief. @@.yellow;Her sexual identity is now dominated by her swelling boobs.@@
 			<<set $slaves[$i].sexualFlaw = "breast growth">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 	<</if>>
@@ -2325,6 +2338,7 @@
 		<<if $slaves[$i].ID == $Wardeness.ID>>
 			As Wardeness, she becomes @@.yellow;sexually addicted to inflicting pain and anguish.@@
 			<<set $slaves[$i].sexualFlaw = "malicious">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 	<</if>>
@@ -2333,6 +2347,7 @@
 		<<if $slaves[$i].addict > 2>>
 			Her aphrodisiac addiction makes her dependent on degradation in other slaves to get off. She becomes @@.yellow;sexually addicted to inflicting pain and anguish.@@
 			<<set $slaves[$i].sexualFlaw = "malicious">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 	<</if>>
@@ -2343,6 +2358,7 @@
 		<<if $slaves[$i].ID == $HeadGirl.ID>>
 			As Head Girl, she's plentifully provided with misbehaving slaves to dominate sexually. She becomes more and more eager until she's actively @@.yellow;sexually abusive, getting off on the thrill of forcing herself on other slaves.@@
 			<<set $slaves[$i].sexualFlaw = "abusive">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 		<</if>>
@@ -2352,6 +2368,7 @@
 		<<if $slaves[$i].addict > 2>>
 			Her aphrodisiac addiction makes her dependent on pain in others to get off. She's become @@.yellow;sexually abusive, getting off on the thrill of forcing herself on other slaves.@@
 			<<set $slaves[$i].sexualFlaw = "abusive">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 	<</if>>
@@ -2360,9 +2377,11 @@
 		<<if ($slaves[$i].assignment == "work a glory hole") || ($slaves[$i].assignment == "be confined in the arcade")>>
 			Condemned to serve as a public fuckhole, her masochistic tendencies darken into sexual appreciation for her life as a human sex toy. @@.yellow;She's descended into true self hatred.@@
 			<<set $slaves[$i].sexualFlaw = "self hating">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<<elseif ($slaves[$i].assignment == "work in the dairy") && ($dairyRestraintsSetting >= 2)>>
 			Strapped into a milking machine's tender, penetrative embrace, her masochistic tendencies darken into sexual appreciation for her life as a human factory. @@.yellow;She's descended into true self hatred.@@
 			<<set $slaves[$i].sexualFlaw = "self hating">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 	<</if>>
 	<<if $slaves[$i].sexualFlaw != "self hating">>
@@ -2370,6 +2389,7 @@
 		<<if $slaves[$i].addict > 2>>
 			Her aphrodisiac addiction makes her dependent on sexual self harm. @@.yellow;She's descended into true self hatred.@@
 			<<set $slaves[$i].sexualFlaw = "self hating">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 	<</if>>
@@ -2378,9 +2398,11 @@
 		<<if $slaves[$i].births > 10>>
 			She's been bred so much that she starts to pay as much sexual attention to pregnancy as to impregnation. @@.yellow;She's become obsessed with breeding.@@
 			<<set $slaves[$i].sexualFlaw = "breeder">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<<elseif ($slaves[$i].assignment == "work in the dairy") && ($dairyPregSetting >= 2) && ($slaves[$i].preg > 0)>>
 			With her womanhood fucked full of cum and fertility drugs, her pregnancy fetish deepens into true perversity. @@.yellow;She's become obsessed with breeding.@@
 			<<set $slaves[$i].sexualFlaw = "breeder">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 	<</if>>
 	<<if $slaves[$i].sexualFlaw != "breeder">>
@@ -2388,6 +2410,7 @@
 		<<if $slaves[$i].addict > 2>>
 			Her aphrodisiac addiction makes her dependent on her pregnancy fantasies. @@.yellow;She's become obsessed with breeding.@@
 			<<set $slaves[$i].sexualFlaw = "breeder">>
+			<<set $slaves[$i].fetishStrength = 100>>
 		<</if>>
 		<</if>>
 	<</if>>


### PR DESCRIPTION
Prevents confusing messages about the slave being 'forced her back towards her past life' when they acquire paraphilias at fetishstrength in the 80s or low 90s.