### PR TITLE
simple solution for FSSpending problems

### DIFF
--- a/src/uncategorized/futureSocities.tw
+++ b/src/uncategorized/futureSocities.tw
@@ -382,10 +382,9 @@ possible societal customizations.
 
 <<if $FSSpending > 10000>><<set _warn = 1>><</if>>
 <<set $FSSpending = Number($FSSpending) || 0>>
-<<set $FSSpending = Math.clamp(Math.trunc($FSSpending/1000)*1000, 0, 10000)>>
-You are spending ¤$FSSpending each week to support your societal goals.
-<<textbox "$FSSpending" $FSSpending "Future Society">>
-<<if _warn>>//Spending more than ¤10000 weekly will be counterproductive//<</if>>
+<<set $FSSpending = Math.clamp(Math.ceil($FSSpending/1000)*1000, 0, 10000)>>
+<br>You are spending ¤<<textbox "_newFSSpending" $FSSpending>> each week to support your societal goals. [[Save changes|Future Society][$FSSpending = Number(_newFSSpending) || 0]]
+<<if _warn>><br>//Spending more than ¤10000 weekly would be counterproductive//<</if>>
 
 <br>
 <span id="mass">


### PR DESCRIPTION
use a temporary variable for the textbox and require user to click a separate link to save changes; also round up (Math.ceil) instead of down (Math.trunc) as it is more user-friendly that way; adjusted line breaks

this fixes #629

note that hitting Enter in the textbox no longer has any effect - this is intentional