### PR TITLE
RESS blind/preg work + RETS Bugfixes

### DIFF
--- a/src/uncategorized/RESS.tw
+++ b/src/uncategorized/RESS.tw
@@ -1459,7 +1459,7 @@ She shrieks, backpedaling, and then falls backward, her <<if $activeSlave.butt >
 
 There are sturdy leather seats placed strategically throughout your penthouse. They offer something convenient to bend your slaves over, wherever you happen to encounter them, and they're comfortable, too. At the moment, you're sitting on one, using a tablet to take care of some business that caught you away from your office, but isn't worth heading back to your desk for. Slaves move by your impromptu throne as you work, mostly <<if $averageTrust > 50>>greeting you cheerfully<<elseif $averageTrust > 20>>greeting you properly<<elseif $averageTrust > -20>>doing their best to greet you properly<<elseif $averageTrust > -50>>greeting you fearfully<<else>>struggling to greet you through their terror<</if>> as they pass. Busy, you spare few of them more than a glance.
 <br><br>
-One of them slows as she goes by, however. Looking up, you see that it's <span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink = passage(), $eventDescription = 1]]">></span>. <<if canTalk($activeSlave)>>"Hi <<Master>>," she says flirtily. "That look<<s>> like a really comfortable <<s>>eat. Can I <<s>>it down and re<<s>>t for a little while?"<<else>>She greets you properly, but adds a flirtiness to her gestures, and asks if she can sit down and rest on the comfortable seat for a little while.<</if>> She is not pointing at the soft leather cushion next to you: she's pointing at your crotch.
+One of them slows as she goes by, however. Looking up, you see that it's <span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink = passage(), $eventDescription = 1]]">></span>. <<if canTalk($activeSlave)>>"Hi <<Master>>," she says flirtily<<if $activeSlave.preg > 20>> rubbing a hand across her pregnancy<</if>>. "That look<<s>> like a really comfortable <<s>>eat. Can I <<s>>it down and re<<s>>t <<if $activeSlave.preg > 20>>my tired leg<<s>> <</if>>for a little while?"<<else>>She greets you properly, but adds a flirtiness to her gestures, and asks if she can sit down and rest <<if $activeSlave.preg > 20>> her gravid bulk <</if>>on the comfortable seat for a little while.<</if>> She is not pointing at the soft leather cushion next to you: she's pointing at your crotch.
 <br><br>
 You're nude, a consequence of <<if $Concubine != 0>>recent activities involving $Concubine.slaveName<<else>>recent unrelated activities<</if>>. <<if $PC.dick == 1>>Your formidable dick is three quarters hard,<<else>>Nude, that is, all except for the strap-on you were just using and haven't taken off yet,<</if>> and $activeSlave.slaveName is pointing right at it. She knows exactly what she's asking for and gives her <<if $activeSlave.hips > 0>>broad<<elseif $activeSlave.hips > -1>>trim<<else>>narrow<</if>> hips a little wiggle to make it even more abundantly clear.
 <<if ($eventSlave.dickAccessory == "chastity")>>
@@ -1482,9 +1482,9 @@ The slutty $desc wants it badly.
 
 <<case "arcade sadist">>
 
-You happen to come across <span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink = passage(), $eventDescription = 1]]">></span> during one of her rest periods. She's lying on a couch in the slave areas, staring at the ceiling above her with a dreamy expression on her face. She's <<if $activeSlave.releaseRules == "permissive">>touching herself idly.<<else>>not allowed to touch herself, but she's extremely aroused.<</if>> Whatever's on her mind, it's so absorbing that she doesn't realize you're there until you're standing over her.
+You happen to come across <span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink = passage(), $eventDescription = 1]]">></span> during one of her rest periods. She's lying on a couch in the slave areas, <<if canSee($activeSlave)>>staring at the ceiling above her<<else>>leaning back<</if>> with a dreamy expression on her face. She's <<if $activeSlave.releaseRules == "permissive">>touching herself idly.<<else>>not allowed to touch herself, but she's extremely aroused.<</if>> Whatever's on her mind, it's so absorbing that she doesn't realize you're there until you're standing over her.
 <br><br>
-"<<S>>orry, <<Master>>," she <<say>>s apologetically, scrambling to her feet. "I didn't noti<<c>>e you there." Seeing your questioning look, she explains herself further. "I was ju<<s>>t thinking about, um, my favorite pla<<c>>e. I can almo<<s>>t get off ju<<s>>t by thinking about it." There's a wild, perverted gleam in her $activeSlave.eyeColor eyes. She's a confirmed sadist, so whatever her favorite mental masturbation is probably quite strong.
+"<<S>>orry, <<Master>>," she <<say>>s apologetically, <<if $activeSlave.preg > 20>>struggling<<else>>scrambling<</if>> to her feet. "I didn't noti<<c>>e you there." <<if canSee($activeSlave)>>Seeing your questioning look<<else>>Hearing your lack of response<</if>>, she explains herself further. "I was ju<<s>>t thinking about, um, my favorite pla<<c>>e. I can almo<<s>>t get off ju<<s>>t by thinking about it." There's a wild, perverted gleam <<if canSee($activeSlave)>>in her $activeSlave.eyeColor eyes<<else>>on her face<</if>>. She's a confirmed sadist, so whatever her favorite mental masturbation is probably quite strong.
 
 <<case "ass fitting">>
 
@@ -1497,6 +1497,8 @@ Your slaves get dressed in a large wardrobe area adjacent to the dormitory, room
 	apparently bigger today than it was yesterday. Pregnancy often causes minor redistributions of weight like this.
 <<elseif $activeSlave.hormones > 1>>
 	apparently bigger today than it was yesterday. Intensive female hormone regimens like hers sometimes cause minor ass expansion.
+<<elseif $activeSlave.buttImplantType == 1>>
+	apparently a little bigger today than it was yesterday. String implants like hers steadily grow if not regularly drained.
 <<elseif $activeSlave.buttImplant > 1>>
 	apparently a little bigger today than it was yesterday. Large implants like hers normally cause some slight size fluctuations.
 <<else>>
@@ -1585,10 +1587,10 @@ She begins her cleaning dutifully, fluttering about your office in a flurry of s
 		Although her movements rarely stray from a slight flick of her wrist as she dusts some surface or a gyration of her body as she scrubs the floor clean, her P-Limbs nonetheless produce a steady stream of minute machine noises. They give her the coordination she needs to purge even the smallest of stains, but the multitude of gyros, servos, and other mechanical pieces constantly working to maintain it ensure that the process is far from silent. 
 	<<elseif $activeSlave.boobs > 4000>>
 		Her breasts are so massive that a whole ream of cloth is needed to provide even the semblance of covering her massive chest. They do little to aid in her cleaning duties, often causing her to attack any blemish on the wall sideways lest her gigantic boobs prevent her from reaching the offending smudge at all.
-		<<elseif $activeSlave.boobs > 800>>
-		Her breasts are pleasingly large and appealingly visible despite the minor concealment provided by her blouse. They often cause her difficulty by mashing against the top surface of your desk as she tries to duck beneath to clean the underside. The struggle is surprisingly erotic - if not without humor.
 	<<elseif $activeSlave.preg > 30>>
 		Despite her pregnancy, she manages to clean with surprising efficacy. She often cradles her gravid belly through her sheer skirt as she dusts or scrubs with one hand, conscious of the fragile life within her even as she works hard to cleanse your office of any unsightly blemishes.
+	<<elseif $activeSlave.boobs > 800>>
+		Her breasts are pleasingly large and appealingly visible despite the minor concealment provided by her blouse. They often cause her difficulty by mashing against the top surface of your desk as she tries to duck beneath to clean the underside. The struggle is surprisingly erotic - if not without humor.
 	<<elseif $activeSlave.muscles > 30>>
 		With her incredible musculature, she's able to conduct a deep cleaning that few other slaves can match. Life as an arcology owner exposes you to a wealth of unique situations, but you doubt many of your peers have seen a slave in a slutty maid ensemble lift up a couch with one outstretched arm as they sweep the now exposed ground beneath it clean with the other.
 	<<elseif $activeSlave.energy > 95>>
@@ -1611,10 +1613,10 @@ She begins her cleaning dutifully, fluttering about your office in a flurry of s
 		Although her movements rarely stray from a slight flick of her wrist as she dusts some surface or a gyration of her body as she scrubs the floor clean, her P-Limbs nonetheless produce a steady stream of minute machine noises. They give her the coordination she needs to purge even the smallest of stains, but the multitude of gyros, servos, and other mechanical pieces constantly working to maintain it ensure that the process is far from silent. 
 	<<elseif $activeSlave.boobs > 4000>>
 		Her breasts are so massive that several reams of cloth are needed to provide her massive chest with any semblance of modesty. They do little to aid in her cleaning duties, often causing her to attack any blemish on the wall sideways lest her gigantic boobs prevent her from reaching the offending smudge at all.
-		<<elseif $activeSlave.boobs > 800>>
-		Her breasts are pleasingly large and appealingly visible, even beneath the folds and ruffles of her dress. They often cause her difficulty by mashing against the top surface of your desk as she tries to duck beneath to clean the underside. The struggle is surprisingly erotic - if not without humor.
 	<<elseif $activeSlave.preg > 30>>
 		Despite her pregnancy, she manages to clean with surprising efficacy. She often cradles her gravid belly through her thick apron as she dusts or scrubs with one hand, conscious of the fragile life within her even as she works hard to cleanse your office of any unsightly blemishes.
+	<<elseif $activeSlave.boobs > 800>>
+		Her breasts are pleasingly large and appealingly visible, even beneath the folds and ruffles of her dress. They often cause her difficulty by mashing against the top surface of your desk as she tries to duck beneath to clean the underside. The struggle is surprisingly erotic - if not without humor.
 	<<elseif $activeSlave.muscles > 30>>
 		With her incredible musculature, she's able to conduct a deep cleaning that few other slaves can match. Life as an arcology owner exposes you to a wealth of unique situations, but you doubt many of your peers have seen a slave in a modest maid ensemble lift up a couch with one outstretched arm as they sweep the now exposed ground beneath it clean with the other.
 	<<elseif $activeSlave.energy > 95>>
@@ -1651,10 +1653,8 @@ As another long weeks draws to a close, <span id="name"><<print "[[$activeSlave.
 <span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink to passage(), $eventDescription to 1]]">></span> comes before you for a routine inspection. The $desc is a well-educated and obedient slave. Though she performs her duties devotedly and to the best of her abilities, slave life is not particularly conducive to straining an individual's brainpower. You happen to run into $activeSlave.slaveName in the hallways of the penthouse, where she takes the opportunity to wordlessly signal she wishes to gain your attention.
 <<if canTalk($activeSlave) == false>>
 	She uses gestures to beg your pardon and explains that while she enjoys life as your slave, she doesn't feel like her new role in your arcology allows her to stimulate her mind as often as it does her body.
-<<elseif SlaveStatsChecker.checkForLisp($activeSlave)>>
-	"<<Master>>," she says. "I really enjoy my role ath your thlave, but I jutht don't feel like my new life thtimulateth me." She blushes prettily at her choice of words before continuing, "Thtimulate my mind, I mean."
 <<else>>
-	"<<Master>>," she says. "I really enjoy my role as your slave, but I just don't feel like my new life stimulates me." She blushes prettily at her choice of words before continuing, "Stimulate my mind, I mean."
+	"<<Master>>," she <<say>>s. "I really enjoy my role a<<s>> your <<s>>lave, but I ju<<s>>t don't feel like my new life <<s>>timulate<<s>> me." She blushes prettily at her choice of words before continuing, "<<S>>timulate my mind, I mean."
 <</if>>
 
 <<case "nice guys">>
@@ -1677,10 +1677,6 @@ $activeSlave.slaveName is doing her job, standing in an area of the arcology tha
 	"Those boobs are bigger than my head,"
 <<elseif $activeSlave.dick > 6>>
 	"I didn't even know girls could have dicks,"
-<<elseif $activeSlave.intelligence > 1>>
-	"She looks like she's really clever,"
-<<elseif $activeSlave.lips > 40>>
-	"I didn't know girls could have lips like that,"
 <<elseif $activeSlave.preg > 20>>
 	"Look at that belly, I bet she's pregnant,"
 <<elseif $activeSlave.dick > 3>>
@@ -1691,8 +1687,12 @@ $activeSlave.slaveName is doing her job, standing in an area of the arcology tha
 	"Look, she's got a cute little dick,"
 <<elseif $activeSlave.age > 35>>
 	"She's looks like my mom, but hot,"
-<<elseif $activeSlave.face > 2>>
+<<elseif $activeSlave.lips > 40>>
+	"I didn't know girls could have lips like that,"
+<<elseif $activeSlave.face > 60>>
 	"She's just so gorgeous,"
+<<elseif $activeSlave.intelligence > 1>>
+	"She looks like she's really clever,"
 <<else>>
 	"She looks like she's down to fuck,"
 <</if>>
@@ -1704,20 +1704,20 @@ Although your life as an arcology owner comes with many associated privileges, e
 <br><br>
 Of course, no self respecting arcology owner could be expected to enjoy a lazy night of idle relaxation on their own. As you resolve the last of your most pressing responsibilities for the evening, $assistantName directs one of your attentive slaves to gently guide you away from the unending burdens of running your arcology. Leaning against the doorway and wearing a facsimile of what an old world woman might wear on a casual night in, <span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink to passage(), $eventDescription to 1]]">></span> <<if canTalk($activeSlave) == false>>asks with a gesture that carries just the right mixture of submission and exaggerated casualness if you'd like to 'hang out.'<<elseif SlaveStatsChecker.checkForLisp($activeSlave)>>lisps with exaggerated casualness, "Let'th hang out, <<Master>>?"<<else>>asks with exaggerated casualness, "Want to hang out, <<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Master<<else>>Mistress<</if>>?"<</if>>
 <br><br>
-She saunters over and kneels obediently in front of you, awaiting further direction.
+She saunters over and <<if $activeSlave.preg > 20>>gently lowers her gravid form to an obediant kneel<<else>>kneels obediently<</if>> in front of you, awaiting further direction.
 <<if $activeSlave.amp < 0>>
-	Clad in an antique T-Shirt referencing some defunct old world website, her P-Limbs stand in stark contrast - gyros and servomotors against simple thread and cloth. With such tangible examples of the technological prowess of the Free Cities serving as her limbs, her shirt is an amusing testimonial to how far behind the old world stands in contrast to the new.
+	Clad in an antique T-Shirt referencing some defunct old world website, her P-Limbs stand in stark contrast - gyros and servomotors against simple thread and cloth. With such tangible examples of the technological prowess of the Free Cities serving as her limbs, her <<if $activeSlave.preg > 20>>taut <</if>>shirt is an amusing testimonial to how far behind the old world stands in contrast to the new.
 <<elseif $activeSlave.boobs > 4000>>
-	Her breasts are so massive that the front of her loose pyjama top must be unbuttoned. Even so, the protrusion of her immense breasts from her chest strains the soft pyjama top to it's breaking point.
+	Her breasts are so massive that the front of her loose pyjama top must be unbuttoned. Even so, the protrusion of her immense breasts<<if $activeSlave.preg > 20>> and rounded belly<</if>> from her chest strains the soft pyjama top to it's breaking point.
 <<elseif $activeSlave.intelligence > 1>>
-	As a clever girl, her simple summer dress evokes memories of bygone warm weather days at elite old world colleges - and the sexual conquest of their youthful residents.
+	As a clever girl, her simple<<if $activeSlave.preg > 20>>, yet tight around the middle,<</if>> summer dress evokes memories of bygone warm weather days at elite old world colleges - and the sexual conquest of their youthful residents.
 <<elseif $activeSlave.muscles > 30>>
-	Her simple sports bra and compression shorts ensemble does little to conceal her incredible musculature, glistening with sweat from a recent workout. Despite her recent exertions, she's able to maintain utter stillness in the perfect posture of an obedient slave.
+	Her simple sports bra and compression shorts ensemble does little to conceal her incredible musculature, <<if $activeSlave.preg > 20>>straining to hold up against her swelling middle and <</if>>glistening with sweat from a recent workout. Despite her recent exertions, she's able to maintain utter stillness in the perfect posture of an obedient slave.
 <<elseif $activeSlave.energy > 95>>
 	She's controlling her absurd sex drive for the moment in deference to the notion of your relaxation time, but she clearly wouldn't mind some sex as part of the evening.
 	<<if $activeSlave.dick > 0>>
 		<<if canAchieveErection($activeSlave)>>
-			Her cock is painfully erect,
+			Her cock is painfully erect<<if $activeSlave.preg > 20>> and pressed against the underside of her belly<</if>>,
 		<<else>>
 			Her soft dick is dribbling precum,
 		<</if>>
@@ -1726,18 +1726,16 @@ She saunters over and kneels obediently in front of you, awaiting further direct
 	<</if>>
 	showing unmistakably how badly she needs release.
 <<else>>
-	She keeps her <<if canSee($activeSlave)>>$activeSlave.eyeColor eyes<<else>>face<</if>> slightly downcast, her hands lightly smoothing the folds from her tight skirt while her breasts visibly rise and fall under her even tighter blouse. She's the perfect picture of an attentive little old world girlfriend<<if $activeSlave.height > 185>> (though, of course, she's anything but physically small)<</if>>.
+	She keeps her <<if canSee($activeSlave)>>$activeSlave.eyeColor eyes<<else>>face<</if>> slightly downcast, her hands lightly smoothing the folds from her tight skirt while her breasts visibly rise and fall under her even tighter blouse<<if $activeSlave.preg > 20>>. Between the two, there is little she can do to cover her exposed pregnancy<</if>>. She's the perfect picture of an attentive little old world girlfriend<<if $activeSlave.height > 185>> (though, of course, she's anything but physically small)<</if>>.
 <</if>>
 
 <<case "devoted shortstack">>
 
-<span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink to passage(), $eventDescription to 1]]">></span> comes before you for a routine inspection. The <<if ($activeSlave.height > 130) && ($activeSlave.boobs > 800)>>shortstack <<elseif ($activeSlave.height > 130) && ($activeSlave.boobs < 600)>>petite <<else>>short <</if>> <<if $activeSlave.preg > 30>>and heavily pregnant <<elseif $activeSlave.preg > 20>>pregnant <</if>>$desc is looking good despite her diminutive height. When she raises her arms above her head to submit to an inspection under your gaze, the top of her $activeSlave.hColor-haired head doesn't even reach your chest. Despite the discrepancy between your height and hers, you notice an unmistakable flush of embarrassment tinging her cheeks. <<if canSee($activeSlave)>>Her $activeSlave.eyeColor eyes flick up to gaze at you, but she must crane her head upwards as well to meet your gaze<<else>>Her ears perk up to hear at the sound of some minute noise you made, before she cranes her head upwards so that her sightless eyes may meet your gaze<</if>>.
+<span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink to passage(), $eventDescription to 1]]">></span> comes before you for a routine inspection. The <<if ($activeSlave.height > 130) && ($activeSlave.boobs > 800)>>shortstack <<elseif ($activeSlave.height > 130) && ($activeSlave.boobs < 600)>>petite <<else>>short <</if>> <<if $activeSlave.preg > 30>>and heavily pregnant <<elseif $activeSlave.preg > 20>>pregnant <</if>><<if $activeSlave.age > 30>>woman<<else>>girl<</if>> is looking good despite her diminutive height. When she raises her arms above her head to submit to an inspection under your gaze, the top of her $activeSlave.hColor-haired head doesn't even reach your chest. Despite the discrepancy between your height and hers, you notice an unmistakable flush of embarrassment tinging her cheeks. <<if canSee($activeSlave)>>Her $activeSlave.eyeColor eyes flick up to gaze at you, but she must crane her head upwards as well to meet your gaze<<else>>Her ears perk up to hear at the sound of some minute noise you made, before she cranes her head upwards so that her sightless eyes may meet your gaze<</if>>.
 <<if canTalk($activeSlave) == false>>
 	She uses gestures to beg your pardon, even as she continues to blush rosily, and explains that she doesn't understand why you keep her in your penthouse, when there are such tall, beautiful slaves in abundance in your arcology. She pauses, shuffling about a little shamefacedly before signing that she thinks their bodies could be more fit to pleasure you.
-<<elseif SlaveStatsChecker.checkForLisp($activeSlave)>>
-	"<<Master>>," she lisps. "Why do you keep a thhort, plain thlave like me in your penthouthe, when there are thuth beautiful, tall thlaveth out there in the arcology?." She shuffles about under your gaze a little shamefacedly before lisping in a quiet voice, "Thurely, their bodieth are more fit for pleathuring you."
 <<else>>
-	"<<Master>>," she says. "Why do you keep a short, plain slave like me in your penthouse, when there are such beautiful, tall slaves out there in the arcology?" She shuffles about under your gaze a little shamefacedly before saying in a quiet voice, "Surely, their bodies are more fit for pleasuring you."
+	"<<Master>>," she <<say>>s. "Why do you keep a <<s>>hort, plain <<s>>lave like me in your penthou<<s>>e, when there are <<s>>uch beautiful, tall <<s>>laves out there in the arcology?" She shuffles about under your gaze a little shamefacedly before <<say>>ing in a quiet voice, "<<S>>urely, their bodie<<s>> are more fit for plea<<s>>uring you."
 <</if>>
 
 <<case "desperate null">>
@@ -1746,13 +1744,12 @@ You're inspecting <span id="name"><<print "[[$activeSlave.slaveName|Long Slave D
 <<if $seeDicks != 0>>cock to get hard<</if>>
 <<if $seeDicks != 100>><<if $seeDicks != 0>>or <</if>>pussy to get wet<</if>>
 to advertise her uncomfortable state. Most slaves have obvious visual cues like that to do their sexual begging for them, but not her. All she's got to show how pent up she is is the stiffness of her $activeSlave.nipples nipples, goosebumps all over her areolae despite the warmth of your office, and a tiny bead of clear fluid at the little hole <<if $activeSlave.scrotum > 0>>above her lonely, abandoned ballsack<<elseif $activeSlave.genes == "XX">>where her pussy used to be<<else>>where the base of her penis used to be<</if>>.
-<<if $activeSlave.assignment == "whore">>
-	It's not like her ass isn't sold to hundreds of different customers, but she apparently isn't buttslut enough to get much sexual satisfaction from it.
-<<elseif $activeSlave.assignment == "serve the public">>
-	It's not like hundreds of citizens aren't allowed to fuck her up the butt, but she apparently isn't buttslut enough to get much sexual satisfaction from it.
-<</if>>
+<<switch $activeSlave.assignment>>
+<<case "whore" "serve the public" "work in the brothel" "serve in the club">>
+	It's not like her ass isn't sold to hundreds of different customers, but she apparently isn't enough of a buttslut to get much sexual satisfaction from it.
+<</switch>>
 <br><br>
-She does her very best to get through the inspection without disgrace, hugging herself uncomfortably and shivering. You let her suffer through it, deferring the delicious choice about how to take advantage of her situation until the inspection is done. She breaks before then, though, suddenly falling to her knees and starting to cry. "Plea<<s>>e, <<Master>>," she begs piteously. "Plea<<s>>e help me! I can't t-take it! It'<<s>> <<s>>-<<s>>o f-fucking f-fru<<s>>trating," she moans, trailing off, clasping her hands in supplication as she looks up at you desperately.
+She does her very best to get through the inspection without disgrace, hugging herself uncomfortably and shivering. You let her suffer through it, deferring the delicious choice about how to take advantage of her situation until the inspection is done. She breaks before then, though, suddenly falling to her knees and starting to cry. "Plea<<s>>e, <<Master>>," she begs piteously. "Plea<<s>>e help me! I can't t-take it! It'<<s>> <<s>>-<<s>>o f-fucking f-fru<<s>>trating," she moans, trailing off, clasping her hands in supplication as she <<if canSee($activeSlave)>>looks up at<<else>>faces<</if>> you desperately.
 
 <<default>>
 	<br>ERROR: bad RESS event $RESSevent
@@ -8015,7 +8012,7 @@ By the time you've finished with her sensitive ass, it shines red, and she is cr
 <<link "Let her do what she wants">>
 	<<replace "#name">>$activeSlave.slaveName<</replace>>
 	<<replace "#result">>
-		You tell her to sit down if she'd like to. She looks at you quizzically, <<if $activeSlave.intelligence < 0>>her dim mind slowly <</if>>realizing that you're letting her choose what to do. <<if canTalk($activeSlave)>>"Oh, thank you, <<Master>>," she <<say>>s,<<else>>She gestures her thanks,<</if>> and then makes a show of deciding. She <<if $activeSlave.intelligence < 0>>doesn't have to pretend<<else>>cheekily pretends<</if>> to be an airheaded bimbo puzzling over how she wants to approach a fuck, bouncing <<if $activeSlave.boobsImplant > 0>>her fake tits a little<<elseif $activeSlave.boobs > 4000>>her monstrous udders heavily<<elseif $activeSlave.boobs > 1000>>her heavy breasts a little<<elseif $activeSlave.boobs > 200>>her boobs a little<<else>>on her heels<</if>> and putting a finger to her slightly parted lips as she stares down at your <<if $PC.dick == 1>>stiff prick<<else>>strap-on<</if>>.
+		You tell her to sit down if she'd like to. She looks at you quizzically, <<if $activeSlave.intelligence < 0>>her dim mind slowly <</if>>realizing that you're letting her choose what to do. <<if canTalk($activeSlave)>>"Oh, thank you, <<Master>>," she <<say>>s,<<else>>She gestures her thanks,<</if>> and then makes a show of deciding. She <<if $activeSlave.intelligence < 0>>doesn't have to pretend<<else>>cheekily pretends<</if>> to be an airheaded bimbo puzzling over how she wants to approach a fuck, bouncing <<if $activeSlave.boobsImplant > 0>>her fake tits a little<<elseif $activeSlave.boobs > 4000>>her monstrous udders heavily<<elseif $activeSlave.boobs > 1000>>her heavy breasts a little<<elseif $activeSlave.boobs > 200>>her boobs a little<<else>>on her heels<</if>><<if $activeSlave.preg > 20>>, rocking her baby bump side to side seductively<</if>> and putting a finger to her slightly parted lips as she stares down at your <<if $PC.dick == 1>>stiff prick<<else>>strap-on<</if>>.
 		<br><br>
 		Finally making her decision, she
 		<<set _fucked = 0>>
@@ -8107,7 +8104,7 @@ By the time you've finished with her sensitive ass, it shines red, and she is cr
 <br><<link "Have her service you while you work">>
 	<<replace "#name">>$activeSlave.slaveName<</replace>>
 	<<replace "#result">>
-		You order her to sit on your <<if $PC.dick == 1>>dick<<else>>strap-on<</if>> and get you off like a good girl, and not to disturb you while you're working. She <<if canTalk($activeSlave)>>shuts up immediately<<else>>obediently drops her hands to her sides and stops communicating with them<</if>>, and approaches you carefully. Meanwhile, you go back to your tablet, ignoring her completely. She gingerly straddles your legs, positioning her intimate areas directly over the pointing head of <<if $PC.dick == 1>>your erection<<else>>the phallus<</if>>. Deciding that she shouldn't use her hands to guide it, she lowers herself slowly,
+		You order her to sit on your <<if $PC.dick == 1>>dick<<else>>strap-on<</if>> and get you off like a good girl, but not to disturb you while you're working. She <<if canTalk($activeSlave)>>shuts up immediately<<else>>obediently drops her hands to her sides and stops communicating with them<</if>>, and approaches you carefully. Meanwhile, you go back to your tablet, ignoring her completely. She gingerly straddles your legs, positioning her intimate areas directly over the pointing head of <<if $PC.dick == 1>>your erection<<else>>the phallus<</if>><<if $activeSlave.preg > 20>>, all while delicately trying to not bump into you with her pregnancy<</if>>. Deciding that she shouldn't use her hands to guide it, she lowers herself slowly,
 		<<if canDoVaginal($activeSlave) && ($activeSlave.vagina > 0)>>
 			breathing a little harder as she feels its head spread her pussylips and then slide inside her.
 			<<set $activeSlave.vaginalCount++, $vaginalTotal++>>
@@ -8118,7 +8115,8 @@ By the time you've finished with her sensitive ass, it shines red, and she is cr
 			getting it situated between her thighs, since that's the best option she has available.
 			<<set $activeSlave.oralCount++, $oralTotal++>>
 		<</if>>
-		Still crouched over you, she begins to move up and down, milking <<if $PC.dick == 1>>your penis<<else>>the strap-on<</if>>. As she works into it, she lets her butt touch you, just once, but you make a nonverbal sound of disapproval, letting her know not to disturb your work like that. Realizing that she needs to play the human sex toy, she <<if $activeSlave.butt > 5>>grabs her huge buttocks and holds them apart, doing her best to keep them out of the way<<elseif $activeSlave.butt > 2>>takes hold of her healthy asscheeks and spreads them as far as they'll go, doing her best to keep them out of the way<<else>>uses her arms for balance, since her cute butt can stay out of the way on its own and doesn't need to be spread by hand<</if>>. She bobs up and down, getting you off without ever touching you<<if $PC.dick == 1>>, other than the contact between your penis and the inside of her body, of course<</if>>. <<if $activeSlave.energy > 80>>She has such a powerful sex drive that even this sterile intercourse brings her to orgasm.<<elseif $activeSlave.releaseRules == "restrictive">>She obeys the rules about orgasm and hasn't gotten off as part of her assignment recently, so she orgasms despite the sterility of the intercourse.<<else>>She does not orgasm, serving you properly and showing appropriate disregard for her own pleasure.<</if>> When she's done, she makes the perfect exit, @@.hotpink;silently padding away like the passive sex object she is.@@
+		<<if $activeSlave.preg > 20>>Before starting to pleasure you, she notices there is no way she can move with her rounded middle sticking out as far as it does. She carefully turns around, feeling your glare on her back at her mistake.<</if>>
+		Still crouched over you, she begins to move up and down, milking <<if $PC.dick == 1>>your penis<<else>>the strap-on<</if>>. As she works into it, she lets her butt touch you, just once, but you make a nonverbal sound of disapproval, letting her know not to disturb your work like that. Realizing that she needs to play the human sex toy, she <<if $activeSlave.butt > 5>>grabs her huge buttocks and holds them apart, doing her best to keep them out of the way<<elseif $activeSlave.butt > 2>>takes hold of her healthy asscheeks and spreads them as far as they'll go, doing her best to keep them out of the way<<else>>uses her arms for balance, since her cute butt can stay out of the way on its own and doesn't need to be spread by hand<</if>>.<<if $activeSlave.preg > 30>> You spread your legs as you shift into a more comfortable position, stealthily showing mercy since she can't possibly keep her full-term belly off you otherwise.<</if>> She bobs up and down, getting you off without ever touching you<<if $PC.dick == 1>>, other than the contact between your penis and the inside of her body, of course<</if>>. <<if $activeSlave.energy > 80>>She has such a powerful sex drive that even this sterile intercourse brings her to orgasm.<<elseif $activeSlave.releaseRules == "restrictive">>She obeys the rules about orgasm and hasn't gotten off as part of her assignment recently, so she orgasms despite the sterility of the intercourse.<<else>>She does not orgasm, serving you properly and showing appropriate disregard for her own pleasure.<</if>> When she's done, she makes the perfect exit, @@.hotpink;silently padding away like the passive sex object she is.@@
 	<</replace>>
 	<<set $activeSlave.devotion += 5>>
 <</link>>
@@ -8179,20 +8177,20 @@ By the time you've finished with her sensitive ass, it shines red, and she is cr
 						slide your stiff prick up between the virgin's thighs for some intercrural sex.
 						<<set $activeSlave.oralCount++, $oralTotal++>>
 					<</if>>
-					As you fuck, her gaze flicks up and down along the row of suffering bodies. She climaxes again and again, shuddering at each new subtle sign that another one of the slaves here is being degraded by yet another cock inserted into yet another of her defenseless holes. By the time you're satisfied, she's so exhausted that her legs are shuddering uncontrollably as she struggles to remain standing with you. You drop her, leaving her to find her own way out of this place. You look back from the entrance, seeing that she's following you on shaky legs, staring at you with a profound look of mixed @@.mediumaquamarine;trust for your understanding of her horrible sadism,@@ and deep unease that this is what truly gets her off.
+					As you fuck<<if $activeSlave.preg > 20>> in the cramped corridor<</if>>, her <<if canSee($activeSlave)>>gaze flicks up and down along the row<<else>>ears perks up at the subtle sounds<</if>> of suffering bodies. She climaxes again and again, shuddering at each new subtle sign that another one of the slaves here is being degraded by yet another cock inserted into yet another of her defenseless holes. By the time you're satisfied, she's so exhausted that her legs are shuddering uncontrollably as she struggles to remain standing with you. You drop her, leaving her to find her own way out of this place. You look back from the entrance, seeing that she's following you on shaky legs, <<if canSee($activeSlave)>>staring at<<else>>facing<</if>> you with a profound look of mixed @@.mediumaquamarine;trust for your understanding of her horrible sadism,@@ and deep unease that this is what truly gets her off.
 				<</replace>>
 				<<set $activeSlave.trust += 5>>
 			<</link>>
 			<br><<link "Teach her about true sadism">>
 				<<replace "#result2">>
-					She seems to be focusing on the purely physical aspects of the degradation here. The true meaning of this place is so much more, and you decide to share it with her. You call her name, tearing her attention away from the spectacle mere centimeters over your heads, and point to a particular slave. You tell $activeSlave.slaveName that this particular Arcade inmate's name is
+					She seems to be focusing on the purely physical aspects of the degradation here. The true meaning of this place is so much more, and you decide to share it with her. You call her name, tearing her attention away from the spectacle mere centimeters over your heads, and <<if $canSee($activeSlave)>>point<<else>>direct her<</if>> to a particular slave. You tell $activeSlave.slaveName that this particular Arcade inmate's name is
 					<<for $i = 0; $i < $slaves.length; $i++>>
 					<<if $slaves[$i].assignment == "be confined in the arcade">>
 						$slaves[$i].slaveName. You tell her that she is $slaves[$i].age years old, that she is $slaves[$i].nationality, and that she was once $slaves[$i].career. You list more details of her life before she was placed here to be fucked endlessly. $activeSlave.slaveName's eyes widen as you recite the details of the prior life of this piece of human sexual equipment and the sheer weight of the intellectual sadism smashes into her. Then the slave above you both jerks a little. <<if $activeSlave.dick == 0>>There's no visible sign her pussy's being fucked, so it must be<<else>>Her cock hardens involuntarily, indicating that it's<</if>> going into her ass. You resume, mentioning that she's been buttfucked $slaves[$i].slaveName times.
 						<<break>>
 					<</if>>
 					<</for>>
-					$activeSlave.slaveName jerks suddenly, <<if canAchieveErection($activeSlave)>>shooting her cum onto the floor<<elseif $activeSlave.vagina < 0>>dribbling a little<<elseif $activeSlave.vaginaLube > 0>>squirting onto the floor<<else>>orgasming<</if>>. She came without being touched. She stares at you helplessly, in the presence of the arcology's @@.hotpink;undisputed preeminent sadist,@@ shuddering at the sheer gothic glory of it. She has a new moment to think of when she feels like @@.lightsalmon;indulging her own sadism.@@
+					$activeSlave.slaveName jerks suddenly, <<if canAchieveErection($activeSlave)>>shooting her cum onto the floor<<elseif $activeSlave.vagina < 0>>dribbling a little<<elseif $activeSlave.vaginaLube > 0>>squirting onto the floor<<else>>orgasming<</if>>. She came without being touched. She <<if canSee($activeSlave)>>stares at<<else>>faces<</if>>, in the presence of the arcology's @@.hotpink;undisputed preeminent sadist,@@ shuddering at the sheer gothic glory of it. She has a new moment to think of when she feels like @@.lightsalmon;indulging her own sadism.@@
 				<</replace>>
 				<<set $activeSlave.devotion += 5, $activeSlave.fetishStrength = Math.clamp($activeSlave.fetishStrength+10, 0, 100)>>
 			<</link>>
@@ -8240,7 +8238,7 @@ By the time you've finished with her sensitive ass, it shines red, and she is cr
 <br><<link "Fuck her">>
 	<<replace "#name">>$activeSlave.slaveName<</replace>>
 	<<replace "#result">>
-		Finding the situation simply too good to pass up, you wait until she's not looking at you, and then approach her from behind.
+		Finding the situation simply too good to pass up, you wait until she's not <<if canSee($activeSlave)>>looking at<<else>>paying attention to<</if>> you, and then approach her from behind.
 		<<if ($activeSlave.fetishKnown == 1) && ($activeSlave.fetish == "buttslut")>>
 			She gasps wantonly as she feels the familiar sensation of <<if $PC.dick == 1>>your dick<<else>>a strap-on<</if>> infiltrating between her cheeks and towards her <<if $activeSlave.anus >= 3>>loose<<elseif $activeSlave.anus >= 2>>relaxed<<else>>tight little<</if>> anus. She releases her grip on the constricting clothing that's binding her thighs together and grinds her ass back against you, making sure every centimeter of your <<if $PC.dick == 1>>hard member<<else>>phallus<</if>> that will fit gets inside her asshole. Some time later, the hard pounding dislodges the clothing and it slides down her legs to gather around her ankles. @@.hotpink;She doesn't notice.@@
 			<<set $activeSlave.analCount++, $analTotal++>>
@@ -8281,7 +8279,7 @@ By the time you've finished with her sensitive ass, it shines red, and she is cr
 		$activeSlave.slaveName
 		<</replace>>
 		<<replace "#result2">>
-			You recline in your chair and inform $activeSlave.slaveName that she has one last thing to clean in your office. She understands your meaning quickly and sinks to her knees and crawls beneath your desk to kneel between your legs. Soon enough you feel the sensation of her lips wrapping obediently about one of your toes, fellating the appendage with some enthusiasm. She works her way through your various digits, taking some solace in the simplicity of her task, before a sudden understanding dawns on her. She runs her tongue up your leg, cleansing your skin with her tongue as best she can, before heading for your
+			You recline in your chair and inform $activeSlave.slaveName that she has one last thing to clean in your office. She understands your meaning quickly, sinks to her knees and <<if $activeSlave.preg > 20>>stuggles to crawl<<else>>crawls<</if>> beneath your desk to kneel between your legs. Soon enough you feel the sensation of her lips wrapping obediently about one of your toes, fellating the appendage with some enthusiasm. She works her way through your various digits, taking some solace in the simplicity of her task, before a sudden understanding dawns on her. She runs her tongue up your leg, cleansing your skin with her tongue as best she can, before heading for your
 		<<if $PC.dick == 1>>cock<<if $PC.vagina == 1>> and <</if>><</if>><<if $PC.vagina == 1>>cunt<</if>>
 		but you lay a hand on her forehead and halt her - she'll do that last.
 		<<if $PC.boobs == 1>>
@@ -8314,16 +8312,10 @@ By the time you've finished with her sensitive ass, it shines red, and she is cr
 
 <<case "young PC age difference">>
 
-As another long weeks draws to a close, <span id="name"><<print "[[$activeSlave.slaveName|Long Slave Description][$nextLink = passage(), $eventDescription = 1]]">></span> happens to walk past your office toward bed. There's nothing inherently abnormal about her actions, but you do notice as she steps past the doorway that an expression of worry and concern adorns her $activeSlave.skin face. When you call her into your office, her face visibly brightens up in an attempt to conceal her obvious distress as she comes before you. Notably, although she stands still and patiently awaits further orders, you notice she <<if canSee($activeSlave)>>never manages to meet your eyes<<else>>keeps her sightless eyes downcast<</if>>.  When you ask her what's troubling her, her face plainly falls.
-<br><br>
-<<if ($activeSlave.lips > 70)>>"<<Master>>, you're tho young," she lisps through her dick-sucking lips before smiling shyly in an attempt to insert some levity into her confession. "It'th jutht that I'm old enough to be your mother, <<Master>>. It'th a little weird, ithn't it?"<<elseif ($activeSlave.lipsPiercing+$activeSlave.tonguePiercing > 2)>>"<<Master>>, you're tho young," she lisps through her ridiculous piercings before smiling around them in an attempt to insert some levity into her confession. "It'th jutht that I'm old enough to be your mother, <<Master>>. It'th a little weird, ithn't it?."<<else>>"<<Master>>, you're so young," she says penitently before smiling shyly in an attempt to insert some levity into her confession. "It's just that I'm old enough to be your mother, <<Master>>. It's a little weird, isn't it?"<</if>>
-
-<<case "young PC age difference">>
-
 <<link "Gently acclimate her to the age difference with some lovemaking">>
 	<<replace "#name">>$activeSlave.slaveName<</replace>>
 	<<replace "#result">>
-	As you cross the breadth of your office to reach $activeSlave.slaveName, she presents herself for your sexual usage out of habit. However, you take her by surprise by drawing her into you arms, running the tips of your fingers through her $activeSlave.hColor hair,  and looking into her $activeSlave.eyeColor eyes. <<if canSee($activeSlave)>>She meets your gaze for a brief moment before blushing girlishly, as if forgetting how many years your senior she is<<else>>She seems to feel the intensity of your gaze despite her sightless eyes and blushes girlishly, as if forgetting how many years your senior she is<</if>> . In lieu of words, you lift her chin with a single beckoning finger and steal her breath from her lips with a firm kiss. Once she's recovered her wits she clings to you with almost animalistic attachment. After a few moments she moves to get down on her knees, clearly defaulting to her role as a sex slave in response to your unexpected intimacy. Instead, you <<if $activeSlave.preg > 20>>carefully <</if>>lift her up from her low position beneath you and carry her to bed, laying the flushed older woman down on the sheets before gently positioning yourself on top of her. Together, the two of you make fiercely intimate love, while you whisper romantic reassurances into her ear, nip at her neck,<<if $activeSlave.preg > 20>>stroke her pregnant belly,<</if>> and bring her to climax again and again. After a final frantic orgasm together in her pussy she <<if canSee($activeSlave)>>looks<<else>>gazes sightlessly<</if>> up at you with @@.hotpink;adoration@@ and a new @@.mediumaquamarine;trust@@ in her young <<Master>>.
+	As you cross the breadth of your office to reach $activeSlave.slaveName, she presents herself for your sexual usage out of habit. However, you take her by surprise by drawing her into you arms, running the tips of your fingers through her $activeSlave.hColor hair, and looking into her $activeSlave.eyeColor eyes. <<if canSee($activeSlave)>>She meets your gaze for a brief moment before blushing girlishly, as if forgetting how many years your senior she is<<else>>She seems to feel the intensity of your gaze despite her sightless eyes and blushes girlishly, as if forgetting how many years your senior she is<</if>> . In lieu of words, you lift her chin with a single beckoning finger and steal her breath from her lips with a firm kiss. Once she's recovered her wits she clings to you with almost animalistic attachment. After a few moments she moves to get down on her knees, clearly defaulting to her role as a sex slave in response to your unexpected intimacy. Instead, you <<if $activeSlave.preg > 20>>carefully <</if>>lift her up from her low position beneath you and carry her to bed, laying the flushed older woman down on the sheets before gently positioning yourself on top of her. Together, the two of you make fiercely intimate love, while you whisper romantic reassurances into her ear, nip at her neck,<<if $activeSlave.preg > 20>>stroke her pregnant belly,<</if>> and bring her to climax again and again. After a final frantic orgasm together in her pussy she <<if canSee($activeSlave)>>looks<<else>>gazes sightlessly<</if>> up at you with @@.hotpink;adoration@@ and a new @@.mediumaquamarine;trust@@ in her young <<Master>>.
 	<<set $activeSlave.devotion += 4>>
 	<<set $activeSlave.trust += 4>>
 	<<set $activeSlave.vaginalCount += 1>>
@@ -8348,7 +8340,7 @@ As another long weeks draws to a close, <span id="name"><<print "[[$activeSlave.
 	<<replace "#result">>
 	You direct $assistantName to clear $activeSlave.slaveName's schedule and to find a local Frat House willing to 'host' a woman of her age and experience. Perhaps a group of virile college boys running a train on $activeSlave.slaveName might accustom her to younger sexual partners. When $activeSlave.slaveName leaves the penthouse, she's dressed up to look like a frumpy Old World MILF and is clearly skeptical about your age-play therapy.
 	<br><br>
-	$activeSlave.slaveName returns to the penthouse naked, disheveled, and absolutely covered in a thick coating of drying cum. Despite her appearance, however, she is practically beaming with happiness. It seems young cock agrees with her, and by the state of her messy pussy her youthful partners particularly enjoyed filling her with their potent seed. Unsurprisingly, at a routine check up later that week, $activeSlave.slaveName joyfully discovers that she was impregnated during her Frat House excursion. It seems that being bred by a bunch of horny college boys has eliminated her prior worries about the importance of age and also caused her to fetishize impregnation. @@.hotpink;She has become more submissive to you@@ for giving her the means to broaden her sexual horizons.
+	$activeSlave.slaveName returns to the penthouse naked, disheveled, and absolutely covered in a thick coating of drying cum. Despite her appearance, however, she is practically beaming with happiness. It seems young cock agrees with her, and by the state of her messy pussy her youthful partners particularly enjoyed filling her with their potent seed. Unsurprisingly, at a routine check up later that week, $activeSlave.slaveName joyfully discovers that she was impregnated during her Frat House excursion. It seems that being bred by a bunch of horny college boys has eliminated her prior worries about the importance of age and also caused her to @@.lightcoral;fetishize impregnation.@@ @@.hotpink;She has become more submissive to you@@ for giving her the means to broaden her sexual horizons.
 	<<set $activeSlave.devotion += 4>>
 	<<set $activeSlave.preg = 1>>
 	<<SetPregType $activeSlave>>
@@ -8391,7 +8383,7 @@ As another long weeks draws to a close, <span id="name"><<print "[[$activeSlave.
 	<<replace "#result">>
 	You direct $assistantName to clear $activeSlave.slaveName's schedule and to find a local retirement community willing to 'host' a girl of her age. Perhaps a group of venerable graybeards running a train on $activeSlave.slaveName might accustom her to older sexual partners. When $activeSlave.slaveName leaves the penthouse, she's dressed up to look like an Old World schoolgirl and is clearly skeptical about your age-play therapy.
 	<br><br>
-	$activeSlave.slaveName returns to the penthouse naked, disheveled, and absolutely covered in a thick coating of drying cum. Despite her appearance, however, she is practically beaming with happiness. It seems a good fucking from experienced older men agrees with her, and by the state of her messy pussy her aged partners particularly enjoyed filling her with their still potent seed. Unsurprisingly, at a routine check up later that week, $activeSlave.slaveName joyfully discovers that she was impregnated during her excursion. It seems that being bred by a bunch of horny old men has eliminated her prior worries about the importance of age and also caused her to fetishize impregnation. @@.hotpink;She has become more submissive to you@@ for giving her the means to broaden her sexual horizons.
+	$activeSlave.slaveName returns to the penthouse naked, disheveled, and absolutely covered in a thick coating of drying cum. Despite her appearance, however, she is practically beaming with happiness. It seems a good fucking from experienced older men agrees with her, and by the state of her messy pussy her aged partners particularly enjoyed filling her with their still potent seed. Unsurprisingly, at a routine check up later that week, $activeSlave.slaveName joyfully discovers that she was impregnated during her excursion. It seems that being bred by a bunch of horny old men has eliminated her prior worries about the importance of age and also caused her to @@.lightcoral;fetishize impregnation.@@ @@.hotpink;She has become more submissive to you@@ for giving her the means to broaden her sexual horizons.
 	<<set $activeSlave.devotion += 4>>
 	<<set $activeSlave.preg = 1>>
 	<<SetPregType $activeSlave>>
@@ -8483,8 +8475,6 @@ As another long weeks draws to a close, <span id="name"><<print "[[$activeSlave.
 		the lucky winner gazing down at a lengthy cock slapping against his stomach as $activeSlave.slaveName rides him.
 	<<elseif $activeSlave.intelligence > 1>>
 		the lucky winner engaged in a lively debate with $activeSlave.slaveName as he takes her from behind.
-	<<elseif $activeSlave.lips > 40>>
-		the lucky winner with a pair of plush lips wrapped around his cock, his hands gripping onto a $activeSlave.hColor-haired head for dear life as $activeSlave.slaveName sucks him dry.
 	<<elseif $activeSlave.preg > 20>>
 		the lucky winner taking $activeSlave.slaveName almost tenderly in missionary, his hands cradling her pregnant belly.
 	<<elseif $activeSlave.dick > 3>>
@@ -8495,6 +8485,8 @@ As another long weeks draws to a close, <span id="name"><<print "[[$activeSlave.
 		the lucky winner gingerly prodding the tiny cock slapping against his stomach as $activeSlave.slaveName rides him.
 	<<elseif $activeSlave.age > 35>>
 		the lucky winner double checking with $activeSlave.slaveName that she isn't his mother, even as she rides his cock and gives him pointers on his lack of technique.
+	<<elseif $activeSlave.lips > 40>>
+		the lucky winner with a pair of plush lips wrapped around his cock, his hands gripping onto a $activeSlave.hColor-haired head for dear life as $activeSlave.slaveName sucks him dry.
 	<<elseif $activeSlave.face > 60>>
 		the lucky winner staring in awe at the beautiful face of $activeSlave.slaveName, as she rides him tenderly.
 	<<else>>
@@ -8517,7 +8509,7 @@ As another long weeks draws to a close, <span id="name"><<print "[[$activeSlave.
 <<link "Enjoy some oral with an evening of wallscreen television">>
 	<<replace "#name">>$activeSlave.slaveName<</replace>>
 	<<replace "#result">>
-	There are some things that never change, even after ascension to the high position of an arcology owner. One of these fixtures of life is the ability to enjoy a relaxing evening of wallscreen television and <<if $PC.dick == 1>>a blowjob<<if $PC.vagina == 1>> and <</if>><</if>><<if $PC.vagina == 1>>some cunnilingus<</if>>. With $activeSlave.slaveName sequestered between your legs, you tune into your favorite Free Cities serial drama and <<if !canSee($activeSlave)>>audibly <</if>>widen your legs slightly as you sink back into the chair with a sigh of contentment. She <<if $activeSlave.preg > 20>>kneels carefully with an arm wrapped protectively around her bump<<else>>sinks to her knees obediently with her hands placed placidly on her thighs<</if>> before putting her mouth to work, <<if $activeSlave.oralSkill >= 100>>her mastery at giving oral providing a wealth of pleasure<<elseif $activeSlave.oralSkill > 60>>her skills in oral providing ample pleasure<<else>>her mediocre oral skills providing some relief<</if>>.<<if $activeSlave.teeth > 2>> Although most of your attention is focused on the intriguing drama unfolding on your wallscreen, you still feel the extreme care she has to take to keep her sharklike teeth clear of you.<<elseif $activeSlave.lips > 40>> Her huge lips are soft and pillowy against you.<<elseif ($activeSlave.teeth is "straightening braces") || ($activeSlave.teeth is "cosmetic braces")>> Although most of your attention is focused on the intriguing drama unfolding on your wallscreen, you can feel the slight hesitations as she takes care to keep her braces off you.<</if>> You have an enjoyable evening glued to your wallscreen, punctuated by the playful ruffling <<if $activeSlave.hLength > 1>>of $activeSlave.slaveName's $activeSlave.hColor hair<<else>>across $activeSlave.slaveName's scalp<</if>> and the occasional orgasm into her waiting mouth. Though your experience was more stimulating than hers, $activeSlave.slaveName enjoyed @@.hotpink;being used while you enjoyed yourself.@@
+	There are some things that never change, even after ascension to the high position of an arcology owner. One of these fixtures of life is the ability to enjoy a relaxing evening of wallscreen television and <<if $PC.dick == 1>>a blowjob<<if $PC.vagina == 1>> and <</if>><</if>><<if $PC.vagina == 1>>some cunnilingus<</if>>. With $activeSlave.slaveName sequestered between your legs, you tune into your favorite Free Cities serial drama and <<if !canSee($activeSlave)>>audibly <</if>>widen your legs slightly as you sink back into the chair with a sigh of contentment. She <<if $activeSlave.preg > 20>>kneels carefully with an arm wrapped protectively around her bump<<else>>sinks to her knees obediently with her hands placed placidly on her thighs<</if>> before putting her mouth to work, <<if $activeSlave.oralSkill >= 100>>her mastery at giving oral providing a wealth of pleasure<<elseif $activeSlave.oralSkill > 60>>her skills in oral providing ample pleasure<<else>>her mediocre oral skills providing some relief<</if>>.<<if $activeSlave.teeth > 2>> Although most of your attention is focused on the intriguing drama unfolding on your wallscreen, you still feel the extreme care she has to take to keep her sharklike teeth clear of you.<<elseif $activeSlave.lips > 40>> Her huge lips are soft and pillowy against you.<<elseif ($activeSlave.teeth == "straightening braces") || ($activeSlave.teeth == "cosmetic braces")>> Although most of your attention is focused on the intriguing drama unfolding on your wallscreen, you can feel the slight hesitations as she takes care to keep her braces off you.<</if>> You have an enjoyable evening glued to your wallscreen, punctuated by the playful ruffling <<if $activeSlave.hLength > 1>>of $activeSlave.slaveName's $activeSlave.hColor hair<<else>>across $activeSlave.slaveName's scalp<</if>> and the occasional orgasm into her waiting mouth. Though your experience was more stimulating than hers, $activeSlave.slaveName enjoyed @@.hotpink;being used while you enjoyed yourself.@@
 	<<set $activeSlave.devotion += 4, $activeSlave.oralCount += 1, $oralTotal += 1>>
 	<</replace>>
 <</link>>
@@ -8554,16 +8546,16 @@ As another long weeks draws to a close, <span id="name"><<print "[[$activeSlave.
 	<<set $activeSlave.devotion += 4>>
 	<<BothVCheck>>
 	<</replace>>
-<</link>><<if ($activeSlave.anus == 0) or ($activeSlave.vagina == 0)>> //This option will take virginity//<</if>>
+<</link>><<if ($activeSlave.anus == 0) || ($activeSlave.vagina == 0)>> //This option will take virginity//<</if>>
 <br><<link "Show her that short girls can still serve">>
 	<<replace "#name">>$activeSlave.slaveName<</replace>>
 	<<replace "#result">>
 		You lightly place your palms on her shoulders and apply a little pressure<<if $PC.dick == 0>>as you don a strap-on<</if>>. From your towering position above her, you easily push her down to her knees with little more than a gradual increase in force. From your standing position, your <<if $PC.dick == 0>>phallus<<else>>cock<</if>> hovers above her head, tantalizingly out of the immediate reach of her lips.
-		<<if ($activeSlave.teeth is "removable")>>
+		<<if ($activeSlave.teeth == "removable")>>
 			She quickly pulls her removable teeth out, setting them aside as she looks up at your <<if $PC.dick == 0>>phallus<<else>>cock<</if>>.
-		<<elseif ($activeSlave.teeth is "pointy")>>
+		<<elseif ($activeSlave.teeth == "pointy")>>
 			She opens her mouth wide, revealing her sharp fangs even as she reminds herself diligently to not let her sharp teeth scrape against your shaft.
-		<<elseif ($activeSlave.teeth is "straightening braces") || ($activeSlave.teeth is "cosmetic braces")>>
+		<<elseif ($activeSlave.teeth == "straightening braces") || ($activeSlave.teeth == "cosmetic braces")>>
 			She opens her mouth wide, revealing a mouthful of braces even as she reminds herself diligently to not let her orthodontia scrape against your shaft.
 		<</if>>
 		You inform her that short slaves like her might have to try harder, but they can still serve just as well as any of their taller peers. Understanding your meaning, she pushes herself up as far as she can with your hands still lightly pressing down on her shoulders, straining her neck until she can take you fully into her waiting mouth, keeping her eyes closed as she concentrates intently on her task. She lightly rocks back and forth on her knees in an attempt to gain a little height to better pleasure you with her mouth, an amusing sight to behold as you stand above her.
@@ -8584,7 +8576,7 @@ As another long weeks draws to a close, <span id="name"><<print "[[$activeSlave.
 	<br><<link "Show her that short girls are amusing in the arcade">>
 	<<replace "#name">>$activeSlave.slaveName<</replace>>
 	<<replace "#result">>
-		You inform $activeSlave.slaveName that short girls like her are delightfully amusing when immured in the arcade. Magnanimous as you are, you have two other slaves drag her off to be installed in the arcade for a day, so that she too may see the humor in having short girls serve in the arcade.  Though $arcadeName has arcade pens to match any height of slave, you have $activeSlave.slaveName confined in a pen built for a much taller slave. Although her head and neck protrude from one side of the pen without issue, she is too short for her ass to fill the other opening. As a result, she must use the tips of her toes maintain an unsteady grip on the rear opening, forcing her to maintain an extremely taxing stretch just to keep her body held aloft within the pen. Costumers are unable to fuck her holes but readily delight in watching her squirm to keep her body extended and horizontal, even with hard cocks brutally fucking her face. Somewhere in the gruelling, 18-hour marathon of relentless throat fucking, her precarious position slips and her lower half tumbles into the interior of the pen proper. Until an attendant rescues her, her neck is held crooked at an unnatural angle by her restraints, as the rest of her body dangles beneath it. Her ordeal forces her to accept that a short girl's place is as an @@.hotpink;amusing arcade hole@@.  Though she can't find the humor@@.gold;in such a terrible plight@@. Furthermore, her intense exertions during her stay @@.red;negatively effects her health@@. Your other  slaves take note of what you do to short girls who ask questions about their place in your penthouse.
+		You inform $activeSlave.slaveName that short girls like her are delightfully amusing when immured in the arcade. Magnanimous as you are, you have two other slaves drag her off to be installed in the arcade for a day, so that she too may see the humor in having short girls serve in the arcade.  Though $arcadeName has arcade pens to match any height of slave, you have $activeSlave.slaveName confined in a pen built for a much taller slave. Although her head and neck protrude from one side of the pen without issue, she is too short for her ass to fill the other opening. As a result, she must use the tips of her toes maintain an unsteady grip on the rear opening, forcing her to maintain an extremely taxing stretch just to keep her body held aloft within the pen. Costumers are unable to fuck her holes but readily delight in watching her squirm to keep her body extended and horizontal, even with hard cocks brutally fucking her face. Somewhere in the gruelling, 18-hour marathon of relentless throat fucking, her precarious position slips and her lower half tumbles into the interior of the pen proper. Until an attendant rescues her, her neck is held crooked at an unnatural angle by her restraints, as the rest of her body dangles beneath it. Her ordeal forces her to accept that a short girl's place is as an @@.hotpink;amusing arcade hole@@.  Though she can't find the humor@@.gold;in such a terrible plight@@. Furthermore, her intense exertions during her stay @@.red;negatively effects her health@@. Your other slaves take note of what you do to short girls who ask questions about their place in your penthouse.
 		<<set $activeSlave.devotion += 5, $activeSlave.trust -= 5, $activeSlave.health -= 5, $activeSlave.oralCount += 55, $activeSlave.oralTotal += 55>>
 	<</replace>>
 <</link>>
@@ -8609,7 +8601,7 @@ As another long weeks draws to a close, <span id="name"><<print "[[$activeSlave.
 <br><<link "Assrape her">>
 	<<replace "#name">>$activeSlave.slaveName<</replace>>
 	<<replace "#result">>
-	She's an anal sex toy, and you decide to use her like one. You walk over, reach down, and jerk her to her feet. You don't hurt her, not yet, but the violence of the motion forces a sob out of her. She sees the open lust in your eyes and is afraid. She's not wrong to be so; you spin her roughly around and use one arm to pin her upper body mercilessly in place while you use your other hand to
+	She's an anal sex toy, and you decide to use her like one. You walk over, reach down, and jerk her to her feet. You don't hurt her, not yet, but the violence of the motion forces a sob out of her. She <<if canSee($activeSlave)>>sees the open lust in your eyes<<else>>feels the lust lingering about you<</if>> and is afraid. She's not wrong to be so; you spin her roughly around and use one arm to pin her upper body mercilessly in place while you use your other hand to
 	<<if $activeSlave.anus > 2>>
 		manhandle your <<if $PC.dick == 1>>cock<<else>>strap-on<</if>> up her roomy ass. It's disappointingly easy, and she takes it without a struggle, so you reach around her front, down between her legs, and jam a couple of fingers up there, too.
 	<<elseif $activeSlave.anus > 1>>
@@ -8633,7 +8625,7 @@ As another long weeks draws to a close, <span id="name"><<print "[[$activeSlave.
 	<<replace "#result">>
 	You order her to take the next pose in the inspection series, as though she hadn't broken down at all. There's such understated menace in your voice that she gets right back to her feet, using the back of a $activeSlave.skin hand to cuff away her tears. "Y-ye<<s>>, <<Master>>," she sniffles, trying to get herself under control, and then shudders.
 	<<if $dairy > 0 && $dairyStimulatorsSetting == 2>>
-		It's never hard to see the exact moment when your slaves remind themselves that you run an industrial Dairy, and that if they displease you, they may find themselves hydrated for milk production from fifty kilogram udders by constant machine rape down their throats and up their asses.
+		It's never hard to see the exact moment when your slaves remind themselves that you run an industrial Dairy, and that if they displease you, they may find themselves hydrated for milk production from fifty kilogram udders by constant machine rape down their throats and up their asses<<if isFertile($activeSlave) && $dairyPregSetting > 0>> as thier wombs steadily fill with life<</if>>.
 	<<elseif $arcade > 0>>
 		It's never hard to see the exact moment when your slaves remind themselves that you own an Arcade, and that if they displease you, they may find themselves immured there and condemned to a universe in which the only sensory stimulation is penetration.
 	<<elseif $activeSlave.trust < -20>>

--- a/src/uncategorized/RETS.tw
+++ b/src/uncategorized/RETS.tw
@@ -99,29 +99,10 @@
 
 <<case "repressed anal virgin">>
 
-<<set $subSlave = 0>>
-<<for $i = 0; $i < $slaves.length; $i++>>
-  <<if $slaves[$i].anus > 0>>
-  <<if $slaves[$i].devotion > 50>>
-  <<if $slaves[$i].amp == 0>>
-	<<set $subSlave = $slaves[$i]>>
-	<<set $slaves[$i].analCount += 1>>
-	<<set $analTotal += 1>>
-	<<break>>
-  <</if>>
-  <</if>>
-  <</if>>
-<</for>>
-<<if $subSlave == 0>>
-  <<for $i = 0; $i < $slaves.length; $i++>>
-	<<if $slaves[$i].anus > 0>>
-	  <<set $subSlave = $slaves[$i]>>
-	  <<set $slaves[$i].analCount += 1>>
-	  <<set $analTotal += 1>>
-	  <<break>>
-	<</if>>
-  <</for>>
-<</if>>
+<<set $subSlave = $RERepressedAnalVirginSub>>
+<<set _m = $slaves.findIndex(function(s) { return s.ID == $subSlave.ID; })>>
+<<set $slaves[_m].analCount += 1>>
+<<set $analTotal += 1>>
 
 <<case "top exhaustion">>
 
@@ -1335,7 +1316,7 @@ $subSlave.slaveName <<if _vaginal>>looks out from under $activeSlave.slaveName<<
 	<<set $activeSlave.anus += 1>>
 	<</replace>>
 <</link>> //This option will take anal virginity//
-<<link "Girls' butts are for pounding">>
+<br><<link "Girls' butts are for pounding">>
 	<<replace "#name">>$activeSlave.slaveName<</replace>>
 	<<replace "#result">>
 	You tell her that her butt is your property, just like $subSlave.slaveName's. She looks @@.gold;terrified.@@ You continue, telling her to bring your property over to you. She stumbles over, begging,
@@ -1432,7 +1413,7 @@ $subSlave.slaveName <<if _vaginal>>looks out from under $activeSlave.slaveName<<
 		<<SimpleVCheck>>
 	<<case "pregnancy">>
 		<<if $activeSlave.preg > 10>>
-			massaging the pregnant sluts belly as you fuck her.
+			massaging the pregnant slut's belly as you fuck her.
 		<<else>>
 			pushing the impregnation slut into a corner and pretending you're knocking her up.
 		<</if>>

--- a/src/uncategorized/randomIndividualEvent.tw
+++ b/src/uncategorized/randomIndividualEvent.tw
@@ -21,7 +21,7 @@
 
 /* SUB CHECKS */
 
-<<set $RERelationshipSlave = 0, $REShowerForceSub = 0, $RESadisticDescriptionSub = 0, $REIfYouEnjoyItSub = 0, $REBoobCollisionSub = 0>>
+<<set $RERelationshipSlave = 0, $REShowerForceSub = 0, $RESadisticDescriptionSub = 0, $REIfYouEnjoyItSub = 0, $REBoobCollisionSub = 0, $RERepressedAnalVirginSub = 0>>
 <<set $REAnalCowgirlSubIDs = [], $RETasteTestSubIDs = [], $RESimpleAssaultIDs = []>>
 
 <<for $i = 0; $i < $slaves.length; $i++>>
@@ -75,15 +75,32 @@
 	<</if>>
 	<</if>>
 	<</if>>
+	<<if $slaves[$i].anus > 0>>
+	<<if $slaves[$i].devotion > 50>>
+	<<if $slaves[$i].amp == 0>>
+		<<set $RERepressedAnalVirginSub = $slaves[$i]>>
+	<</if>>
+	<</if>>
+	<</if>>
 <</if>>
 <</if>>
+<</if>>
+<<if $RERepressedAnalVirginSub == 0>>
+	<<for $i = 0; $i < $slaves.length; $i++>>
+		<<if $slaves[$i].anus > 0>>
+		  <<set $RERepressedAnalVirginSub = $slaves[$i]>>
+		  <<break>>
+		<</if>>
+	<</for>>
 <</if>>
 <<if ($REShowerForceSub != 0)>>
 <<if ($RESadisticDescriptionSub != 0)>>
 <<if ($REIfYouEnjoyItSub != 0)>>
+<<if $RERepressedAnalVirginSub != 0>>
 <<if ($REAnalCowgirlSubIDs.length > 1)>>
 <<if ($RETasteTestSubIDs.length > 1)>>
 	<<break>>
+<</if>>
 <</if>>
 <</if>>
 <</if>>
@@ -124,11 +141,13 @@
 <</if>>
 <</if>>
 
+<<if $RERepressedAnalVirginSub != 0>>
 <<if ($eventSlave.anus == 0)>>
 <<if ($eventSlave.devotion >= -50)>>
 <<if ($eventSlave.trust >= -50)>>
 <<if ($eventSlave.sexualFlaw == "repressed")>>
 	<<set $RETSevent.push("repressed anal virgin")>>
+<</if>>
 <</if>>
 <</if>>
 <</if>>
@@ -1545,7 +1564,7 @@
 <<if ($eventSlave.boobs < 500)>>
 <<if ($eventSlave.butt < 3)>>
 <<if ($eventSlave.devotion <= 50)>>
-<<if ($eventSlave.devotion > 20) || ($eventSlave.trust < -20)>>
+<<if ($eventSlave.devotion > 20) && ($eventSlave.trust > -20)>>
 <<if ($eventSlave.anus > 0)>>
 <<if ($eventSlave.weight <= 10)>>
 <<if ($eventSlave.muscles <= 30)>>


### PR DESCRIPTION
Fixes resistant anal virgin from showing up when you have no applicable subSlaves and keeps obediant girlish from showing up on disobediant slaves.