### PR TITLE
Prevent break of 'aid invitation' 

### DIFF
--- a/src/uncategorized/genericPlotEvents.tw
+++ b/src/uncategorized/genericPlotEvents.tw
@@ -123,13 +123,13 @@ The crowd of nude slaves led up to the lawn and chained to rings along one edge 
 <<case "aid invitation">>
 
 <<set $seed = []>>
-<<if (random(1,100) > $seeDicks)>>
+<<if ($seeDicks <= 75)>>
 	<<set $seed.push("convent")>>
 	<<set $seed.push("school")>>
 	<<set $seed.push("housewives")>>
 	<<set $seed.push("maternity")>>
 <</if>>
-<<if (random(0,99) < $seeDicks)>>
+<<if $seeDicks >= 25)>>
 	<<set $seed.push("conversion")>>
 <</if>>
 <<set $PAidTarget = $seed.random()>>

--- a/src/uncategorized/genericPlotEvents.tw
+++ b/src/uncategorized/genericPlotEvents.tw
@@ -129,7 +129,7 @@ The crowd of nude slaves led up to the lawn and chained to rings along one edge 
 	<<set $seed.push("housewives")>>
 	<<set $seed.push("maternity")>>
 <</if>>
-<<if $seeDicks >= 25)>>
+<<if ($seeDicks >= 25)>>
 	<<set $seed.push("conversion")>>
 <</if>>
 <<set $PAidTarget = $seed.random()>>


### PR DESCRIPTION
A couple times I've seen 'aid invitation' have no group specified before they made a choice, and the only reason it didn't break entirely is because it defaults to the housewife social circle if there's no $PAidTarget. This fixes that while still respecting $seeDicks.