### PR TITLE
corrected missing recruiterProgress

### DIFF
--- a/src/uncategorized/saRecruitGirls.tw
+++ b/src/uncategorized/saRecruitGirls.tw
@@ -49,6 +49,7 @@ uses your online resources and some @@.yellowgreen;modest funds@@ to convince $r
 	<<set $recruiterProgress += 2>>
 <<elseif $slaves[$i].entertainSkill > 60>>
 	She has the entertainment expertise to lure in most targets.
+	<<set $recruiterProgress += 1.5>>
 <<elseif $slaves[$i].entertainSkill > 30>>
 	She has the necessary entertainment skills to banter successfully with her targets.
 	<<set $recruiterProgress += 1>>


### PR DESCRIPTION
Previously a recruiter with an entertain skill higher than 60 but less than 100 doesn't make any progress in recruiting while a slave that's one category lower gets +1 recruiterProgress. Obviously there is a missing set statement. I added that in. Now the recruiter described above gets 1.5 to recruiterProgress.