### PR TITLE
Arcade upgrade changes

### DIFF
--- a/src/uncategorized/arcade.tw
+++ b/src/uncategorized/arcade.tw
@@ -85,9 +85,9 @@ $arcadeNameCaps
 <<elsif $arcadeUpgradeCollectors == 1>>
 	It has been retrofitted to milk lactating slaves<<if $seeDicks != 0>> and cockmilk slaves capable of ejaculating<</if>>, though less efficiently than a dedicated facility.
 <<else>>
-	It is a standard arcade. It can be upgraded to either maximize the pleasure of those that visit it at the expense of the health or the inmates, or to keep them healthy (if not happy) and milk them of useful fluids.
-	[[Upgrade the arcade with invasive performance-enhancing systems|Arcade][$cash -= _Tmult1, $arcadeUpgradeInjectors = 1]] | [[Retrofit the arcade to collect useful fluids|Arcade][$cash -= _Tmult1, $arcadeUpgradeCollectors = 1]]
-	//Costs either will cost ¤_Tmult1 and will increase upkeep costs. They are mutually exclusive; only one can be chosen.// 
+	It is a standard arcade. It can be upgraded to either maximize the pleasure of those that visit it at the expense of the health or the inmates, or to keep them healthy (if not happy) and milk them of useful fluids.<br>
+	[[Upgrade the arcade with invasive performance-enhancing systems|Arcade][$cash -= _Tmult1, $arcadeUpgradeInjectors = 1]] | [[Retrofit the arcade to collect useful fluids|Arcade][$cash -= _Tmult1, $arcadeUpgradeCollectors = 1]]<br>
+	//Choosing either upgrade will cost ¤_Tmult1 and will increase upkeep costs. They are mutually exclusive; only one can be chosen.// 
 <</if>>
 
 <<if $arcologies[0].FSPaternalist == "unset">>

--- a/src/uncategorized/arcade.tw
+++ b/src/uncategorized/arcade.tw
@@ -82,12 +82,12 @@ $arcadeNameCaps
 <<set _Tmult1 = Math.trunc(10000*$upgradeMultiplierArcology)>>
 <<if $arcadeUpgradeInjectors == 1>>
 	It has been upgraded with aphrodisiac injection systems and electroshock applicators. If the aphrodisiacs fail to force an orgasm from an inmate, she is shocked to tighten her holes regardless.
-<<elsif $arcadeUpgradeCollectors == 1>>
+<<elseif $arcadeUpgradeCollectors == 1>>
 	It has been retrofitted to milk lactating slaves<<if $seeDicks != 0>> and cockmilk slaves capable of ejaculating<</if>>, though less efficiently than a dedicated facility.
 <<else>>
-	It is a standard arcade. It can be upgraded to either maximize the pleasure of those that visit it at the expense of the health or the inmates, or to keep them healthy (if not happy) and milk them of useful fluids.<br>
+	<br>It is a standard arcade. It can be upgraded to either maximize the pleasure of those that visit it at the expense of the health or the inmates, or to keep them healthy (if not happy) and milk them of useful fluids.<br>
 	[[Upgrade the arcade with invasive performance-enhancing systems|Arcade][$cash -= _Tmult1, $arcadeUpgradeInjectors = 1]] | [[Retrofit the arcade to collect useful fluids|Arcade][$cash -= _Tmult1, $arcadeUpgradeCollectors = 1]]<br>
-	//Choosing either upgrade will cost ¤_Tmult1 and will increase upkeep costs. They are mutually exclusive; only one can be chosen.// 
+	//Choosing either upgrade will cost ¤_Tmult1 and will increase upkeep costs. They are mutually exclusive; only one can be chosen.// <br>
 <</if>>
 
 <<if $arcologies[0].FSPaternalist == "unset">>

--- a/src/uncategorized/arcade.tw
+++ b/src/uncategorized/arcade.tw
@@ -82,15 +82,12 @@ $arcadeNameCaps
 <<set _Tmult1 = Math.trunc(10000*$upgradeMultiplierArcology)>>
 <<if $arcadeUpgradeInjectors == 1>>
 	It has been upgraded with aphrodisiac injection systems and electroshock applicators. If the aphrodisiacs fail to force an orgasm from an inmate, she is shocked to tighten her holes regardless.
-<<else>>
-	It is a standard arcade. [[Upgrade the arcade with invasive performance-enhancing systems|Arcade][$cash -= _Tmult1, $arcadeUpgradeInjectors = 1]] //Costs ¤_Tmult1 and will increase upkeep costs//
-<</if>>
-
-<br>
-<<if $arcadeUpgradeCollectors == 1>>
+<<elsif $arcadeUpgradeCollectors == 1>>
 	It has been retrofitted to milk lactating slaves<<if $seeDicks != 0>> and cockmilk slaves capable of ejaculating<</if>>, though less efficiently than a dedicated facility.
-<<else>>
-	There is no special provision for lactating<<if $seeDicks != 0>> or ejaculating<</if>> slaves. [[Retrofit the arcade to collect useful fluids|Arcade][$cash -= _Tmult1, $arcadeUpgradeCollectors = 1]] //Costs ¤_Tmult1 and will increase upkeep costs//
+<</else>>
+	It is a standard arcade. It can be upgraded to either maximize the pleasure of those that visit it at the expense of the health or the inmates, or to keep them healthy (if not happy) and milk them of useful fluids.
+	[[Upgrade the arcade with invasive performance-enhancing systems|Arcade][$cash -= _Tmult1, $arcadeUpgradeInjectors = 1]] | [[Retrofit the arcade to collect useful fluids|Arcade][$cash -= _Tmult1, $arcadeUpgradeCollectors = 1]]
+	//Costs either will cost ¤_Tmult1 and will increase upkeep costs. They are mutually exclusive; only one can be chosen.// 
 <</if>>
 
 <<if $arcologies[0].FSPaternalist == "unset">>

--- a/src/uncategorized/arcade.tw
+++ b/src/uncategorized/arcade.tw
@@ -84,7 +84,7 @@ $arcadeNameCaps
 	It has been upgraded with aphrodisiac injection systems and electroshock applicators. If the aphrodisiacs fail to force an orgasm from an inmate, she is shocked to tighten her holes regardless.
 <<elsif $arcadeUpgradeCollectors == 1>>
 	It has been retrofitted to milk lactating slaves<<if $seeDicks != 0>> and cockmilk slaves capable of ejaculating<</if>>, though less efficiently than a dedicated facility.
-<</else>>
+<<else>>
 	It is a standard arcade. It can be upgraded to either maximize the pleasure of those that visit it at the expense of the health or the inmates, or to keep them healthy (if not happy) and milk them of useful fluids.
 	[[Upgrade the arcade with invasive performance-enhancing systems|Arcade][$cash -= _Tmult1, $arcadeUpgradeInjectors = 1]] | [[Retrofit the arcade to collect useful fluids|Arcade][$cash -= _Tmult1, $arcadeUpgradeCollectors = 1]]
 	//Costs either will cost ¤_Tmult1 and will increase upkeep costs. They are mutually exclusive; only one can be chosen.// 

--- a/src/uncategorized/arcadeReport.tw
+++ b/src/uncategorized/arcadeReport.tw
@@ -43,7 +43,7 @@
 			<<set $slaves[$i].health -= 10>>
 		<</if>>
 		<<set $slaves[$i].aphrodisiacs = 2, $slaves[$i].devotion -= 5, $slaves[$i].trust -= 10>>
-	<<elseif ($arcadeUpgradeCollectors > 0)>>>>
+	<<elseif ($arcadeUpgradeCollectors > 0)>>
 		<<if ($slaves[$i].health < -60)>>
 			<<set $slaves[$i].health += 20>>
 		<<elseif ($slaves[$i].health < 40)>>

--- a/src/uncategorized/arcadeReport.tw
+++ b/src/uncategorized/arcadeReport.tw
@@ -1,6 +1,6 @@
 :: Arcade Report [nobr]
 
-<<set _DL = $ArcadeiIDs.length, $arcadeSlaves = _DL, _SL = $slaves.length, _cockmilked = 0, _milked = 0, _profits = 0, _oldCash = $cash, $boobsImplanted = 0, $prostatesImplanted = 0>>
+<<set _DL = $ArcadeiIDs.length, $arcadeSlaves = _DL, _SL = $slaves.length, _cockmilked = 0, _milked = 0, _milkprofits = 0, _profits = 0, _oldCash = 0, $boobsImplanted = 0, $prostatesImplanted = 0>>
 
 <<for _dI = 0; _dI < _DL; _dI++>>
 	<<set $i = $ArcadeiIDs[_dI].Index, _ID = $ArcadeiIDs[_dI].ID>>
@@ -91,11 +91,13 @@
     <<elseif $slaves[$i].prostate == 1>>
       <<set $slaves[$i].prostate = 2, $slaves[$i].health -= 10, $cash -= $surgeryCost, $prostatesImplanted++>>
 		<<elseif ($slaves[$i].lactation > 0) || ($slaves[$i].balls > 0)>>
+			<<set _oldCash = $cash>>
 			<<if $showEWD != 0>>
 				<br>&nbsp;&nbsp;&nbsp;&nbsp;She <<include "SA get milked">>
 			<<else>>
 				<<silently>><<include "SA get milked">><</silently>>
 			<</if>>
+			<<set _milkprofits += $cash-_oldCash>>
 			<<if ($slaves[$i].boobs < 2000)>>
 				<<set $slaves[$i].boobs += 100>>
 			<<elseif ($slaves[$i].boobs < 5000)>>
@@ -117,7 +119,6 @@
 			<</if>>
 		<</if>>
 	<</if>>
-	<<set _profits += $cash-_oldCash>>
 	<<if $showEWD != 0>>
 		<br>&nbsp;&nbsp;&nbsp;
 		<<include "SA drugs">>
@@ -167,7 +168,7 @@
 	<<elseif _cockmilked > 1>>
 		_cockmilked of them retain testicles and are brutally cockmilked as they are used.
 	<</if>>
-	The arcade makes you @@.yellowgreen;¤_profits@@ this week.
+	The arcade makes you @@.yellowgreen;¤_profits@@ from selling the inmates' holes<<if ($arcadeUpgradeCollectors > 0)>> and @@.yellowgreen;¤_milkprofits@@ from selling the fluids they produced<</if>> this week.
 	<<if ($arcologies[0].FSDegradationist > 20)>>
 	<<elseif ($arcologies[0].FSPaternalist > 20)>>
 		<<set $repGain -= Math.trunc(_profits/20)>>

--- a/src/uncategorized/arcadeReport.tw
+++ b/src/uncategorized/arcadeReport.tw
@@ -43,6 +43,15 @@
 			<<set $slaves[$i].health -= 10>>
 		<</if>>
 		<<set $slaves[$i].aphrodisiacs = 2, $slaves[$i].devotion -= 5, $slaves[$i].trust -= 10>>
+	<<elseif ($arcadeUpgradeCollectors > 0)>>>>
+		<<if ($slaves[$i].health < -60)>>
+			<<set $slaves[$i].health += 20>>
+		<<elseif ($slaves[$i].health < 40)>>
+			<<set $slaves[$i].health += 10>>
+		<<elseif ($slaves[$i].health > 50)>>
+			<<set $slaves[$i].health -= 10>>
+		<</if>>
+		<<set $slaves[$i].trust -= 5>>	
 	<<else>>
 		<<if ($slaves[$i].health < -60)>>
 			<<set $slaves[$i].health += 20>>

--- a/src/uncategorized/saGetMilked.tw
+++ b/src/uncategorized/saGetMilked.tw
@@ -44,10 +44,12 @@ gets milked this week.
 			Her udders are forced to adapt to this unnatural productivity.
 			<<set $slaves[$i].lactationAdaptation += 1>>
 		<</if>>
-		<<if $slaves[$i].curatives == 0>>
+		<<if ($slaves[$i].curatives == 0) && ($slaves[$i].assignment != "be confined in the arcade")>>
 			The stress of extreme milk production @@.red;damages her health.@@
 			<<set $slaves[$i].health -= 3>>
 		<</if>>
+		<<if ($slaves[$i].assignment == "be confined in the arcade")>>
+			The automated arcade systems pump her full of drugs to prevent the extreme milk production from damaging her health.
 	<</if>>
 
 	<<if ($slaves[$i].devotion > 50)>>

--- a/src/uncategorized/saGetMilked.tw
+++ b/src/uncategorized/saGetMilked.tw
@@ -50,6 +50,7 @@ gets milked this week.
 		<</if>>
 		<<if ($slaves[$i].assignment == "be confined in the arcade")>>
 			The automated arcade systems pump her full of drugs to prevent the extreme milk production from damaging her health.
+		<</if>>
 	<</if>>
 
 	<<if ($slaves[$i].devotion > 50)>>

--- a/src/uncategorized/saWorkAGloryHole.tw
+++ b/src/uncategorized/saWorkAGloryHole.tw
@@ -209,3 +209,4 @@ $possessiveCap feelings, skills, and appearance do not matter. $pronounCap is co
 <</if>>
 
 <<set $cash += ($beauty*$FResult)>>
+<<set _profits += ($beauty*$FResult)>>

--- a/src/uncategorized/saWorkAGloryHole.tw
+++ b/src/uncategorized/saWorkAGloryHole.tw
@@ -39,7 +39,9 @@ is <<if $slaves[$i].fuckdoll == 0>>restrained in a glory hole<<else>>set out for
 	Demand for $possessive holes is strong due to the appetite for degradation rampant in $arcologies[0].name.
 <</if>>
 
-<<if ($slaves[$i].curatives > 0)>>
+<<if ($slaves[$i].assignment == "be confined in the arcade") && ($arcadeUpgradeCollectors > 0)>>
+	The steady stream of drugs from the upgraded arcade protects $possessive health from the stress of being used as a sexual appliance.
+<<elseif ($slaves[$i].curatives > 0)>>
 	The drugs $pronoun's on protect $possessive health from the stress of being used as a sexual appliance.
 <<elseif ($slaves[$i].health < -50)>>
 	The stress of being used while very ill @@.red;damaged $possessive health.@@


### PR DESCRIPTION
Made them mutually exclusive, and the collector has a positive effect on slave health; also made the arcade report break down the results into profits from use and profits from fluids. This has the side-benefit of preventing arcade milk profits from damaging reputation - only the pure throughput on slave holes damages rep now.

Compiled and tested it from my branch, seems to be working fine.