### PR TITLE
LegendaryCow and LegendaryBalls Patch

### DIFF
--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -131,7 +131,7 @@
 					She makes sure to massage $slaves[$i].slaveName's huge breasts to get the milk flowing before enticing clients to suckle and play with her.
 					<<set $madamCashBonus += 0.10>>
 				<<else>>
-					She would like to show off $slaves[$i].slaveName's huge udders, but $slaves[$i].slaveName's not producing milk like she once was.
+					She would like to show off $slaves[$i].slaveName's huge udders, but $slaves[$i].slaveName <<if ($slaves[$i].lactation = 0)>> isn't producing milk anymore. <<else>> doesn't exactly have huge udders anymore. <</if>>
 				<</if>>
 			<</if>>
 		<<elseif $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a cockmilker.">>
@@ -147,7 +147,7 @@
 					She shows off $slaves[$i].slaveName's copious loads by putting a condom over her dick and teasing her till she bursts it. The show draws multiple clients that want to play with her oversized junk and messy orgasms.
 					<<set $madamCashBonus += 0.15>>
 				<<else>>
-					She would love to show off $slaves[$i].slaveName's copious loads, but $slaves[$i].slaveName's not producing cum like she used to.
+					She would love to show off $slaves[$i].slaveName's copious loads, but $slaves[$i].slaveName's <<if [$i].balls = 0>> not producing cum. <<else>> orgasms just aren't messy enough. <</if>>
 				<</if>>
 			<</if>>
 		<</if>>

--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -120,18 +120,18 @@
 			<<set $madamCashBonus += 0.15>>
 		<<elseif $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a dairy cow.">>
 			<<if ($arcologies[0].FSPhysicalIdealist != "unset")>>
-				<<if ($slaves[$i].muscles > 30) && ($slaves[$i].lactation < 1) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) < 6000)>>
+				<<if ($slaves[$i].muscles > 30) && ($slaves[$i].weight < 30) && ($slaves[$i].lactation < 1) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) < 6000)>>
 					She shows off how a formerly fat cow like $slaves[$i].slaveName can be restored to physical perfection.
 					<<set $madamCashBonus += 0.15>>
 				<<else>>
-					Fat cows are woefully out of fashion, so she tries to draw attention away from $slaves[$i].slaveName.
+					 A<<if ($slaves[$i].muscles < 30)>>n unmuscled,<</if>><<if ($slaves[$i].weight > 30)>> fat,<</if>> legendary breastmilker <<if ($slaves[$i].lactation > 0)>>cow<<elseif (($slaves[$i].boobs-$slaves[$i].boobsImplant) < 6000)>>mass of titflesh<<else>>slave<</if>> like $slaves[$i].slaveName is woefully out of fashion, so $Milkmaid.slaveName tries to draw attention away from her.
 				<</if>>
 			<<else>>
 				<<if ($slaves[$i].lactation > 0) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000)>>
 					She makes sure to massage $slaves[$i].slaveName's huge breasts to get the milk flowing before enticing clients to suckle and play with her.
 					<<set $madamCashBonus += 0.10>>
 				<<else>>
-					She would like to show off $slaves[$i].slaveName's huge udders, but $slaves[$i].slaveName <<if ($slaves[$i].lactation = 0)>> isn't producing milk anymore. <<else>> doesn't exactly have huge udders anymore. <</if>>
+					She would like to show off $slaves[$i].slaveName's huge udders, but $slaves[$i].slaveName <<if ($slaves[$i].lactation == 0)>> isn't producing milk anymore. <<else>> doesn't exactly have huge udders anymore. <</if>>
 				<</if>>
 			<</if>>
 		<<elseif $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a cockmilker.">>
@@ -140,14 +140,14 @@
 					She uses $slaves[$i].slaveName as an example of how even a huge-balled freak like her can be restored to proper feminity.
 					<<set $madamCashBonus += 0.20>>
 				<<else>>
-					She tried to hide $slaves[$i].slaveName; 'her' body being notorious for defiance of conventional feminity.
+					She tries to hide $slaves[$i].slaveName; 'her' body being notorious for defiance of conventional feminity.
 				<</if>>
 			<<else>>
 				<<if ($slaves[$i].balls > 5)>>
 					She shows off $slaves[$i].slaveName's copious loads by putting a condom over her dick and teasing her till she bursts it. The show draws multiple clients that want to play with her oversized junk and messy orgasms.
 					<<set $madamCashBonus += 0.15>>
 				<<else>>
-					She would love to show off $slaves[$i].slaveName's copious loads, but $slaves[$i].slaveName's <<if [$i].balls = 0>> not producing cum. <<else>> orgasms just aren't messy enough. <</if>>
+					She would love to show off $slaves[$i].slaveName's copious loads, but $slaves[$i].slaveName's <<if [$i].balls == 0>> not producing cum. <<else>> orgasms just aren't messy enough. <</if>>
 				<</if>>
 			<</if>>
 		<</if>>

--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -143,11 +143,11 @@
 					She tries to hide $slaves[$i].slaveName; 'her' body being notorious for defiance of conventional femininity.
 				<</if>>
 			<<else>>
-				<<if ($slaves[$i].balls > 5)>>
+				<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
 					She shows off $slaves[$i].slaveName's copious loads by putting a condom over her dick and teasing her till she bursts it. The show draws multiple clients that want to play with her oversized junk and messy orgasms.
 					<<set $madamCashBonus += 0.15>>
 				<<else>>
-					She would love to show off $slaves[$i].slaveName's copious loads, but $slaves[$i].slaveName's <<if $slaves[$i].balls == 0>> not producing cum. <<else>> orgasms just aren't messy enough. <</if>>
+					She would love to show off $slaves[$i].slaveName's copious loads, but $slaves[$i].slaveName<<if $slaves[$i].dick == 0>> doesn't have a dick.<<elseif $slaves[$i].balls == 0>>'s not producing cum. <<else>>'s orgasms just aren't messy enough. <</if>>
 				<</if>>
 			<</if>>
 		<</if>>

--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -143,7 +143,7 @@
 					She tries to hide $slaves[$i].slaveName; 'her' body being notorious for defiance of conventional femininity.
 				<</if>>
 			<<else>>
-				<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) || ($slaves[$i].balls > 4) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
+				<<if (($slaves[$i].balls > 5) && ($slaves[$i].dick != 0)) || (($slaves[$i].balls > 4) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1))>>
 					She shows off $slaves[$i].slaveName's copious loads by putting a condom over her dick and teasing her till she bursts it. The show draws multiple clients that want to play with her oversized junk and messy orgasms.
 					<<set $madamCashBonus += 0.15>>
 				<<else>>

--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -119,7 +119,7 @@
 			She makes sure to promote $slaves[$i].slaveName, the famed entertainer, in order to capitalize on her popularity.
 			<<set $madamCashBonus += 0.15>>
 		<<elseif $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a dairy cow.">>
-			<<if ($arcologies[0].FSPhysicalIdealist != "unset") 
+			<<if ($arcologies[0].FSPhysicalIdealist != "unset")>>
 				<<if ($slaves[$i].muscles > 30) && ($slaves[$i].lactation < 1) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) < 6000)>>
 					She shows off how a formerly fat cow like $slaves[$i].slaveName can be restored to physical perfection.
 					<<set $madamCashBonus += 0.15>>

--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -143,7 +143,7 @@
 					She tries to hide $slaves[$i].slaveName; 'her' body being notorious for defiance of conventional femininity.
 				<</if>>
 			<<else>>
-				<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
+				<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) || ($slaves[$i].balls > 4) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
 					She shows off $slaves[$i].slaveName's copious loads by putting a condom over her dick and teasing her till she bursts it. The show draws multiple clients that want to play with her oversized junk and messy orgasms.
 					<<set $madamCashBonus += 0.15>>
 				<<else>>

--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -125,25 +125,31 @@
 					<<set $madamCashBonus += 0.15>>
 				<<else>>
 					Fat cows are woefully out of fashion, so she tries to draw attention away from $slaves[$i].slaveName.
+				<</if>>
 			<<else>>
 				<<if ($slaves[$i].lactation > 0) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000)>>
 					She makes sure to massage $slaves[$i].slaveName's huge breasts to get the milk flowing before enticing clients to suckle and play with her.
 					<<set $madamCashBonus += 0.10>>
 				<<else>>
 					She would like to show off $slaves[$i].slaveName's huge udders, but $slaves[$i].slaveName's not producing milk like she once was.
+				<</if>>
+			<</if>>
 		<<elseif $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a cockmilker.">>
 			<<if $arcologies[0].FSGenderFundamentalist != "unset">>
-				<<if ($slaves[$i].balls == 0) && ($slaves[$i].dick == 0) && ($slaves[$i].vagina > -1)>>>>
+				<<if ($slaves[$i].balls == 0) && ($slaves[$i].dick == 0) && ($slaves[$i].vagina > -1)>>
 					She uses $slaves[$i].slaveName as an example of how even a huge-balled freak like her can be restored to proper feminity.
 					<<set $madamCashBonus += 0.20>>
 				<<else>>
 					She tried to hide $slaves[$i].slaveName; 'her' body being notorious for defiance of conventional feminity.
+				<</if>>
 			<<else>>
 				<<if ($slaves[$i].balls > 5)>>
 					She shows off $slaves[$i].slaveName's copious loads by putting a condom over her dick and teasing her till she bursts it. The show draws multiple clients that want to play with her oversized junk and messy orgasms.
 					<<set $madamCashBonus += 0.15>>
 				<<else>>
 					She would love to show off $slaves[$i].slaveName's copious loads, but $slaves[$i].slaveName's not producing cum like she used to.
+				<</if>>
+			<</if>>
 		<</if>>
 	<</for>>
 

--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -147,7 +147,7 @@
 					She shows off $slaves[$i].slaveName's copious loads by putting a condom over her dick and teasing her till she bursts it. The show draws multiple clients that want to play with her oversized junk and messy orgasms.
 					<<set $madamCashBonus += 0.15>>
 				<<else>>
-					She would love to show off $slaves[$i].slaveName's copious loads, but $slaves[$i].slaveName's <<if [$i].balls == 0>> not producing cum. <<else>> orgasms just aren't messy enough. <</if>>
+					She would love to show off $slaves[$i].slaveName's copious loads, but $slaves[$i].slaveName's <<if $slaves[$i].balls == 0>> not producing cum. <<else>> orgasms just aren't messy enough. <</if>>
 				<</if>>
 			<</if>>
 		<</if>>

--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -124,7 +124,7 @@
 					She shows off how a formerly fat cow like $slaves[$i].slaveName can be restored to physical perfection.
 					<<set $madamCashBonus += 0.15>>
 				<<else>>
-					 A<<if ($slaves[$i].muscles < 30)>>n unmuscled,<</if>><<if ($slaves[$i].weight > 30)>> fat,<</if>> legendary breastmilker <<if ($slaves[$i].lactation > 0)>>cow<<elseif (($slaves[$i].boobs-$slaves[$i].boobsImplant) < 6000)>>mass of titflesh<<else>>slave<</if>> like $slaves[$i].slaveName is woefully out of fashion, so $Milkmaid.slaveName tries to draw attention away from her.
+					 A<<if ($slaves[$i].muscles < 30)>>n unmuscled,<</if>><<if ($slaves[$i].weight > 30)>> fat,<</if>> 'prestigious' <<if ($slaves[$i].lactation > 0)>>cow<<elseif (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000)>>mass of titflesh<<else>>slave<</if>> like $slaves[$i].slaveName is woefully out of fashion, so $Milkmaid.slaveName tries to draw attention away from her.
 				<</if>>
 			<<else>>
 				<<if ($slaves[$i].lactation > 0) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000)>>
@@ -137,10 +137,10 @@
 		<<elseif $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a cockmilker.">>
 			<<if $arcologies[0].FSGenderFundamentalist != "unset">>
 				<<if ($slaves[$i].balls == 0) && ($slaves[$i].dick == 0) && ($slaves[$i].vagina > -1)>>
-					She uses $slaves[$i].slaveName as an example of how even a huge-balled freak like her can be restored to proper feminity.
+					She uses $slaves[$i].slaveName as an example of how even a huge-balled freak like her can be restored to proper femininity.
 					<<set $madamCashBonus += 0.20>>
 				<<else>>
-					She tries to hide $slaves[$i].slaveName; 'her' body being notorious for defiance of conventional feminity.
+					She tries to hide $slaves[$i].slaveName; 'her' body being notorious for defiance of conventional femininity.
 				<</if>>
 			<<else>>
 				<<if ($slaves[$i].balls > 5)>>

--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -119,11 +119,31 @@
 			She makes sure to promote $slaves[$i].slaveName, the famed entertainer, in order to capitalize on her popularity.
 			<<set $madamCashBonus += 0.15>>
 		<<elseif $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a dairy cow.">>
-			She makes sure to massage $slaves[$i].slaveName's huge breasts to get the milk flowing before enticing clients to suckle and play with her.
-			<<set $madamCashBonus += 0.10>>
+			<<if ($arcologies[0].FSPhysicalIdealist != "unset") 
+				<<if ($slaves[$i].muscles > 30) && ($slaves[$i].lactation < 1) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) < 6000)>>
+					She shows off how a formerly fat cow like $slaves[$i].slaveName can be restored to physical perfection.
+					<<set $madamCashBonus += 0.15>>
+				<<else>>
+					Fat cows are woefully out of fashion, so she tries to draw attention away from $slaves[$i].slaveName.
+			<<else>>
+				<<if ($slaves[$i].lactation > 0) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000)>>
+					She makes sure to massage $slaves[$i].slaveName's huge breasts to get the milk flowing before enticing clients to suckle and play with her.
+					<<set $madamCashBonus += 0.10>>
+				<<else>>
+					She would like to show off $slaves[$i].slaveName's huge udders, but $slaves[$i].slaveName's not producing milk like she once was.
 		<<elseif $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a cockmilker.">>
-			She shows off $slaves[$i].slaveName's copious loads by putting a condom over her dick and teasing her till she bursts it. The show draws multiple clients that want to play with her oversized junk and messy orgasms.
-			<<set $madamCashBonus += 0.15>>
+			<<if $arcologies[0].FSGenderFundamentalist != "unset">>
+				<<if ($slaves[$i].balls == 0) && ($slaves[$i].dick == 0) && ($slaves[$i].vagina > -1)>>>>
+					She uses $slaves[$i].slaveName as an example of how even a huge-balled freak like her can be restored to proper feminity.
+					<<set $madamCashBonus += 0.20>>
+				<<else>>
+					She tried to hide $slaves[$i].slaveName; 'her' body being notorious for defiance of conventional feminity.
+			<<else>>
+				<<if ($slaves[$i].balls > 5)>>
+					She shows off $slaves[$i].slaveName's copious loads by putting a condom over her dick and teasing her till she bursts it. The show draws multiple clients that want to play with her oversized junk and messy orgasms.
+					<<set $madamCashBonus += 0.15>>
+				<<else>>
+					She would love to show off $slaves[$i].slaveName's copious loads, but $slaves[$i].slaveName's not producing cum like she used to.
 		<</if>>
 	<</for>>
 

--- a/src/uncategorized/brothelReport.tw
+++ b/src/uncategorized/brothelReport.tw
@@ -140,7 +140,7 @@
 					She uses $slaves[$i].slaveName as an example of how even a huge-balled freak like her can be restored to proper femininity.
 					<<set $madamCashBonus += 0.20>>
 				<<else>>
-					She tries to hide $slaves[$i].slaveName; 'her' body being notorious for defiance of conventional femininity.
+					She tries to hide $slaves[$i].slaveName, 'her' body being notorious for defiance of conventional femininity.
 				<</if>>
 			<<else>>
 				<<if (($slaves[$i].balls > 5) && ($slaves[$i].dick != 0)) || (($slaves[$i].balls > 4) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1))>>

--- a/src/uncategorized/clinicReport.tw
+++ b/src/uncategorized/clinicReport.tw
@@ -103,7 +103,7 @@
 			She does her best to aid the famous entertainer, $slaves[$i].slaveName, making sure she can show off as soon as possible.
 			<<set $slaves[$i].health += 2>>
 		<<case "She is remembered for winning best in show as a cockmilker.">>
-			<<if ($slaves[$i].balls > 5)>>
+			<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
 				She does her best to aid the dribbling $slaves[$i].slaveName, paying special attention to her huge cock and balls as well as making sure to milk her erect dick hourly.
 				<<set $slaves[$i].health += 4>>
 				<<if (random(1,100) > 65) && (($Nurse.fetish == "none") || ($Nurse.fetish == "cumslut"))>>

--- a/src/uncategorized/clinicReport.tw
+++ b/src/uncategorized/clinicReport.tw
@@ -103,23 +103,27 @@
 			She does her best to aid the famous entertainer, $slaves[$i].slaveName, making sure she can show off as soon as possible.
 			<<set $slaves[$i].health += 2>>
 		<<case "She is remembered for winning best in show as a cockmilker.">>
-			She does her best to aid the dribbling $slaves[$i].slaveName, paying special attention to her huge cock and balls as well as making sure to milk her erect dick hourly.
-			<<set $slaves[$i].health += 4>>
-			<<if (random(1,100) > 65) && (($Nurse.fetish == "none") || ($Nurse.fetish == "cumslut"))>>
-				<<if $Nurse.fetish == "none">>
-					<<set $Nurse.fetish = "cumslut", $slaves[_FLs].fetish = "cumslut">>
-				<<else>>
-					<<set $Nurse.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>
+			<<if ($slaves[$i].balls > 5)>>
+				She does her best to aid the dribbling $slaves[$i].slaveName, paying special attention to her huge cock and balls as well as making sure to milk her erect dick hourly.
+				<<set $slaves[$i].health += 4>>
+				<<if (random(1,100) > 65) && (($Nurse.fetish == "none") || ($Nurse.fetish == "cumslut"))>>
+					<<if $Nurse.fetish == "none">>
+						<<set $Nurse.fetish = "cumslut", $slaves[_FLs].fetish = "cumslut">>
+					<<else>>
+						<<set $Nurse.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>
+					<</if>>
 				<</if>>
 			<</if>>
 		<<case "She is remembered for winning best in show as a dairy cow.">>
-			She does her best to aid the leaking $slaves[$i].slaveName, paying special attention to her huge breasts as well as making sure to milk her hourly.
-			<<set $slaves[$i].health += 4>>
-			<<if (random(1,100) > 65) && (($Nurse.fetish == "none") || ($Nurse.fetish == "boobs"))>>
-				<<if $Nurse.fetish == "none">>
-					<<set $Nurse.fetish = "boobs", $slaves[_FLs].fetish = "boobs">>
-				<<else>>
-					<<set $Nurse.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>
+			<<if ($slaves[$i].lactation > 0) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000)>>
+				She does her best to aid the leaking $slaves[$i].slaveName, paying special attention to her huge breasts as well as making sure to milk her hourly.
+				<<set $slaves[$i].health += 4>>
+				<<if (random(1,100) > 65) && (($Nurse.fetish == "none") || ($Nurse.fetish == "boobs"))>>
+					<<if $Nurse.fetish == "none">>
+						<<set $Nurse.fetish = "boobs", $slaves[_FLs].fetish = "boobs">>
+					<<else>>
+						<<set $Nurse.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>
+					<</if>>
 				<</if>>
 			<</if>>
 		<</switch>>

--- a/src/uncategorized/clinicReport.tw
+++ b/src/uncategorized/clinicReport.tw
@@ -103,7 +103,7 @@
 			She does her best to aid the famous entertainer, $slaves[$i].slaveName, making sure she can show off as soon as possible.
 			<<set $slaves[$i].health += 2>>
 		<<case "She is remembered for winning best in show as a cockmilker.">>
-			<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
+			<<if ($slaves[$i].balls > 4) && ($slaves[$i].dick != 0)>>
 				She does her best to aid the dribbling $slaves[$i].slaveName, paying special attention to her huge cock and balls as well as making sure to milk her erect dick hourly.
 				<<set $slaves[$i].health += 4>>
 				<<if (random(1,100) > 65) && (($Nurse.fetish == "none") || ($Nurse.fetish == "cumslut"))>>

--- a/src/uncategorized/dairyReport.tw
+++ b/src/uncategorized/dairyReport.tw
@@ -133,10 +133,10 @@
 		<</if>>
 		<<if $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a dairy cow.">>
 			<<if ($slaves[$i].lactation > 0) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000)>>
-				She spends extra time with $slaves[$i].slaveName, the well-known cow. $Milkmaid.slaveName is fascinated by her massive $slaves[$i].boobs cc breasts and spends extra time massaging and kneading them to maximize production.
+				She spends extra time with $slaves[$i].slaveName, the well-known cow. She is fascinated by $slaves[$i].slaveName's massive $slaves[$i].boobs cc breasts and spends extra time massaging and kneading them to maximize production.
 				<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 			<<else>>
-				She is disapointed that $slaves[$i].slaveName, the well-known cow, is<<if ($slaves[$i].lactation = 0)>>n't producing milk anymore. <<else>> breasts have shruken considerably from their height.<</if>>
+				She is disappointed that the well-known cow $slaves[$i].slaveName<<if ($slaves[$i].lactation == 0)>> isn't producing milk anymore. <<else>>'s breasts have shrunken considerably from their height.<</if>>
 			<</if>>
 		<</if>>
 		<<if $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a cockmilker.">>
@@ -144,7 +144,7 @@
 				She spends extra time with $slaves[$i].slaveName, the massive ejaculating cow.  She can't help but massage the cow's dick and testes to stimulate them further and coax more from them.
 				<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 			<<else>>
-				She is disapointed that $slaves[$i].slaveName, the (formerly) massive ejaculating cow, is<<if [$i].balls = 0>> not producing cum. <<else>> balls are considerably smaller than at their height.<</if>>
+				She is disappointed that the (formerly) massive ejaculating cow $slaves[$i].slaveName<<if [$i].balls == 0>> is not producing cum. <<else>>'s balls are considerably smaller than at their height.<</if>>
 			<</if>>
 		<</if>>
 	<</for>>

--- a/src/uncategorized/dairyReport.tw
+++ b/src/uncategorized/dairyReport.tw
@@ -140,7 +140,7 @@
 			<</if>>
 		<</if>>
 		<<if $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a cockmilker.">>
-			<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
+			<<if (($slaves[$i].balls > 5) && ($slaves[$i].dick != 0)) || (($slaves[$i].balls > 4) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1))>>
 				She spends extra time with $slaves[$i].slaveName, the massive ejaculating cow.  She can't help but massage the cow's dick and testes to stimulate them further and coax more from them.
 				<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 			<<else>>

--- a/src/uncategorized/dairyReport.tw
+++ b/src/uncategorized/dairyReport.tw
@@ -203,7 +203,7 @@
 	<<if ($legendaryCowID == 0) && ($slaves[$i].lactation > 0) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000) && ($slaves[$i].devotion > 50) && ($slaves[$i].prestige == 0)>>
 		<<set $legendaryCowID = $slaves[$i].ID>>
 	<</if>>
-	<<if ($legendaryBallsID == 0) && ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1) && ($slaves[$i].devotion > 50) && ($slaves[$i].prestige == 0)>>
+	<<if ($legendaryBallsID == 0) && ($slaves[$i].balls > 5) ||((($slaves[$i].balls > 4) && ($slaves[$i].prostate > 1)) && ($slaves[$i].devotion > 50) && ($slaves[$i].prestige == 0)  && ($slaves[$i].dick != 0)>>
 		<<set $legendaryBallsID = $slaves[$i].ID>>
 	<</if>>
 

--- a/src/uncategorized/dairyReport.tw
+++ b/src/uncategorized/dairyReport.tw
@@ -132,12 +132,20 @@
 			<<set $slaves[$i].trust++>>
 		<</if>>
 		<<if $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a dairy cow.">>
-			She spends extra time with $slaves[$i].slaveName, the well-known cow. $Milkmaid.slaveName is fascinated by her massive $slaves[$i].boobs cc breasts and spends extra time massaging and kneading them to maximize production.
-			<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
+			<<if ($slaves[$i].lactation > 0) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000)>>
+				She spends extra time with $slaves[$i].slaveName, the well-known cow. $Milkmaid.slaveName is fascinated by her massive $slaves[$i].boobs cc breasts and spends extra time massaging and kneading them to maximize production.
+				<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
+			<<else>>
+				She is disapointed that $slaves[$i].slaveName, the well-known cow, is unable to give milk like she used to.
+			<</if>>
 		<</if>>
 		<<if $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a cockmilker.">>
-			She spends extra time with $slaves[$i].slaveName, the massive ejaculating cow.  She can't help but massage the cow's dick and testes to stimulate them further and coax more from them.
-			<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
+			<<if ($slaves[$i].balls > 5)>>
+				She spends extra time with $slaves[$i].slaveName, the massive ejaculating cow.  She can't help but massage the cow's dick and testes to stimulate them further and coax more from them.
+				<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
+			<<else>>
+				She is disapointed that $slaves[$i].slaveName, the massive ejaculating cow, is unable to give cum like she used to.
+			<</if>>
 		<</if>>
 	<</for>>
 <</if>>

--- a/src/uncategorized/dairyReport.tw
+++ b/src/uncategorized/dairyReport.tw
@@ -140,11 +140,11 @@
 			<</if>>
 		<</if>>
 		<<if $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a cockmilker.">>
-			<<if ($slaves[$i].balls > 5)>>
+			<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
 				She spends extra time with $slaves[$i].slaveName, the massive ejaculating cow.  She can't help but massage the cow's dick and testes to stimulate them further and coax more from them.
 				<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 			<<else>>
-				She is disappointed that the (formerly) massive ejaculating cow $slaves[$i].slaveName<<if $slaves[$i].balls == 0>> is incapable of producing cum. <<else>>'s balls are considerably smaller than at their height.<</if>>
+				She is disappointed that the (formerly) massive ejaculating cow $slaves[$i].slaveName<<if $slaves[$i].balls == 0 || $slaves[$i].dick == 0>> is incapable of giving cum. <<if $slaves[$i].prostate != 2>> no longer possesses a hyperactive prostate. <<else>>'s balls are considerably smaller than at their height.<</if>>
 			<</if>>
 		<</if>>
 	<</for>>
@@ -203,7 +203,7 @@
 	<<if ($legendaryCowID == 0) && ($slaves[$i].lactation > 0) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000) && ($slaves[$i].devotion > 50) && ($slaves[$i].prestige == 0)>>
 		<<set $legendaryCowID = $slaves[$i].ID>>
 	<</if>>
-	<<if ($legendaryBallsID == 0) && ($slaves[$i].balls > 5) && ($slaves[$i].devotion > 50) && ($slaves[$i].prestige == 0)>>
+	<<if ($legendaryBallsID == 0) && ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1) && ($slaves[$i].devotion > 50) && ($slaves[$i].prestige == 0)>>
 		<<set $legendaryBallsID = $slaves[$i].ID>>
 	<</if>>
 

--- a/src/uncategorized/dairyReport.tw
+++ b/src/uncategorized/dairyReport.tw
@@ -136,7 +136,7 @@
 				She spends extra time with $slaves[$i].slaveName, the well-known cow. $Milkmaid.slaveName is fascinated by her massive $slaves[$i].boobs cc breasts and spends extra time massaging and kneading them to maximize production.
 				<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 			<<else>>
-				She is disapointed that $slaves[$i].slaveName, the well-known cow, is unable to give milk like she used to.
+				She is disapointed that $slaves[$i].slaveName, the well-known cow, is<<if ($slaves[$i].lactation = 0)>>n't producing milk anymore. <<else>> breasts have shruken considerably from their height.<</if>>
 			<</if>>
 		<</if>>
 		<<if $slaves[$i].prestigeDesc == "She is remembered for winning best in show as a cockmilker.">>
@@ -144,7 +144,7 @@
 				She spends extra time with $slaves[$i].slaveName, the massive ejaculating cow.  She can't help but massage the cow's dick and testes to stimulate them further and coax more from them.
 				<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 			<<else>>
-				She is disapointed that $slaves[$i].slaveName, the massive ejaculating cow, is unable to give cum like she used to.
+				She is disapointed that $slaves[$i].slaveName, the (formerly) massive ejaculating cow, is<<if [$i].balls = 0>> not producing cum. <<else>> balls are considerably smaller than at their height.<</if>>
 			<</if>>
 		<</if>>
 	<</for>>

--- a/src/uncategorized/dairyReport.tw
+++ b/src/uncategorized/dairyReport.tw
@@ -144,7 +144,7 @@
 				She spends extra time with $slaves[$i].slaveName, the massive ejaculating cow.  She can't help but massage the cow's dick and testes to stimulate them further and coax more from them.
 				<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 			<<else>>
-				She is disappointed that the (formerly) massive ejaculating cow $slaves[$i].slaveName<<if [$i].balls == 0>> is not producing cum. <<else>>'s balls are considerably smaller than at their height.<</if>>
+				She is disappointed that the (formerly) massive ejaculating cow $slaves[$i].slaveName<<if $slaves[$i].balls == 0>> is incapable of producing cum. <<else>>'s balls are considerably smaller than at their height.<</if>>
 			<</if>>
 		<</if>>
 	<</for>>

--- a/src/uncategorized/servantsQuartersReport.tw
+++ b/src/uncategorized/servantsQuartersReport.tw
@@ -125,7 +125,7 @@
 			She ignores her duties in order the fawn over the famous entertainer, $slaves[$i].slaveName.
 		<<case "She is remembered for winning best in show as a cockmilker.">>
 			<<if ($slaves[$i].balls > 5)>>
-				$slaves[$i].slaveName leaves a trail of cum wherever she goes and frequently stops to masturbate greatly annoying $Stewardess.slaveName.
+				$slaves[$i].slaveName leaves a trail of cum wherever she goes and frequently stops to masturbate, greatly annoying $Stewardess.slaveName.
 				<<if random(1,100) > 90 && $Stewardess.rivalry == 0 && $slaves[$i].rivalry == 0>>
 					<<set $Stewardess.rivalryTarget = $slaves[$i].ID, $Stewardess.rivalry++, $slaves[_FLs].rivalryTarget = $slaves[$i].ID, $slaves[_FLs].rivalry++>>
 					<<set $slaves[$i].rivalryTarget = $Stewardess.ID, $slaves[$i].rivalry++>>

--- a/src/uncategorized/servantsQuartersReport.tw
+++ b/src/uncategorized/servantsQuartersReport.tw
@@ -124,16 +124,20 @@
 		<<case "She is a famed Free Cities slut, and can please anyone.">>
 			She ignores her duties in order the fawn over the famous entertainer, $slaves[$i].slaveName.
 		<<case "She is remembered for winning best in show as a cockmilker.">>
-			$slaves[$i].slaveName leaves a trail of cum wherever she goes and frequently stops to masturbate greatly annoying $Stewardess.slaveName.
-			<<if random(1,100) > 90 && $Stewardess.rivalry == 0 && $slaves[$i].rivalry == 0>>
-				<<set $Stewardess.rivalryTarget = $slaves[$i].ID, $Stewardess.rivalry++, $slaves[_FLs].rivalryTarget = $slaves[$i].ID, $slaves[_FLs].rivalry++>>
-				<<set $slaves[$i].rivalryTarget = $Stewardess.ID, $slaves[$i].rivalry++>>
+			<<if ($slaves[$i].balls > 5)>>
+				$slaves[$i].slaveName leaves a trail of cum wherever she goes and frequently stops to masturbate greatly annoying $Stewardess.slaveName.
+				<<if random(1,100) > 90 && $Stewardess.rivalry == 0 && $slaves[$i].rivalry == 0>>
+					<<set $Stewardess.rivalryTarget = $slaves[$i].ID, $Stewardess.rivalry++, $slaves[_FLs].rivalryTarget = $slaves[$i].ID, $slaves[_FLs].rivalry++>>
+					<<set $slaves[$i].rivalryTarget = $Stewardess.ID, $slaves[$i].rivalry++>>
+				<</if>>
 			<</if>>
 		<<case "She is remembered for winning best in show as a dairy cow.">>
-			$slaves[$i].slaveName's huge breasts frequently get in the way of her work and she leaks milk everywhere, greatly annoying $Stewardess.slaveName.
-			<<if random(1,100) > 90 && $Stewardess.rivalry == 0 && $slaves[$i].rivalry == 0>>
-				<<set $Stewardess.rivalryTarget = $slaves[$i].ID, $Stewardess.rivalry++, $slaves[_FLs].rivalryTarget = $slaves[$i].ID, $slaves[_FLs].rivalry++>>
-				<<set $slaves[$i].rivalryTarget = $Stewardess.ID, $slaves[$i].rivalry++>>
+			<<if ($slaves[$i].lactation > 0) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000)>>
+				$slaves[$i].slaveName's huge breasts frequently get in the way of her work and she leaks milk everywhere, greatly annoying $Stewardess.slaveName.
+				<<if random(1,100) > 90 && $Stewardess.rivalry == 0 && $slaves[$i].rivalry == 0>>
+					<<set $Stewardess.rivalryTarget = $slaves[$i].ID, $Stewardess.rivalry++, $slaves[_FLs].rivalryTarget = $slaves[$i].ID, $slaves[_FLs].rivalry++>>
+					<<set $slaves[$i].rivalryTarget = $Stewardess.ID, $slaves[$i].rivalry++>>
+				<</if>>
 			<</if>>
 		<</switch>>
 		<<if (_BonusToggle == 1) && ($slaves[$i].devotion < 45)>>

--- a/src/uncategorized/servantsQuartersReport.tw
+++ b/src/uncategorized/servantsQuartersReport.tw
@@ -124,7 +124,7 @@
 		<<case "She is a famed Free Cities slut, and can please anyone.">>
 			She ignores her duties in order the fawn over the famous entertainer, $slaves[$i].slaveName.
 		<<case "She is remembered for winning best in show as a cockmilker.">>
-			<<if ($slaves[$i].balls > 5)>>
+			<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
 				$slaves[$i].slaveName leaves a trail of cum wherever she goes and frequently stops to masturbate, greatly annoying $Stewardess.slaveName.
 				<<if random(1,100) > 90 && $Stewardess.rivalry == 0 && $slaves[$i].rivalry == 0>>
 					<<set $Stewardess.rivalryTarget = $slaves[$i].ID, $Stewardess.rivalry++, $slaves[_FLs].rivalryTarget = $slaves[$i].ID, $slaves[_FLs].rivalry++>>

--- a/src/uncategorized/servantsQuartersReport.tw
+++ b/src/uncategorized/servantsQuartersReport.tw
@@ -124,7 +124,7 @@
 		<<case "She is a famed Free Cities slut, and can please anyone.">>
 			She ignores her duties in order the fawn over the famous entertainer, $slaves[$i].slaveName.
 		<<case "She is remembered for winning best in show as a cockmilker.">>
-			<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
+			<<if ($slaves[$i].dick != 0) && ($slaves[$i].balls != 0) && ($slaves[$i].prostate > 1) && ($slaves[$i].energy > 95)>>
 				$slaves[$i].slaveName leaves a trail of cum wherever she goes and frequently stops to masturbate, greatly annoying $Stewardess.slaveName.
 				<<if random(1,100) > 90 && $Stewardess.rivalry == 0 && $slaves[$i].rivalry == 0>>
 					<<set $Stewardess.rivalryTarget = $slaves[$i].ID, $Stewardess.rivalry++, $slaves[_FLs].rivalryTarget = $slaves[$i].ID, $slaves[_FLs].rivalry++>>

--- a/src/uncategorized/spaReport.tw
+++ b/src/uncategorized/spaReport.tw
@@ -71,7 +71,7 @@
 		$Attendant.slaveName lets the slaves resting in the spa take the lead sexually, doing her best to please them.
 		<<set _idleBonus++>>
 	<<elseif ($Attendant.fetishKnown == 1)>>
-		$Attendant.slaveName can't keep her hands to herself,preventing the slaves in the spa from relaxing completely.
+		$Attendant.slaveName can't keep her hands to herself, preventing the slaves in the spa from relaxing completely.
 	<</if>>
 	<<if ($Attendant.age > 35)>>
 		Her age encourages the slaves in the spa to relax and pour out their troubles to her.

--- a/src/uncategorized/spaReport.tw
+++ b/src/uncategorized/spaReport.tw
@@ -124,7 +124,7 @@
 			She does her best to soothe the famous entertainer, $slaves[$i].slaveName, letting her relax in blissful peace.
 			<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 		<<case "She is remembered for winning best in show as a cockmilker.">>
-			<<if ($slaves[$i].balls > 5)>>
+			<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
 				<<if $Attendant.fetish == "cumslut">>
 					She can't keep her hands off $slaves[$i].slaveName's cock and balls, but she doesn't mind being milked constantly.  Before long strands of cum can be found floating all throughout the bath.
 					<<set $Attendant.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>

--- a/src/uncategorized/spaReport.tw
+++ b/src/uncategorized/spaReport.tw
@@ -71,7 +71,7 @@
 		$Attendant.slaveName lets the slaves resting in the spa take the lead sexually, doing her best to please them.
 		<<set _idleBonus++>>
 	<<elseif ($Attendant.fetishKnown == 1)>>
-		$Attendant.slaveName can't keep her hands to herself, preventing the slaves in the spa from relaxing completely.
+		$Attendant.slaveName can't keep her hands to herself,preventing the slaves in the spa from relaxing completely.
 	<</if>>
 	<<if ($Attendant.age > 35)>>
 		Her age encourages the slaves in the spa to relax and pour out their troubles to her.
@@ -124,29 +124,33 @@
 			She does her best to soothe the famous entertainer, $slaves[$i].slaveName, letting her relax in blissful peace.
 			<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 		<<case "She is remembered for winning best in show as a cockmilker.">>
-			<<if $Attendant.fetish == "cumslut">>
-				She can't keep her hands off $slaves[$i].slaveName's cock and balls, but she doesn't mind being milked constantly.  Before long strands of cum can be found floating all throughout the bath.
-				<<set $Attendant.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>
-			<<else>>
-				She does her best to accommodate $slaves[$i].slaveName's massive genitals and tends to her when ever she feels a need for release.
-				<<if random(1,100) > 65 && $Attendant.fetish == "none">>
-					After taking several massive loads to the face, $Attendant.slaveName begins to find satisfaction in being coated in cum.
-					<<set $Attendant.fetish = "cumslut", $slaves[_FLs].fetish = "cumslut">>
+			<<if ($slaves[$i].balls == 0) && ($slaves[$i].dick == 0) && ($slaves[$i].vagina > -1)>>
+				<<if $Attendant.fetish == "cumslut">>
+					She can't keep her hands off $slaves[$i].slaveName's cock and balls, but she doesn't mind being milked constantly.  Before long strands of cum can be found floating all throughout the bath.
+					<<set $Attendant.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>
+				<<else>>
+					She does her best to accommodate $slaves[$i].slaveName's massive genitals and tends to her when ever she feels a need for release.
+					<<if random(1,100) > 65 && $Attendant.fetish == "none">>
+						After taking several massive loads to the face, $Attendant.slaveName begins to find satisfaction in being coated in cum.
+						<<set $Attendant.fetish = "cumslut", $slaves[_FLs].fetish = "cumslut">>
+					<</if>>
 				<</if>>
 			<</if>>
 			<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 		<<case "She is remembered for winning best in show as a dairy cow.">>
-			<<if $Attendant.fetish == "boobs">>
-				She can't keep her hands off $slaves[$i].slaveName's huge breasts, but she doesn't mind being milked constantly.  Before long the bath gains a white tint.
-				<<set $Attendant.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>
-			<<else>>
-				She does her best to accommodate $slaves[$i].slaveName's massive breasts and tends to her when ever she feels a need for release.
-				<<if random(1,100) > 65 && $Attendant.fetish == "none">>
-					After multiple milking sessions, $Attendant.slaveName begins to find herself fantasizing about having giant milky breasts too.
-					<<set $Attendant.fetish = "boobs", $slaves[_FLs].fetish = "boobs">>
+			<<if ($slaves[$i].lactation > 0) && (($slaves[$i].boobs-$slaves[$i].boobsImplant) > 6000)>>
+				<<if $Attendant.fetish == "boobs">>
+					She can't keep her hands off $slaves[$i].slaveName's huge breasts, but she doesn't mind being milked constantly.  Before long the bath gains a white tint.
+					<<set $Attendant.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>
+				<<else>>
+					She does her best to accommodate $slaves[$i].slaveName's massive breasts and tends to her when ever she feels a need for release.
+					<<if random(1,100) > 65 && $Attendant.fetish == "none">>
+						After multiple milking sessions, $Attendant.slaveName begins to find herself fantasizing about having giant milky breasts too.
+						<<set $Attendant.fetish = "boobs", $slaves[_FLs].fetish = "boobs">>
+					<</if>>
 				<</if>>
+				<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 			<</if>>
-			<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 		<</switch>>
 		<<if ($Attendant.intelligence > 0) && (_attendantUsedCure == 0) && random(1,100) > (100-($Attendant.intelligence*10)-_seed)>>
 			<<if $slaves[$i].behavioralFlaw != "none">>

--- a/src/uncategorized/spaReport.tw
+++ b/src/uncategorized/spaReport.tw
@@ -124,7 +124,7 @@
 			She does her best to soothe the famous entertainer, $slaves[$i].slaveName, letting her relax in blissful peace.
 			<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 		<<case "She is remembered for winning best in show as a cockmilker.">>
-			<<if ($slaves[$i].balls == 0) && ($slaves[$i].dick == 0) && ($slaves[$i].vagina > -1)>>
+			<<if ($slaves[$i].balls > 5)>>
 				<<if $Attendant.fetish == "cumslut">>
 					She can't keep her hands off $slaves[$i].slaveName's cock and balls, but she doesn't mind being milked constantly.  Before long strands of cum can be found floating all throughout the bath.
 					<<set $Attendant.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>

--- a/src/uncategorized/spaReport.tw
+++ b/src/uncategorized/spaReport.tw
@@ -129,7 +129,7 @@
 					She can't keep her hands off $slaves[$i].slaveName's cock and balls, but she doesn't mind being milked constantly.  Before long strands of cum can be found floating all throughout the bath.
 					<<set $Attendant.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>
 				<<else>>
-					She does her best to accommodate $slaves[$i].slaveName's massive genitals and tends to her when ever she feels a need for release.
+					She does her best to accommodate $slaves[$i].slaveName's massive genitals and tends to her whenever she feels a need for release.
 					<<if random(1,100) > 65 && $Attendant.fetish == "none">>
 						After taking several massive loads to the face, $Attendant.slaveName begins to find satisfaction in being coated in cum.
 						<<set $Attendant.fetish = "cumslut", $slaves[_FLs].fetish = "cumslut">>
@@ -143,7 +143,7 @@
 					She can't keep her hands off $slaves[$i].slaveName's huge breasts, but she doesn't mind being milked constantly.  Before long the bath gains a white tint.
 					<<set $Attendant.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>
 				<<else>>
-					She does her best to accommodate $slaves[$i].slaveName's massive breasts and tends to her when ever she feels a need for release.
+					She does her best to accommodate $slaves[$i].slaveName's massive breasts and tends to her whenever she feels a need for release.
 					<<if random(1,100) > 65 && $Attendant.fetish == "none">>
 						After multiple milking sessions, $Attendant.slaveName begins to find herself fantasizing about having giant milky breasts too.
 						<<set $Attendant.fetish = "boobs", $slaves[_FLs].fetish = "boobs">>

--- a/src/uncategorized/spaReport.tw
+++ b/src/uncategorized/spaReport.tw
@@ -124,7 +124,7 @@
 			She does her best to soothe the famous entertainer, $slaves[$i].slaveName, letting her relax in blissful peace.
 			<<set $slaves[$i].devotion += 3, $slaves[$i].trust += 3>>
 		<<case "She is remembered for winning best in show as a cockmilker.">>
-			<<if ($slaves[$i].balls > 5) && ($slaves[$i].dick != 0) && ($slaves[$i].prostate > 1)>>
+			<<if ($slaves[$i].balls > 4) && ($slaves[$i].dick != 0)>>
 				<<if $Attendant.fetish == "cumslut">>
 					She can't keep her hands off $slaves[$i].slaveName's cock and balls, but she doesn't mind being milked constantly.  Before long strands of cum can be found floating all throughout the bath.
 					<<set $Attendant.fetishStrength += 4, $slaves[_FLs].fetishStrength += 4>>


### PR DESCRIPTION
This is a patch for several facilities which would automatically mention prestigious cows producing large amounts of cum/milk even when they no longer did so. As this is my first edit, I tried to keep it fairly simple: the spa, clinic and servants quarters all simply omit mention of the slaves if they no longer fit the criteria that gave them their prestige. The dairy mentions that the slaves are no longer producing milk or cum as they once did.

The Brothel is a special case. I tried to set it up so that if certain future societies were in effect, the bonus for having the cows in your brothel would change. Specifically, Gender Fundamentalists approve of Legendary Cockmilkers who no longer have penises and Physical Idealists approve of fit cows no longer produce milk.

This is my first edit, hope I did everything right. Thank you.