### PR TITLE
Rebalanced obedience/trust fetishstrength changes

### DIFF
--- a/src/uncategorized/saLongTermEffects.tw
+++ b/src/uncategorized/saLongTermEffects.tw
@@ -1223,7 +1223,7 @@
 
 <<if $slaves[$i].fetishKnown == 1>>
 <<if $slaves[$i].fetish != "none">>
-	<<if $slaves[$i].fetishStrength <= 95>>
+	<<if $slaves[$i].fetishStrength <= 75>>
 		<<if $slaves[$i].devotion > 50>>
 		<<if $slaves[$i].trust > 50>>
 			She has the confidence to pursue what pleases her, @@.lightcoral;increasing her kinkiness.@@
@@ -1231,7 +1231,7 @@
 		<</if>>
 		<</if>>
 	<</if>>
-	<<if $slaves[$i].fetishStrength > 5>>
+	<<if $slaves[$i].fetishStrength > 10>>
 		<<if $slaves[$i].trust < -20>>
 			She's too afraid to pursue what pleases her, @@.pink;reducing her sexual distinctiveness.@@
 			<<set $slaves[$i].fetishStrength -= 4>>


### PR DESCRIPTION
1) Made it so that being sufficiently devoted and trusting isn't enough to get a slave into maximum strength and paraphilia territory - events, smart piercings, or complimentary softened flaws are needed.

2) Made it so that fetishes were a little 'stickier' on disobedient and terrified slaves - it'll still fall to a really low level, but it's less likely to disappear entirely now, making slaves a little bit more unique and stopping them all from trending to vanilla.