### PR TITLE
Tweaked profit reporting in dairy

### DIFF
--- a/src/uncategorized/dairyReport.tw
+++ b/src/uncategorized/dairyReport.tw
@@ -613,7 +613,11 @@ $dairyNameCaps produced _milkWeek liters of milk<<if _cumWeek > 0>> and _cumWeek
 <<elseif _births > 0>>
 	Additionally, one cow gave birth<<if _births > _birthers>> to a total of _births calves<</if>> this week.
 <</if>>
-These products sell for @@.yellowgreen;¤_profits@@.
+<<if (_profits > 0)>>
+These sale of these products makes a profit of @@.yellowgreen;¤_profits@@.
+<<elseif (_profits < 0)>>
+Due to one-off costs of hormonal implants to encourage fluid production, your dairy made a loss of @@.red;¤_profits@@.
+<</if>>
 
 <<if ($arcologies[0].FSPastoralistLaw == 1)>>
 	Slave products have completely replaced traditional dairy, making the facility extremely lucrative.


### PR DESCRIPTION
_profits is net instead of gross, which could lead to some misleading messages. Eliminated the ambiguity and added a message clarifying things when the dairy makes a loss - AFAIK this is only possible due to hormone implants in new cows.