### PR TITLE
Scrota fixes for event slaves

### DIFF
--- a/src/uncategorized/reRecruit.tw
+++ b/src/uncategorized/reRecruit.tw
@@ -544,6 +544,7 @@ It isn't just all natural females either, as a few men also jumped on the bandwa
 <<set $activeSlave.preg = 0>>
 <<set $activeSlave.dick = random(3,5)>>
 <<set $activeSlave.balls = random(2,4)>>
+<<set $activeSlave.scrotum = $activeSlave.balls>>
 <<set $activeSlave.anus = 0>>
 <<set $activeSlave.weight = 0>>
 <<set $activeSlave.muscles = 50>>

--- a/src/uncategorized/reRecruit.tw
+++ b/src/uncategorized/reRecruit.tw
@@ -307,6 +307,7 @@ After a short while, your assistant whispers in your earpiece, <<if $assistant =
 <<set $activeSlave.voice = 1>>
 <<set $activeSlave.dick = random(1,2)>>
 <<set $activeSlave.balls = random(1,2)>>
+<<set $activeSlave.scrotum = $activeSlave.balls>>
 <<set $activeSlave.anus = 1>>
 <<set $activeSlave.analSkill = 15>>
 <<set $activeSlave.oralSkill = 15>>
@@ -394,6 +395,7 @@ Given the damage to an expensive classic car and the meager balance of her bank 
 <<set $activeSlave.anus = random(0,1)>>
 <<set $activeSlave.dick = random(3,5)>>
 <<set $activeSlave.balls = random(2,4)>>
+<<set $activeSlave.scrotum = $activeSlave.balls>>
 <<set $activeSlave.weight = 0>>
 <<set $activeSlave.muscles = 50>>
 <<set $activeSlave.intelligence = random(1,2)>>
@@ -507,6 +509,7 @@ It isn't just all natural females either, as a few men also jumped on the bandwa
 <<set $activeSlave.anus = 0>>
 <<set $activeSlave.dick = random(1,4)>>
 <<set $activeSlave.balls = random(1,4)>>
+<<set $activeSlave.scrotum = $activeSlave.balls>>
 <<set $activeSlave.weight = 0>>
 <<set $activeSlave.muscles = 20>>
 <<set $activeSlave.intelligence = random(-1,1)>>
@@ -821,6 +824,7 @@ The young woman is best described as being 'angelic', in a stereotypical Western
 <<set $activeSlave.anus = 0>>
 <<set $activeSlave.dick = random(4,5)>>
 <<set $activeSlave.balls = random(3,4)>>
+<<set $activeSlave.scrotum = $activeSlave.balls>>
 <<set $activeSlave.height = random(180,200)>>
 <<set $activeSlave.weight = 0>>
 <<set $activeSlave.muscles = 50>>
@@ -1068,6 +1072,7 @@ From the looks of all the brochures and extra information included, the associat
 <<set $activeSlave.ovaries = -1>>
 <<set $activeSlave.dick = random(4,5)>>
 <<set $activeSlave.balls = random(3,4)>>
+<<set $activeSlave.scrotum = $activeSlave.balls>>
 <<set $activeSlave.pubicHStyle = "waxed">>
 <<set $activeSlave.hips = random(1,2)>>
 <<set $activeSlave.butt = random(2,5)>>
@@ -1186,6 +1191,7 @@ Knowing what's coming, the teachers in the facility do train their pupils accord
 <<set $activeSlave.ovaries = -1>>
 <<set $activeSlave.dick = random(3,4)>>
 <<set $activeSlave.balls = random(2,3)>>
+<<set $activeSlave.scrotum = $activeSlave.balls>>
 <<set $activeSlave.pubicHStyle = "waxed">>
 <<set $activeSlave.height = random(140,170)>>
 <<set $activeSlave.hips = random(-1,0)>>


### PR DESCRIPTION
A lot of the event slaves specify specific ball sizes but don't do anything re: the scrotum, leading to a lot of mismatches and some unexpected internal balls - including on a gang leader in the event that brought this to my attention.