### PR TITLE
Fixed minor inaccuracy in arcade report

### DIFF
--- a/src/uncategorized/saWorkAGloryHole.tw
+++ b/src/uncategorized/saWorkAGloryHole.tw
@@ -29,6 +29,10 @@
 	<<set $FResult = 1>>
 <</if>>
 
+<<if ($slaves[$i].assignment == "be confined in the arcade") && ($arcadeUpgradeInjectors == 1)>>
+	<<set $FResult += 1>>
+<</if>>
+
 is <<if $slaves[$i].fuckdoll == 0>>restrained in a glory hole<<else>>set out for use<</if>>. $beauty customers (<<print Math.trunc($beauty/7)>> a day) paid ¤$FResult to use $possessive holes.
 
 <<if ($arcologies[0].FSDegradationist > 0)>>
@@ -122,10 +126,6 @@ is <<if $slaves[$i].fuckdoll == 0>>restrained in a glory hole<<else>>set out for
 			@@.mediumorchid;$possessiveCap helpless hatred of you is increased@@ and $pronoun is @@.gold;filled with fear@@ $pronoun won't be let out.
 		<</if>>
 	<</if>>
-<</if>>
-
-<<if ($slaves[$i].assignment == "be confined in the arcade") && ($arcadeUpgradeInjectors == 1)>>
-	<<set $FResult += 1>>
 <</if>>
 
 $possessiveCap feelings, skills, and appearance do not matter. $pronounCap is condemned to a world that consists of a tiny cell, featureless except for the never-ending dicks $pronoun is required to service. You were paid @@.yellowgreen;¤<<print ($beauty*$FResult)>>@@ for the use of $slaves[$i].slaveName's holes this week.


### PR DESCRIPTION
The arcade report is currently reporting the wrong price per customer, though the total profit is still correct. This fixes that.