### PR TITLE
Fix emotional slut flip-flopping

### DIFF
--- a/src/uncategorized/saRelationships.tw
+++ b/src/uncategorized/saRelationships.tw
@@ -222,8 +222,14 @@
 		<<elseif _SlaveI.relationship < 0>>
 			/% Relationship with the PC %/
 			<<if _SlaveI.relationship == -1>>
-				<<if (_SlaveI.energy < 90)>>
-					She is no longer such a complete nymphomaniac, and has @@.lightsalmon;begun to rely less on sex for emotional support@@ than she once did.
+				<<if (_SlaveI.energy >= 90) && (_SlaveI.assignment != "serve the public") && (_SlaveI.assignment != "serve in the club") && (_SlaveI.assignment != "whore") && (_SlaveI.assignment != "work in the brothel")>>
+					She is such a nymphomaniac that even without a steady stream of lovers, her emotional reliance on promiscuity remains.
+				<<else>>
+				<<if (_SlaveI.assignment == "serve the public") || (_SlaveI.assignment == "serve in the club") || (_SlaveI.assignment == "whore") || (_SlaveI.assignment == "work in the brothel")>>
+					Her endless stream of lovers maintains and satisfies her emotional reliance on sex.
+				<<else>>
+					She is not a complete nymphomaniac and she doesn't have a constant stream of lovers, so she has @@.lightsalmon;begun to rely less on sex for emotional support@@ than she once did.
+				<</if>>
 					<<set _SlaveI.relationship = 0>>
 				<<elseif (_SlaveI.assignment == "serve in the master suite") && ($masterSuiteUpgradeLuxury == 2)>>
 					Forming a part of the pile of copulating bodies in $masterSuiteName satisfies her voracious sexual appetite.


### PR DESCRIPTION
Devoted non-nympho slaves on public use would acquire and then immediately lose emotional slut status. Made it so that whoring or public use will maintain that status, and also gave some more feedback as to what maintains emotional slut status.