### PR TITLE
Further clarified social event reputation changes

### DIFF
--- a/src/uncategorized/persBusiness.tw
+++ b/src/uncategorized/persBusiness.tw
@@ -167,10 +167,12 @@
 <</if>>
 <</if>>
 <<if $rep <= 18000>>
-<<if $rep > 1500>>
 <<if $RegularParties != 1>>
+<<if $rep > 1500>>
 	Your @@.red;reputation is damaged@@ by your not hosting regular social events for your leading citizens.
 	<<set $rep -= 100>>
+	<<else>>
+	Though you are not hosting regular social events for your leading citizens, your lack of renown prevents this from damaging your reputation; they don't expect someone so relatively unknown to be throwing parties.
 <</if>>
 <</if>>
 <</if>>


### PR DESCRIPTION
Added text for not losing reputation because your reputation is already low and nobody wants to come to your parties anyway.