### PR TITLE
Collective spirit impacts needs min no. of slaves

### DIFF
--- a/src/uncategorized/saDevotion.tw
+++ b/src/uncategorized/saDevotion.tw
@@ -350,6 +350,7 @@
 
 /* COLLECTIVE SPIRIT IMPACTS */
 
+<<if ($slaves.length > 3)>>
 <<set _collectiveTrustEffect = 0>>
 <<set _collectiveDevotionEffect = 0>>
 <<if $enduringDevotion > 50>>
@@ -401,6 +402,8 @@
 		The @@.mediumorchid;collective anger@@ @@.gold;and fear@@ your slaves feel reinforce her own feelings.
 	<</if>>
 <</if>>
+<</if>>
+
 <<if $slaves[$i].assignmentVisible == 1>>
 <<if ($arcade != 0) || (($dairy != 0) && ($dairyRestraintsSetting >= 2))>>
 	<<if $slaves[$i].devotion <= 95>>


### PR DESCRIPTION
In this case, 4 or more.

$slaves.length should work here since it's hooked into the sex slave counter in storyCaption.