### PR TITLE
New Raiding System

### DIFF
--- a/src/init/storyInit.tw
+++ b/src/init/storyInit.tw
@@ -698,6 +698,7 @@ You should have received a copy of the GNU General Public License along with thi
 <<set $CoursingAssociation = 0>>
 	<<set $Lurcher = 0>>
 	<<set $coursed = 0>>
+<<set $RaidingMercenaries = 0>>
 <<set $MixedMarriage = 0>>
 <<set $CulturalOpenness = 0>>
 

--- a/src/init/storyInit.tw
+++ b/src/init/storyInit.tw
@@ -699,6 +699,7 @@ You should have received a copy of the GNU General Public License along with thi
 	<<set $Lurcher = 0>>
 	<<set $coursed = 0>>
 <<set $RaidingMercenaries = 0>>
+	<<set $raided = 0>>
 <<set $MixedMarriage = 0>>
 <<set $CulturalOpenness = 0>>
 

--- a/src/uncategorized/policies.tw
+++ b/src/uncategorized/policies.tw
@@ -752,7 +752,7 @@
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will cost ¤$policyCost weekly to maintain//
 <</if>>
 
-<<if $RaidingMercenaries == 0>>
+<<if ($RaidingMercenaries == 0) && ($mercenariesHelpCorp = 1>>)>>
 	<br>''Mercenary Raiding:'' you will allow your mercenaries to occasionaly conduct a raid directly for your benefit.
 	[[Implement|Policies][$RaidingMercenaries = 1, $cash -=5000, $rep -= 1000]]
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will cost ¤$policyCost weekly to maintain//

--- a/src/uncategorized/policies.tw
+++ b/src/uncategorized/policies.tw
@@ -141,7 +141,7 @@
 <</if>>
 
 <</if>>
-<<if $alwaysSubsidizeGrowth + $alwaysSubsidizeRep + $CashForRep + $RepForCash + $RegularParties + $PAPublic + $CoursingAssociation > 0>>
+<<if $alwaysSubsidizeGrowth + $alwaysSubsidizeRep + $CashForRep + $RepForCash + $RegularParties + $PAPublic + $CoursingAssociation + $RaidingMercenaries > 0>>
 <br>__Domestic Policy__
 
 <<if $alwaysSubsidizeGrowth == 1>>
@@ -180,6 +180,11 @@
 <<if $CoursingAssociation == 1>>
 	<br>''Coursing Association:'' you are sponsoring a [[Coursing Association]] that will hold monthly races.
 	[[Repeal|Policies][$CoursingAssociation = 0]]
+<</if>>
+
+<<if $RaidingMercenaries == 1>>
+	<br>''Raiding Mercenaries:'' you are allowing your mercenaries to occasionally raid to your direct benefit.
+	[[Repeal|Policies][$RaidingMercenaries = 0]]
 <</if>>
 
 <</if>>
@@ -744,6 +749,12 @@
 <<if $CoursingAssociation == 0>>
 	<br>''Coursing Association:'' you will sponsor a Coursing Association that will hold monthly races.
 	[[Implement|Policies][$CoursingAssociation = 1, $cash -=5000, $rep -= 1000]]
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will cost ¤$policyCost weekly to maintain//
+<</if>>
+
+<<if $RaidingMercenaries == 0>>
+	<br>''Mercenary Raiding:'' you will allow your mercenaries to occasionaly conduct a raid directly for your benefit.
+	[[Implement|Policies][$RaidingMercenaries = 1, $cash -=5000, $rep -= 1000]]
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will cost ¤$policyCost weekly to maintain//
 <</if>>
 

--- a/src/uncategorized/policies.tw
+++ b/src/uncategorized/policies.tw
@@ -752,7 +752,7 @@
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will cost ¤$policyCost weekly to maintain//
 <</if>>
 
-<<if ($RaidingMercenaries == 0) && ($mercenariesHelpCorp = 1>>)>>
+<<if ($RaidingMercenaries == 0) && ($mercenariesHelpCorp == 1)>>
 	<br>''Mercenary Raiding:'' you will allow your mercenaries to occasionaly conduct a raid directly for your benefit.
 	[[Implement|Policies][$RaidingMercenaries = 1, $cash -=5000, $rep -= 1000]]
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;//Will cost ¤$policyCost weekly to maintain//

--- a/src/uncategorized/scheduledEvent.tw
+++ b/src/uncategorized/scheduledEvent.tw
@@ -112,7 +112,7 @@
 	<<goto "SE custom slave delivery">>
 <<elseif ($Lurcher != 0) && ($CoursingAssociation != 0) && (Math.trunc($week/4) == ($week/4)) && ($coursed != 1)>>
 	<<goto "SE coursing">>
-<<elseif ($RaidingMercenaries != 0) && ($week % 4 == 1) && ($week > ($raided + 6))>>
+<<elseif ($RaidingMercenaries != 0) && ($week > ($raided + 6))>>
 	<<goto "SE raiding">>
 <<elseif ((($fighterIDs.length > 1) && ($pitBG == 0)) || (($fighterIDs.length > 0) && ($Bodyguard != 0) && ($pitBG == 1))) && ($pitFought == 0)>>
 	<<if $pitLethal == 1>><<goto "SE lethal pit">><<else>><<goto "SE nonlethal pit">><</if>>

--- a/src/uncategorized/scheduledEvent.tw
+++ b/src/uncategorized/scheduledEvent.tw
@@ -112,7 +112,7 @@
 	<<goto "SE custom slave delivery">>
 <<elseif ($Lurcher != 0) && ($CoursingAssociation != 0) && (Math.trunc($week/4) == ($week/4)) && ($coursed != 1)>>
 	<<goto "SE coursing">>
-<<elseif ($RaidingMercenaries != 0) && (Math.trunc($week/4) == ($week/4)) && ($raided != 1)>>
+<<elseif ($RaidingMercenaries != 0) && ($week % 4 == 1) && ($week > ($raided + 6))>>
 	<<goto "SE raiding">>
 <<elseif ((($fighterIDs.length > 1) && ($pitBG == 0)) || (($fighterIDs.length > 0) && ($Bodyguard != 0) && ($pitBG == 1))) && ($pitFought == 0)>>
 	<<if $pitLethal == 1>><<goto "SE lethal pit">><<else>><<goto "SE nonlethal pit">><</if>>

--- a/src/uncategorized/scheduledEvent.tw
+++ b/src/uncategorized/scheduledEvent.tw
@@ -112,6 +112,8 @@
 	<<goto "SE custom slave delivery">>
 <<elseif ($Lurcher != 0) && ($CoursingAssociation != 0) && (Math.trunc($week/4) == ($week/4)) && ($coursed != 1)>>
 	<<goto "SE coursing">>
+<<elseif ($RaidingMercenaries != 0) && (Math.trunc($week/4) == ($week/4)) && ($raided != 1)>>
+	<<goto "SE raiding">>
 <<elseif ((($fighterIDs.length > 1) && ($pitBG == 0)) || (($fighterIDs.length > 0) && ($Bodyguard != 0) && ($pitBG == 1))) && ($pitFought == 0)>>
 	<<if $pitLethal == 1>><<goto "SE lethal pit">><<else>><<goto "SE nonlethal pit">><</if>>
 <<elseif ($bioreactorPerfectedID != 0) && ($bioreactorsAnnounced != 1)>>

--- a/src/uncategorized/seRaiding
+++ b/src/uncategorized/seRaiding
@@ -1,0 +1,525 @@
+:: SE raiding
+
+<<nobr>>
+
+<<set $nextLink = "Scheduled Event">>
+<<set $returnTo = "Scheduled Event">>
+<<set $nextButton = "Continue">>
+<<set $raided = 1>>
+<<set $seed = 0>>
+
+The leader of your $mercenariesTitle has contacted you from the world outside your arcology. It seems that your mercenaries have enjoyed a profitable series of raids in their time outside the arcology and have hence decided to push their luck by plundering one last location on their way back to the arcology. As your nominal leader, they ask your opinion of a small number of potential targets. Given the distance from the arcology and the time sensitivity of conducting such a mission, you have little to base your decision on besides a brief description.
+<br><br>
+Worthy of consideration is that although the $mercenariesTitle will enslave the lion's share of enslaved prisoners for the corporation, they will present you the finest slave captured as a gesture of respect for your high position.
+
+<<set $target1 = 0>>
+<<set $target2 = 0>>
+<<set $target3 = 0>>
+
+<<set $origins = []>>
+<<if $seeDicks != 100>>
+	<<set $origins.push("housewife")>>
+	<<set $origins.push("university professor")>>
+	<<set $origins.push("university student")>>
+	<<set $origins.push("female military officer")>>
+	<<set $origins.push("military soldier")>>
+<</if>>
+<<if $seeDicks != 0>>
+	<<set $origins.push("male military officer")>>	
+<</if>>
+
+<<for $i = 0; $i < 3; $i++>>
+
+<<if $i == 0>>
+	The first target
+<<elseif $i == 1>>
+	The second target
+<<else>>
+	The third and final target
+<</if>>
+
+<<set $origin = $origins.pluck()>>
+<<if $origin == "housewife">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.boobs += 800>>
+	<<set $activeSlave.boobsImplant += 800>>
+	<<set $activeSlave.butt += 1>>
+	<<set $activeSlave.buttImplant += 1>>
+	<<set $activeSlave.face = 55>>
+	<<set $activeSlave.faceImplant += 1>>
+	<<set $activeSlave.anus = 1>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.analCount += 1>>
+	<<set $analTotal += 1>>
+	<<set $activeSlave.preg = -1>>
+	<<set $activeSlave.ovaries = 1>>
+	<<set $activeSlave.vaginalSkill = 35>>
+	<<set $activeSlave.oralSkill = 100>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 35>>
+	<<set $activeSlave.age = random(35,39)>>
+	<<set $activeSlave.career = either("a housewife", "a trophy wife")>>
+	is an idyllic manse in the countryside of an Old World Nation. It's owner is a businessman of some notoriety, but is often away from his expansive estate. A number of servants and maids are in residence, but the primary resident of the manse is his wife. From the sound of things, she is not a young woman but attractive enough in a fake sort of way.
+<<elseif $origin == "university professor">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(35,$retirementAge-1)>>
+	<<set $activeSlave.career = "a professor">>
+	<<set $activeSlave.health = random(10,30)>>
+	<<set $activeSlave.face = random(15,100)>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 100>>
+	<<set $activeSlave.intelligence = 2>>
+	<<set $activeSlave.intelligenceImplant = 1>>
+	<<set $activeSlave.teeth = "normal">>
+	is the department offices of a still operational Old World University. The University prides itself on a diverse and capable faculty, often touting its wealth of female professors as a symbol of its progressive agenda. Though they are unlikely to be young, these professors will be educated and quite intelligent. The head of the department is no exception, a woman of considerable academic credentials. 
+<<elseif $origin == "university student">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(18,22)>>
+	<<set $activeSlave.career = "a student">>
+	<<set $activeSlave.health = random(-10,10)>>
+	<<set $activeSlave.face = random(-20,0)>>
+	<<set $activeSlave.anus to 0>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.vaginalSkill = 0>>
+	<<set $activeSlave.analSkill = 0>>
+	<<set $activeSlave.oralSkill = 0>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 0>>
+	<<set $activeSlave.intelligence = random(1,2)>>
+	<<set $activeSlave.intelligenceImplant = 1>>
+	<<set $activeSlave.teeth = "normal">>
+	is the residence dormitories of a still operational Old World University. The University prides itself on a diverse and inspired student body, often touting its wealth of female students as a symbol of its progressive agenda. Though they are young, these students will likely have benefited from their education and fairly intelligent. By all accounts the prettiest of them is no exception, a student with a shining academic record. 
+<<elseif $origin == "female military officer">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(26,$retirementAge-1)>>
+	<<set $activeSlave.career = "a military officer">>
+	<<set $activeSlave.prestige = 1>>
+	<<set $activeSlave.health = random(10,30)>>
+	<<set $activeSlave.face = random(15,100)>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.combatSkill = 1>>
+	<<set $activeSlave.entertainSkill = 100>>
+	<<set $activeSlave.intelligence = random(1,2)>>
+	<<set $activeSlave.intelligenceImplant = 1>>
+	<<set $activeSlave.teeth = "normal">>
+	is a military officer currently traveling to the front of a fresh conflict between rival powers in the Old World. In an attempt to disguise her high rank, she is traveling with only a small escort of soldiers and is a prime target for enslavement. The officer is a graduate of a renowned Old World military college and no stranger to the battlefield, yet has retained her femininity despite her considerable achievements.
+<<elseif $origin == "male military officer">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(26,$retirementAge-1)>>
+	<<set $activeSlave.career = "a military officer">>
+	<<set $activeSlave.prestige = 1>>
+	<<set $activeSlave.face = Math.clamp($activeSlave.face+20,-100,100)>>
+	<<set $activeSlave.faceImplant = 1>>
+	<<set $activeSlave.analSkill = 0>>
+	<<set $activeSlave.oralSkill = 0>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.combatSkill = 1>>
+	<<set $activeSlave.age = random(26,$retirementAge-1)>>
+	<<set $activeSlave.hStyle = either("very short", "short")>>
+	<<set $activeSlave.boobs = 150>>
+	<<set $activeSlave.vagina = -1>>
+	<<set $activeSlave.clit = 0>>
+	<<set $activeSlave.ovaries = 0>>
+	<<set $activeSlave.preg = 0>>
+	<<set $activeSlave.dick = random(3,5)>>
+	<<set $activeSlave.balls = random(2,4)>>
+	<<set $activeSlave.anus = 0>>
+	<<set $activeSlave.weight = 0>>
+	<<set $activeSlave.muscles = 50>>
+	is a military officer currently traveling to the front of a fresh conflict between rival powers in the Old World. In an attempt to disguise his high rank, he is traveling with only a small escort of soldiers and is a prime target for enslavement. The officer is a graduate of a renowned Old World military college and no stranger to the battlefield.
+	<<elseif $origin == "military soldier">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(18,25)>>
+	<<set $activeSlave.career = "a soldier">>
+	<<set $activeSlave.prestige = 1>>
+	<<set $activeSlave.health = random(10,30)>>
+	<<set $activeSlave.face = random(15,100)>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.combatSkill = 1>>
+	<<set $activeSlave.entertainSkill = 100>>
+	<<set $activeSlave.intelligenceImplant = 0>>
+	<<set $activeSlave.teeth = "normal">>
+	is the barracks of a local garrison in an Old World town. The majority of the town's young men have already been sent to the front of a new conflict, so the town has conscripted a number of young women to fill the ranks of their garrison. Though the soldiers are likely to be untested, they have still received some measure of combat training. Their sergeant is the nominal leader of the group, though she holds the position due to familial connections rather than any real military seniority.
+<</if>>
+
+<<set $activeSlave.origin = "Your $mercenariesTitle caught her while raiding; she was a $origin.">>
+<<set $activeSlave.health = random(30,50)>>
+<<set $activeSlave.devotion = random(-45,-25)>>
+<<set $activeSlave.trust = random(-60,-75)>>
+<<set $activeSlave.oldDevotion = $activeSlave.devotion>>
+
+<<if $activeSlave.weight > 95>>
+	They're a catastrophically fat individual, and may stand a better chance of getting away rolling than outrunning your mercenaries.
+	<<set $targetEscape -= 2>>
+<<elseif $activeSlave.weight > 30>>
+	They're chubby enough that outrunning your mercenaries will be difficult.
+	<<set $targetEscape -= 1>>
+<<elseif $activeSlave.weight < -95>>
+	They're so skinny that their emaciated figure will impede any attempt at outrunning your mercenaries.
+	<<set $targetEscape -= 1>>
+<</if>>
+<<if $activeSlave.muscles > 30>>
+	Their heavy musculature weighs them down.
+	<<set $targetEscape -= 1>>
+<<elseif $activeSlave.muscles <= 5>>
+	They're soft and toneless.
+	<<set $targetEscape -= 1>>
+<</if>>
+<<if $activeSlave.height >= 185>>
+	They're tall enough that her height makes her easy to spot and slow to escape.
+	<<set $targetEscape -= 2>>
+<<elseif $activeSlave.height < 150>>
+	They're short enough that her height makes her difficult to spot, though also slow to escape.
+	<<set $targetEscape -= 1>>
+<</if>>
+<<if $activeSlave.boobs >= 2000>>
+	They have absurdly large breasts that seriously hamper any rapid movement.
+	<<set $targetEscape -= 1>>
+<<elseif $activeSlave.boobs >= 800>>
+	They have huge boobs that will make it painful for them to move rapidly.
+	<<set $targetEscape -= 1>>
+<</if>>
+<<if $activeSlave.butt >= 6>>
+	They have an immense posterior that will impede any attempts at hiding or running.
+	<<set $targetEscape -= 1>>
+<</if>>
+<<if $activeSlave.dick >= 5>>
+	Their cock is large enough to slow them down.
+	<<set $targetEscape -= 1>>
+<</if>>
+<<if ($activeSlave.balls >= 5) && ($activeSlave.scrotum > 0)>>
+	Their balls are likely to hurt while running, enough to slow them down.
+	<<set $targetEscape -= 1>>
+<</if>>
+<<if $activeSlave.preg >= 20>>
+	Their pregnant belly is likely to preclude them from escaping on foot at all.
+	<<set $targetEscape -= 5>>
+<</if>>
+
+<<if $i == 0>>
+	<<set $target = $activeSlave>>
+	<<set $origin1 = $origin>>
+	<<set $targetEscape1 = $targetEscape>>
+<<elseif $i == 1>>
+	<<set $target2 = $activeSlave>>
+	<<set $origin2 = $origin>>
+	<<set $targetEscape2 = $targetEscape>>
+<<else>>
+	<<set $target3 = $activeSlave>>
+	<<set $origin3 = $origin>>
+	<<set $targetEscape3 = $targetEscape>>
+<</if>>
+
+<</for>>
+<br><br>
+
+Your $mercenariesTitle look to you for guidance and will strike the target of your choosing. 
+
+<</nobr>>\
+
+<span id="result">
+<<link "The first">>
+<<replace "#result">>
+<<nobr>>
+<<set $activeSlave = $target1>>
+<<set $origin = $origin1>>
+<<set $targetEscape = $targetEscape1>>
+
+You make your selection and direct your $mercenariesTitle to attack the target.
+
+<<set $MercCapture = random(-4,4)>>
+
+<<if $targetEscape >= $MercCapture>>
+	<<if $origin == "housewife">>
+	Somehow the housewife manages to evade your mercenaries
+	<<elseif $origin == "university professor">>
+	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	<<elseif $origin == "university student">>
+	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	<<elseif $origin == "female military officer">>
+	The officer's escort engages your mercenaries in a gunfight and in the confusion she manages to escape capture on foot.
+	<<elseif $origin == "male military officer">>
+	The officer's escort engages your mercenaries in a gunfight and in the confusion he manages to escape capture on foot.
+	<<elseif $origin == "military soldier">>
+	The young soldiers fight valiantly against your mercenaries until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+	<</if>>
+<<else>>
+	The $mercenariesTitle manage to close in on the target and make their final preparations to apprehend them.
+	<<set $seed = 1>>
+<</if>>
+
+<<if $seed == 1>>
+	<<if $origin == "housewife">>
+	<<if random(1,3) == 1>>
+		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
+	<</if>>
+	<<elseif $origin == "university professor">>
+	<<if random(1,3) == 1>>
+		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
+	<</if>>
+	<<elseif $origin == "university student">>
+	<<if random(1,3) == 1>>
+		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
+	<</if>>
+	<<elseif $origin == "female military officer">>
+	<<if random(1,3) == 1>>
+		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
+		<<set $seed = 0>>
+	<<else>>
+	As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+	<</if>>
+	<<elseif $origin == "male military officer">>
+	<<if random(1,3) == 1>>
+		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
+		<<set $seed = 0>>
+	<<else>>
+	As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+	<</if>>
+	<<elseif $origin == "military soldier">>
+		<<if random(1,3) == 1>>
+		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
+		<<set $seed = 0>>
+	<<else>>
+	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
+	<</if>>
+<</if>>
+<</if>>
+
+<<if $seed == 1>>
+	<<if $origin == "housewife">>
+	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
+	<<elseif $origin == "university professor">>
+	The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+	<<elseif $origin == "university student">>
+	The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+	<<elseif $origin == "female military officer">>
+	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
+	<<elseif $origin == "male military officer">>
+	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
+	<<elseif $origin == "military soldier">>
+	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
+	<<AddSlave $activeSlave>> /* skip New Slave Intro */	
+	<<else>>
+	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
+	<</if>>
+<</if>>
+<</nobr>>
+<</replace>>
+<</link>>
+<<link "The second">>
+<<replace "#result">>
+<<nobr>>
+<<set $activeSlave = $target2>>
+<<set $origin = $origin2>>
+<<set $targetEscape = $targetEscape2>>
+
+You make your selection and direct your $mercenariesTitle to attack the target.
+
+<<set $MercCapture = random(-4,4)>>
+
+<<if $targetEscape >= $MercCapture>>
+	<<if $origin == "housewife">>
+	Somehow the housewife manages to evade your mercenaries
+	<<elseif $origin == "university professor">>
+	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	<<elseif $origin == "university student">>
+	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	<<elseif $origin == "female military officer">>
+	The officer's escort engages your mercenaries in a gunfight and in the confusion she manages to escape capture on foot.
+	<<elseif $origin == "male military officer">>
+	The officer's escort engages your mercenaries in a gunfight and in the confusion he manages to escape capture on foot.
+	<<elseif $origin == "military soldier">>
+	The young soldiers fight valiantly against your mercenaries until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+	<<else>>
+	The target manages to escape on foot
+	<</if>>
+<<else>>
+	The $mercenariesTitle manage to close in on the target and make their final preparations to apprehend them.
+	<<set $seed = 1>>
+<</if>>
+
+<<if $seed == 1>>
+	<<if $origin == "housewife">>
+	<<if random(1,3) == 1>>
+		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
+	<</if>>
+	<<elseif $origin == "university professor">>
+	<<if random(1,3) == 1>>
+		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
+	<</if>>
+	<<elseif $origin == "university student">>
+	<<if random(1,3) == 1>>
+		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
+	<</if>>
+	<<elseif $origin == "female military officer">>
+	<<if random(1,3) == 1>>
+		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
+		<<set $seed = 0>>
+	<<else>>
+	As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+	<</if>>
+	<<elseif $origin == "male military officer">>
+	<<if random(1,3) == 1>>
+		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
+		<<set $seed = 0>>
+	<<else>>
+	As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+	<</if>>
+	<<elseif $origin == "military soldier">>
+		<<if random(1,3) == 1>>
+		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
+		<<set $seed = 0>>
+	<<else>>
+	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
+	<</if>>
+<</if>>
+<</if>>
+
+<<if $seed == 1>>
+	<<if $origin == "housewife">>
+	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
+	<<elseif $origin == "university professor">>
+	The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+	<<elseif $origin == "university student">>
+	The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+	<<elseif $origin == "female military officer">>
+	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
+	<<elseif $origin == "male military officer">>
+	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
+	<<elseif $origin == "military soldier">>
+	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
+	<<AddSlave $activeSlave>> /* skip New Slave Intro */	
+	<<else>>
+	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
+	<</if>>
+<</if>>
+<</nobr>>
+<</replace>>
+<</link>>
+<<link "The third">>
+<<replace "#result">>
+<<nobr>>
+<<set $activeSlave = $target3>>
+<<set $origin = $origin3>>
+<<set $targetEscape = $targetEscape3>>
+
+You make your selection and direct your $mercenariesTitle to attack the target.
+
+<<set $MercCapture = random(-4,4)>>
+
+<<if $targetEscape >= $MercCapture>>
+	<<if $origin == "housewife">>
+	Somehow the housewife manages to evade your mercenaries
+	<<elseif $origin == "university professor">>
+	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	<<elseif $origin == "university student">>
+	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	<<elseif $origin == "female military officer">>
+	The officer's escort engages your mercenaries in a gunfight and in the confusion she manages to escape capture on foot.
+	<<elseif $origin == "male military officer">>
+	The officer's escort engages your mercenaries in a gunfight and in the confusion he manages to escape capture on foot.
+	<<elseif $origin == "military soldier">>
+	The young soldiers fight valiantly against your mercenaries until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+	<<else>>
+	The target manages to escape on foot
+	<</if>>
+<<else>>
+	The $mercenariesTitle manage to close in on the target and make their final preparations to apprehend them.
+	<<set $seed = 1>>
+<</if>>
+
+<<if $seed == 1>>
+	<<if $origin == "housewife">>
+	<<if random(1,3) == 1>>
+		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
+	<</if>>
+	<<elseif $origin == "university professor">>
+	<<if random(1,3) == 1>>
+		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
+	<</if>>
+	<<elseif $origin == "university student">>
+	<<if random(1,3) == 1>>
+		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
+	<</if>>
+	<<elseif $origin == "female military officer">>
+	<<if random(1,3) == 1>>
+		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
+		<<set $seed = 0>>
+	<<else>>
+	As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+	<</if>>
+	<<elseif $origin == "male military officer">>
+	<<if random(1,3) == 1>>
+		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
+		<<set $seed = 0>>
+	<<else>>
+	As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+	<</if>>
+	<<elseif $origin == "military soldier">>
+		<<if random(1,3) == 1>>
+		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
+		<<set $seed = 0>>
+	<<else>>
+	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
+	<</if>>
+<</if>>
+<</if>>
+
+<<if $seed == 1>>
+	<<if $origin == "housewife">>
+	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
+	<<elseif $origin == "university professor">>
+	The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+	<<elseif $origin == "university student">>
+	The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+	<<elseif $origin == "female military officer">>
+	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
+	<<elseif $origin == "male military officer">>
+	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
+	<<elseif $origin == "military soldier">>
+	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
+	<<AddSlave $activeSlave>> /* skip New Slave Intro */	
+	<<else>>
+	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
+	<</if>>
+<</if>>
+<</nobr>>
+<</replace>>
+<</link>>
+</span>

--- a/src/uncategorized/seRaiding
+++ b/src/uncategorized/seRaiding
@@ -133,7 +133,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.weight = 0>>
 	<<set $activeSlave.muscles = 50>>
 	is a military officer currently traveling to the front of a fresh conflict between rival powers in the Old World. In an attempt to disguise his high rank, he is traveling with only a small escort of soldiers and is a prime target for enslavement. The officer is a graduate of a renowned Old World military college and no stranger to the battlefield.
-	<<elseif $origin == "military soldier">>
+<<elseif $origin == "military soldier">>
 	<<include "Generate XX Slave">>
 	<<set $activeSlave.age = random(18,25)>>
 	<<set $activeSlave.career = "a soldier">>
@@ -175,10 +175,10 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $targetEscape -= 1>>
 <</if>>
 <<if $activeSlave.height >= 185>>
-	They're tall enough that her height makes her easy to spot and slow to escape.
+	They're tall enough that their height makes them easy to spot and slow to escape.
 	<<set $targetEscape -= 2>>
 <<elseif $activeSlave.height < 150>>
-	They're short enough that her height makes her difficult to spot, though also slow to escape.
+	They're short enough that their height makes them difficult to spot, though also slow to escape.
 	<<set $targetEscape -= 1>>
 <</if>>
 <<if $activeSlave.boobs >= 2000>>
@@ -316,10 +316,10 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "military soldier">>
 	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
-	<<AddSlave $activeSlave>> /* skip New Slave Intro */	
-	<<else>>
-	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
 	<</if>>
+<<AddSlave $activeSlave>> /* skip New Slave Intro */	
+<<else>>
+	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
 <</if>>
 <</nobr>>
 <</replace>>
@@ -415,10 +415,10 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "military soldier">>
 	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
-	<<AddSlave $activeSlave>> /* skip New Slave Intro */	
-	<<else>>
-	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
 	<</if>>
+<<AddSlave $activeSlave>> /* skip New Slave Intro */	
+<<else>>
+	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
 <</if>>
 <</nobr>>
 <</replace>>
@@ -514,10 +514,10 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "military soldier">>
 	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
-	<<AddSlave $activeSlave>> /* skip New Slave Intro */	
-	<<else>>
-	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
 	<</if>>
+<<AddSlave $activeSlave>> /* skip New Slave Intro */	
+<<else>>
+	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
 <</if>>
 <</nobr>>
 <</replace>>

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -36,10 +36,13 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 <<for $i = 0; $i < 3; $i++>>
 
 <<if $i == 0>>
+<br><br>
 	The first target
 <<elseif $i == 1>>
+<br><br>
 	The second target
 <<else>>
+<br><br>
 	The third and final target
 <</if>>
 
@@ -204,7 +207,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.behavioralFlaw to "liberated">>
 	<<set $activeSlave.sexualFlaw to "idealistic">>
 	is the offices of an esteemed Old World newspaper firm. The paper is known for its investigative journalism, particularly as one of the few firms willing to delve into the brave new world of the Free Cities. The rising star of the paper is undoubtedly a young journalist who has been an outspoken critic of slaveholding and other Free Cities traditions.
-<<if $origin == "local news anchor">>
+<<elseif $origin == "local news anchor">>
 	<<include "Generate XX Slave">>
 	<<set $activeSlave.boobs += 800>>
 	<<set $activeSlave.boobsImplant += 800>>
@@ -224,7 +227,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.whoreSkill = 35>>
 	<<set $activeSlave.entertainSkill = 35>>
 	<<set $activeSlave.age = random(35,39)>>
-	<<set $activeSlave.career = "a local news anchor>>
+	<<set $activeSlave.career = "a local news anchor">>
 	is the recording studio of a sleepy Old World town's local news channel. The news channel itself is unremarkable, a quaint reminder of the tedious life of a small town, save for its news anchor. The anchor stands in stark contrast to her fellow residents by the abundance of her plastic surgery, likely an attempt to cling to youth lest her coveted anchor position be snatched away by a younger woman.
 <<elseif $origin == "classical dancer">>
 	<<include "Generate XX Slave">>
@@ -354,7 +357,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	Unfortunately for your mercenaries, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
 	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
-<</if>>
+	<</if>>
 <<else>>
 	The $mercenariesTitle manage to close in on the target and make their final preparations to apprehend them.
 	<<set $seed = 1>>

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -307,15 +307,18 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 <<set $activeSlave.trust = random(-60,-75)>>
 <<set $activeSlave.oldDevotion = $activeSlave.devotion>>
 
+	The $origin is the primary target of the raid.
 <<if $activeSlave.weight > 95>>
-	They're a catastrophically fat individual, and may stand a better chance of getting away rolling than outrunning your mercenaries.
+	They're a catastrophically fat individual, so much so that they might be better off rolling around than walking.
 	<<set $targetEscape -= 2>>
 <<elseif $activeSlave.weight > 30>>
-	They're chubby enough that outrunning your mercenaries will be difficult.
+	Their figure is fairly chubby.
 	<<set $targetEscape -= 1>>
 <<elseif $activeSlave.weight < -95>>
-	They're so skinny that their emaciated figure will impede any attempt at outrunning your mercenaries.
+	They're so skinny that they appear almost emaciated.
 	<<set $targetEscape -= 1>>
+<<else>>
+	They have a fairly average weight.
 <</if>>
 <<if $activeSlave.muscles > 30>>
 	Their heavy musculature weighs them down.
@@ -323,24 +326,38 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 <<elseif $activeSlave.muscles <= 5>>
 	Their body is soft and toneless.
 	<<set $targetEscape -= 1>>
+<<else>>
+	Their body is fairly muscular.
 <</if>>
 <<if $activeSlave.height >= 185>>
-	They're tall enough that their height makes them easy to spot and slow to escape.
+	They're tall enough that their height makes them easy to spot.
 	<<set $targetEscape -= 2>>
 <<elseif $activeSlave.height < 150>>
-	They're short enough that their height makes them difficult to spot while also slow to escape.
+	They're short enough that their height makes them difficult to spot.
 	<<set $targetEscape -= 1>>
+<<else>>
+	They're of an average height.
 <</if>>
 <<if $activeSlave.boobs >= 2000>>
-	They have absurdly large breasts that seriously hamper any rapid movement.
+	They have absurdly large breasts.
 	<<set $targetEscape -= 1>>
 <<elseif $activeSlave.boobs >= 800>>
-	They have huge boobs that will make it painful for them to move rapidly.
+	They have fairly large breasts.
 	<<set $targetEscape -= 1>>
+<<elseif $activeSlave.boobs >= 400>>
+	They have medium sized breasts.
+<<else>>
+	They're fairly flat chested.
 <</if>>
 <<if $activeSlave.butt >= 6>>
-	They have an immense posterior that will impede any attempts at hiding or running.
+	They have an immense posterior.
 	<<set $targetEscape -= 1>>
+<<elseif $activeSlave.butt >= 4>>
+	They have a large ass.
+<<elseif $activeSlave.butt >= 2>>
+	They've got a big butt.
+<<else>>
+	They've got a flat ass.
 <</if>>
 <<if $activeSlave.dick >= 5>>
 	Their cock is large enough to slow them down.

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -504,10 +504,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
-	 The $mercenariesTitle are able to carry out their plan.
-	<<set _raidseed = 1>>
-<</if>>
-
+<<set _raidseed = 1>>
 <<if _raidseed == 1>>
 	<<if $origin == "housewife">>
 	<<if _raidescape == 1>>
@@ -643,6 +640,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
+<</if>>
 <</if>>
 
 <<if _raidseed == 1>>
@@ -744,10 +742,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
-	 The $mercenariesTitle are able to carry out their plan.
-	<<set _raidseed = 1>>
-<</if>>
-
+<<set _raidseed = 1>>
 <<if _raidseed == 1>>
 	<<if $origin == "housewife">>
 	<<if _raidescape == 1>>
@@ -883,6 +878,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
+<</if>>
 <</if>>
 
 <<if _raidseed == 1>>
@@ -984,10 +980,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
-	 The $mercenariesTitle are able to carry out their plan.
-	<<set _raidseed = 1>>
-<</if>>
-
+<<set _raidseed = 1>>
 <<if _raidseed == 1>>
 	<<if $origin == "housewife">>
 	<<if _raidescape == 1>>
@@ -1123,6 +1116,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
+<</if>>
 <</if>>
 
 <<if _raidseed == 1>>

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -23,6 +23,11 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $origins.push("university student")>>
 	<<set $origins.push("female military officer")>>
 	<<set $origins.push("military soldier")>>
+	<<set $origins.push("doctor")>>
+	<<set $origins.push("nun")>>
+	<<set $origins.push("journalist")>>
+	<<set $origins.push("local news anchor")>>
+	<<set $origins.push("classical dancer")>>
 <</if>>
 <<if $seeDicks != 0>>
 	<<set $origins.push("male military officer")>>	
@@ -54,7 +59,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.preg = -1>>
 	<<set $activeSlave.ovaries = 1>>
 	<<set $activeSlave.vaginalSkill = 35>>
-	<<set $activeSlave.oralSkill = 100>>
+	<<set $activeSlave.oralSkill = 35>>
 	<<set $activeSlave.analSkill = 15>>
 	<<set $activeSlave.whoreSkill = 35>>
 	<<set $activeSlave.age = random(35,39)>>
@@ -70,7 +75,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.oralSkill = 35>>
 	<<set $activeSlave.analSkill = 15>>
 	<<set $activeSlave.whoreSkill = 0>>
-	<<set $activeSlave.entertainSkill = 100>>
+	<<set $activeSlave.entertainSkill = 10>>
 	<<set $activeSlave.intelligence = 2>>
 	<<set $activeSlave.intelligenceImplant = 1>>
 	<<set $activeSlave.teeth = "normal">>
@@ -104,7 +109,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.analSkill = 15>>
 	<<set $activeSlave.whoreSkill = 0>>
 	<<set $activeSlave.combatSkill = 1>>
-	<<set $activeSlave.entertainSkill = 100>>
+	<<set $activeSlave.entertainSkill = 10>>
 	<<set $activeSlave.intelligence = random(1,2)>>
 	<<set $activeSlave.intelligenceImplant = 1>>
 	<<set $activeSlave.teeth = "normal">>
@@ -145,10 +150,98 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.analSkill = 15>>
 	<<set $activeSlave.whoreSkill = 0>>
 	<<set $activeSlave.combatSkill = 1>>
-	<<set $activeSlave.entertainSkill = 100>>
+	<<set $activeSlave.entertainSkill = 10>>
 	<<set $activeSlave.intelligenceImplant = 0>>
 	<<set $activeSlave.teeth = "normal">>
 	is the barracks of a local garrison in an Old World town. The majority of the town's young men have already been sent to the front of a new conflict, so the town has conscripted a number of young women to fill the ranks of their garrison. Though the soldiers are likely to be untested, they have still received some measure of combat training. Their sergeant is the nominal leader of the group, though she holds the position due to familial connections rather than any real military seniority.
+<<elseif $origin == "doctor">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(28,$retirementAge-1)>>
+	<<set $activeSlave.career = "a doctor">>
+	<<set $activeSlave.health = random(10,30)>>
+	<<set $activeSlave.face = random(15,100)>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 10>>
+	<<set $activeSlave.intelligence = 2>>
+	<<set $activeSlave.intelligenceImplant = 1>>
+	<<set $activeSlave.teeth = "normal">>
+	is a hospital located in an impoverished Old World City. Despite its crime ridden surroundings, the hospital possesses a sterling reputation as a result of its distinguished staff of veteran doctors and nurses. Chief among these medical professionals is a female doctor, an accomplished pioneer in her field.
+<<elseif $origin == "nun">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.career to "a nun">>
+	<<set $activeSlave.anus to 0>>
+	<<set $activeSlave.vagina to 0>>
+	<<set $activeSlave.weight to random(-20,-100)>>
+	<<set $activeSlave.attrXX to random(10,50)>>
+	<<set $activeSlave.attrXY to random(10,50)>>
+	<<set $activeSlave.energy to random(5,20)>>
+	<<set $activeSlave.vaginalSkill = 0>>
+	<<set $activeSlave.oralSkill = 15>>
+	<<set $activeSlave.analSkill = 0>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 0>>
+	<<set $activeSlave.age to random(18,$retirementAge-1)>>
+	<<set $activeSlave.behavioralFlaw to "devout">>
+	<<set $activeSlave.sexualFlaw to "repressed">>
+	is a reclusive religious community in a mountain range between two currently contested territories. The members of the community have withdrawn from the collapsing social order of the world and established a commune in their mountain retreat, filling their days with peaceful reflection and prayer. Though the nuns have no true leader, one among them has emerged as the most pious of the sisters.
+<<elseif $origin == "journalist">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(18,26)>>
+	<<set $activeSlave.career = "a journalist">>
+	<<set $activeSlave.prestige = 1>>
+	<<set $activeSlave.health = random(-10,10)>>
+	<<set $activeSlave.face = random(-20,0)>>
+	<<set $activeSlave.anus to 0>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.vaginalSkill = 0>>
+	<<set $activeSlave.analSkill = 0>>
+	<<set $activeSlave.oralSkill = 0>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 35>>
+	<<set $activeSlave.behavioralFlaw to "liberated">>
+	<<set $activeSlave.sexualFlaw to "idealistic">>
+	is the offices of an esteemed Old World newspaper firm. The paper is known for its investigative journalism, particularly as one of the few firms willing to delve into the brave new world of the Free Cities. The rising star of the paper is undoubtedly a young journalist who has been an outspoken critic of slaveholding and other Free Cities traditions.
+<<if $origin == "local news anchor">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.boobs += 800>>
+	<<set $activeSlave.boobsImplant += 800>>
+	<<set $activeSlave.butt += 1>>
+	<<set $activeSlave.buttImplant += 1>>
+	<<set $activeSlave.face = 55>>
+	<<set $activeSlave.faceImplant += 1>>
+	<<set $activeSlave.anus = 1>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.analCount += 1>>
+	<<set $analTotal += 1>>
+	<<set $activeSlave.preg = -1>>
+	<<set $activeSlave.ovaries = 1>>
+	<<set $activeSlave.vaginalSkill = 35>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 35>>
+	<<set $activeSlave.entertainSkill = 35>>
+	<<set $activeSlave.age = random(35,39)>>
+	<<set $activeSlave.career = "a local news anchor>>
+	is the recording studio of a sleepy Old World town's local news channel. The news channel itself is unremarkable, a quaint reminder of the tedious life of a small town, save for its news anchor. The anchor stands in stark contrast to her fellow residents by the abundance of her plastic surgery, likely an attempt to cling to youth lest her coveted anchor position be snatched away by a younger woman.
+<<elseif $origin == "classical dancer">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(18,20)>>
+	<<set $activeSlave.career = "a classical dancer">>
+	<<set $activeSlave.prestige = 1>>
+	<<set $activeSlave.health = random(-10,10)>>
+	<<set $activeSlave.face = random(-20,0)>>
+	<<set $activeSlave.anus to 0>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.vaginalSkill = 0>>
+	<<set $activeSlave.analSkill = 0>>
+	<<set $activeSlave.oralSkill = 0>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 50>>
+	<<set $activeSlave.teeth = "normal">>
+	is the performing arts theater at the heart of an aristocratic Old World city. The theater itself would usually not be considered a choice target, except that tonight its stage is graced by a renowned dance troupe. The jewel of the troupe's cast is a young girl, barely past her majority, whose performance has been said to bring tears to the eyes of audiences the world over.
 <</if>>
 
 <<set $activeSlave.origin = "Your $mercenariesTitle caught her while raiding; she was a $origin.">>
@@ -251,7 +344,17 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The officer's escort engages your mercenaries in a gunfight and in the confusion he manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
 	The young soldiers fight valiantly against your mercenaries until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
-	<</if>>
+	<<elseif $origin == "doctor">>
+	The hospital's security staff alone would prove little match for your mercenaries, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
+	<<elseif $origin == "nun">>
+	As your mercenaries close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+	<<elseif $origin == "journalist">>
+	Though your mercenaries easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+	<<elseif $origin == "local news anchor">>
+	Unfortunately for your mercenaries, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+	<<elseif $origin == "classical dancer">>
+	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+<</if>>
 <<else>>
 	The $mercenariesTitle manage to close in on the target and make their final preparations to apprehend them.
 	<<set $seed = 1>>
@@ -300,6 +403,41 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<else>>
 	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
+	<<elseif $origin == "doctor">>
+		<<if random(1,3) == 1>>
+		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
+		<<set $seed = 0>>
+	<<else>>
+	The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
+	<</if>>
+	<<elseif $origin == "nun">>
+		<<if random(1,3) == 1>>
+		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
+		<<set $seed = 0>>
+	<<else>>
+	Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
+	<</if>>
+	<<elseif $origin == "journalist">>
+		<<if random(1,3) == 1>>
+		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
+		<<set $seed = 0>>
+	<<else>>
+	Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "local news anchor">>
+		<<if random(1,3) == 1>>
+		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
+		<<set $seed = 0>>
+	<<else>>
+	The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "classical dancer">>
+		<<if random(1,3) == 1>>
+		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
+		<<set $seed = 0>>
+	<<else>>
+	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking in, each member is cuffed and escorted out the door to the waiting VTOL.
+	<</if>>
 <</if>>
 <</if>>
 
@@ -316,6 +454,16 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "military soldier">>
 	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
+	<<elseif $origin == "doctor">>
+	The distinguished doctor spends the VTOL ride looking on at her colleagues and peers being raped by your mercenaries. She naively hopes that she has been spared from that fate out of a desire for her medical knowledge rather than her body.
+	<<elseif $origin == "nun">>
+	The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
+	<<elseif $origin == "journalist">>
+	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies ever brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
+	<<elseif $origin == "local news anchor">>
+	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
+	<<elseif $origin == "nun">>
+	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>
@@ -348,9 +496,17 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The officer's escort engages your mercenaries in a gunfight and in the confusion he manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
 	The young soldiers fight valiantly against your mercenaries until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
-	<<else>>
-	The target manages to escape on foot
-	<</if>>
+	<<elseif $origin == "doctor">>
+	The hospital's security staff alone would prove little match for your mercenaries, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
+	<<elseif $origin == "nun">>
+	As your mercenaries close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+	<<elseif $origin == "journalist">>
+	Though your mercenaries easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+	<<elseif $origin == "local news anchor">>
+	Unfortunately for your mercenaries, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+	<<elseif $origin == "classical dancer">>
+	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+<</if>>
 <<else>>
 	The $mercenariesTitle manage to close in on the target and make their final preparations to apprehend them.
 	<<set $seed = 1>>
@@ -399,6 +555,41 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<else>>
 	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
+	<<elseif $origin == "doctor">>
+		<<if random(1,3) == 1>>
+		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
+		<<set $seed = 0>>
+	<<else>>
+	The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
+	<</if>>
+	<<elseif $origin == "nun">>
+		<<if random(1,3) == 1>>
+		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
+		<<set $seed = 0>>
+	<<else>>
+	Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
+	<</if>>
+	<<elseif $origin == "journalist">>
+		<<if random(1,3) == 1>>
+		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
+		<<set $seed = 0>>
+	<<else>>
+	Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "local news anchor">>
+		<<if random(1,3) == 1>>
+		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
+		<<set $seed = 0>>
+	<<else>>
+	The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "classical dancer">>
+		<<if random(1,3) == 1>>
+		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
+		<<set $seed = 0>>
+	<<else>>
+	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking in, each member is cuffed and escorted out the door to the waiting VTOL.
+	<</if>>
 <</if>>
 <</if>>
 
@@ -415,6 +606,16 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "military soldier">>
 	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
+	<<elseif $origin == "doctor">>
+	The distinguished doctor spends the VTOL ride looking on at her colleagues and peers being raped by your mercenaries. She naively hopes that she has been spared from that fate out of a desire for her medical knowledge rather than her body.
+	<<elseif $origin == "nun">>
+	The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
+	<<elseif $origin == "journalist">>
+	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies ever brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
+	<<elseif $origin == "local news anchor">>
+	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
+	<<elseif $origin == "nun">>
+	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>
@@ -447,9 +648,17 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The officer's escort engages your mercenaries in a gunfight and in the confusion he manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
 	The young soldiers fight valiantly against your mercenaries until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
-	<<else>>
-	The target manages to escape on foot
-	<</if>>
+	<<elseif $origin == "doctor">>
+	The hospital's security staff alone would prove little match for your mercenaries, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
+	<<elseif $origin == "nun">>
+	As your mercenaries close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+	<<elseif $origin == "journalist">>
+	Though your mercenaries easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+	<<elseif $origin == "local news anchor">>
+	Unfortunately for your mercenaries, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+	<<elseif $origin == "classical dancer">>
+	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+<</if>>
 <<else>>
 	The $mercenariesTitle manage to close in on the target and make their final preparations to apprehend them.
 	<<set $seed = 1>>
@@ -498,6 +707,41 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<else>>
 	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
+	<<elseif $origin == "doctor">>
+		<<if random(1,3) == 1>>
+		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
+		<<set $seed = 0>>
+	<<else>>
+	The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
+	<</if>>
+	<<elseif $origin == "nun">>
+		<<if random(1,3) == 1>>
+		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
+		<<set $seed = 0>>
+	<<else>>
+	Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
+	<</if>>
+	<<elseif $origin == "journalist">>
+		<<if random(1,3) == 1>>
+		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
+		<<set $seed = 0>>
+	<<else>>
+	Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "local news anchor">>
+		<<if random(1,3) == 1>>
+		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
+		<<set $seed = 0>>
+	<<else>>
+	The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "classical dancer">>
+		<<if random(1,3) == 1>>
+		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
+		<<set $seed = 0>>
+	<<else>>
+	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking in, each member is cuffed and escorted out the door to the waiting VTOL.
+	<</if>>
 <</if>>
 <</if>>
 
@@ -514,6 +758,16 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "military soldier">>
 	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
+	<<elseif $origin == "doctor">>
+	The distinguished doctor spends the VTOL ride looking on at her colleagues and peers being raped by your mercenaries. She naively hopes that she has been spared from that fate out of a desire for her medical knowledge rather than her body.
+	<<elseif $origin == "nun">>
+	The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
+	<<elseif $origin == "journalist">>
+	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies ever brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
+	<<elseif $origin == "local news anchor">>
+	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
+	<<elseif $origin == "nun">>
+	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -358,7 +358,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	is the offices of a law firm operating on the boundary between the Old World and the Free Cities. The lawyers within profit from the shaky legal channels between Old World nations and new Free Cities, largely drawing up contracts or facilitating the transfer of goods, services, and slaves. The sole senior partner of the firm is one of the pioneers of this new field of legal work, having been a staunch corporate advocate for much of her life.
 <</if>>
 
-<<set $activeSlave.origin = "Your $mercenariesTitle caught her while raiding; she was a $origin.">>
+<<set $activeSlave.origin = "Your " + $mercenariesTitle + " caught her while raiding; she was a " + $origin + ".">>
 <<set $activeSlave.health = random(30,50)>>
 <<set $activeSlave.devotion = random(-45,-25)>>
 <<set $activeSlave.trust = random(-60,-75)>>
@@ -464,43 +464,43 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 
 <<if $targetEscape >= $MercCapture>>
 	<<if $origin == "housewife">>
-	Somehow the housewife manages to evade your mercenaries
+		Somehow the housewife manages to evade your mercenaries.
 	<<elseif $origin == "university professor">>
-	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
+		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "university student">>
-	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
+		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "female military officer">>
-	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "male military officer">>
-	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
-	The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
 	<<elseif $origin == "doctor">>
-	The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
+		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
 	<<elseif $origin == "nun">>
-	As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
 	<<elseif $origin == "journalist">>
-	Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
 	<<elseif $origin == "local news anchor">>
-	Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
-	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 	<<elseif $origin == "law enforcement officer">>
-	Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
+		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
 	<<elseif $origin == "classical musician">>
-	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
 	<<elseif $origin == "politician">>
-	The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
 	<<elseif $origin == "shut-in">>
-	The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
 	<<elseif $origin == "procuress">>
-	The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
+		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
 	<<elseif $origin == "investor">>
-	The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
+		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
 	<<elseif $origin == "scientist">>
-	When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
+		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
 	<<elseif $origin == "lawyer">>
-	It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
+		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
@@ -513,133 +513,133 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
+		Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
+		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
+		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
 		<<set $raidseed = 0>>
 	<<else>>
-	As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
 		<<set $raidseed = 0>>
 	<<else>>
-	As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
 		<<if random(1,3) == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
 		<<set $raidseed = 0>>
 	<<else>>
-	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
+		The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "doctor">>
 		<<if random(1,3) == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
 		<<set $raidseed = 0>>
 	<<else>>
-	The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
+		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
 		<<if random(1,3) == 1>>
 		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
 		<<set $raidseed = 0>>
 	<<else>>
-	Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
+		Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
 		<<set $raidseed = 0>>
 	<<else>>
-	Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
+		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
 		<<set $raidseed = 0>>
 	<<else>>
-	The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
+		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
 		<<set $raidseed = 0>>
 	<<else>>
-	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
 		<<if random(1,3) == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
+		Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
 		<<set $raidseed = 0>>
 	<<else>>
-	Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
 		<<if random(1,3) == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
 		<<set $raidseed = 0>>
 	<<else>>
-	With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
+		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "shut-in">>
 		<<if random(1,3) == 1>>
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
 		<<set $raidseed = 0>>
 	<<else>>
-	When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+		When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "procuress">>
 		<<if random(1,3) == 1>>
 		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
 		<<set $raidseed = 0>>
 	<<else>>
-	When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
+		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
 	<</if>>
 	<<elseif $origin == "investor">>
 		<<if random(1,3) == 1>>
 		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
 		<<set $raidseed = 0>>
 	<<else>>
-	When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
+		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
 	<</if>>
 	<<elseif $origin == "scientist">>
 		<<if random(1,3) == 1>>
 		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
 		<<set $raidseed = 0>>
 	<<else>>
-	The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
+		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
 	<</if>>
 	<<elseif $origin == "lawyer">>
 		<<if random(1,3) == 1>>
 		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
+		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>
@@ -704,43 +704,43 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 
 <<if $targetEscape >= $MercCapture>>
 	<<if $origin == "housewife">>
-	Somehow the housewife manages to evade your mercenaries
+		Somehow the housewife manages to evade your mercenaries.
 	<<elseif $origin == "university professor">>
-	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
+		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "university student">>
-	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
+		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "female military officer">>
-	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "male military officer">>
-	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
-	The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
 	<<elseif $origin == "doctor">>
-	The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
+		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
 	<<elseif $origin == "nun">>
-	As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
 	<<elseif $origin == "journalist">>
-	Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
 	<<elseif $origin == "local news anchor">>
-	Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
-	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 	<<elseif $origin == "law enforcement officer">>
-	Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
+		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
 	<<elseif $origin == "classical musician">>
-	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
 	<<elseif $origin == "politician">>
-	The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
 	<<elseif $origin == "shut-in">>
-	The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
 	<<elseif $origin == "procuress">>
-	The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
+		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
 	<<elseif $origin == "investor">>
-	The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
+		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
 	<<elseif $origin == "scientist">>
-	When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
+		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
 	<<elseif $origin == "lawyer">>
-	It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
+		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
@@ -753,133 +753,133 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
+		Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
+		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
+		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
 		<<set $raidseed = 0>>
 	<<else>>
-	As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
 		<<set $raidseed = 0>>
 	<<else>>
-	As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
 		<<if random(1,3) == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
 		<<set $raidseed = 0>>
 	<<else>>
-	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
+		The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "doctor">>
 		<<if random(1,3) == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
 		<<set $raidseed = 0>>
 	<<else>>
-	The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
+		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
 		<<if random(1,3) == 1>>
 		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
 		<<set $raidseed = 0>>
 	<<else>>
-	Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
+		Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
 		<<set $raidseed = 0>>
 	<<else>>
-	Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
+		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
 		<<set $raidseed = 0>>
 	<<else>>
-	The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
+		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
 		<<set $raidseed = 0>>
 	<<else>>
-	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
 		<<if random(1,3) == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
+		Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
 		<<set $raidseed = 0>>
 	<<else>>
-	Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
 		<<if random(1,3) == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
 		<<set $raidseed = 0>>
 	<<else>>
-	With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
+		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "shut-in">>
 		<<if random(1,3) == 1>>
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
 		<<set $raidseed = 0>>
 	<<else>>
-	When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+		When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "procuress">>
 		<<if random(1,3) == 1>>
 		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
 		<<set $raidseed = 0>>
 	<<else>>
-	When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
+		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
 	<</if>>
 	<<elseif $origin == "investor">>
 		<<if random(1,3) == 1>>
 		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
 		<<set $raidseed = 0>>
 	<<else>>
-	When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
+		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
 	<</if>>
 	<<elseif $origin == "scientist">>
 		<<if random(1,3) == 1>>
 		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
 		<<set $raidseed = 0>>
 	<<else>>
-	The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
+		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
 	<</if>>
 	<<elseif $origin == "lawyer">>
 		<<if random(1,3) == 1>>
 		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
+		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>
@@ -944,43 +944,43 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 
 <<if $targetEscape >= $MercCapture>>
 	<<if $origin == "housewife">>
-	Somehow the housewife manages to evade your mercenaries
+		Somehow the housewife manages to evade your mercenaries.
 	<<elseif $origin == "university professor">>
-	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
+		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "university student">>
-	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
+		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "female military officer">>
-	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "male military officer">>
-	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
-	The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
 	<<elseif $origin == "doctor">>
-	The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
+		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
 	<<elseif $origin == "nun">>
-	As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
 	<<elseif $origin == "journalist">>
-	Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
 	<<elseif $origin == "local news anchor">>
-	Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
-	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 	<<elseif $origin == "law enforcement officer">>
-	Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
+		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
 	<<elseif $origin == "classical musician">>
-	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
 	<<elseif $origin == "politician">>
-	The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
 	<<elseif $origin == "shut-in">>
-	The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
 	<<elseif $origin == "procuress">>
-	The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
+		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
 	<<elseif $origin == "investor">>
-	The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
+		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
 	<<elseif $origin == "scientist">>
-	When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
+		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
 	<<elseif $origin == "lawyer">>
-	It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
+		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
@@ -993,133 +993,133 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
+		Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
+		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
+		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
 		<<set $raidseed = 0>>
 	<<else>>
-	As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
 		<<set $raidseed = 0>>
 	<<else>>
-	As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
 		<<if random(1,3) == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
 		<<set $raidseed = 0>>
 	<<else>>
-	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
+		The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "doctor">>
 		<<if random(1,3) == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
 		<<set $raidseed = 0>>
 	<<else>>
-	The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
+		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
 		<<if random(1,3) == 1>>
 		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
 		<<set $raidseed = 0>>
 	<<else>>
-	Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
+		Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
 		<<set $raidseed = 0>>
 	<<else>>
-	Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
+		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
 		<<set $raidseed = 0>>
 	<<else>>
-	The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
+		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
 		<<set $raidseed = 0>>
 	<<else>>
-	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
 		<<if random(1,3) == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
+		Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
 		<<set $raidseed = 0>>
 	<<else>>
-	Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
 		<<if random(1,3) == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
 		<<set $raidseed = 0>>
 	<<else>>
-	With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
+		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "shut-in">>
 		<<if random(1,3) == 1>>
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
 		<<set $raidseed = 0>>
 	<<else>>
-	When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+		When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "procuress">>
 		<<if random(1,3) == 1>>
 		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
 		<<set $raidseed = 0>>
 	<<else>>
-	When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
+		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
 	<</if>>
 	<<elseif $origin == "investor">>
 		<<if random(1,3) == 1>>
 		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
 		<<set $raidseed = 0>>
 	<<else>>
-	When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
+		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
 	<</if>>
 	<<elseif $origin == "scientist">>
 		<<if random(1,3) == 1>>
 		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
 		<<set $raidseed = 0>>
 	<<else>>
-	The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
+		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
 	<</if>>
 	<<elseif $origin == "lawyer">>
 		<<if random(1,3) == 1>>
 		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
 		<<set $raidseed = 0>>
 	<<else>>
-	Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
+		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -28,6 +28,10 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $origins.push("journalist")>>
 	<<set $origins.push("local news anchor")>>
 	<<set $origins.push("classical dancer")>>
+	<<set $origins.push("law enforcement officer")>>
+	<<set $origins.push("classical musician")>>
+	<<set $origins.push("politician")>>
+	<<set $origins.push("shut-in")>>
 <</if>>
 <<if $seeDicks != 0>>
 	<<set $origins.push("male military officer")>>	
@@ -238,6 +242,63 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.entertainSkill = 50>>
 	<<set $activeSlave.teeth = "normal">>
 	is the performing arts theater at the heart of an aristocratic Old World city. The theater itself would usually not be considered a choice target, except that tonight its stage is graced by a renowned dance troupe. The jewel of the troupe's cast is a young girl, barely past her majority, whose performance has been said to bring tears to the eyes of audiences the world over.
+<<elseif $origin == "law enforcement officer">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(18,25)>>
+	<<set $activeSlave.career = "a law enforcement officer">>
+	<<set $activeSlave.prestige = 1>>
+	<<set $activeSlave.face = random(15,100)>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.combatSkill = 1>>
+	<<set $activeSlave.entertainSkill = 10>>
+	<<set $activeSlave.intelligenceImplant = 0>>
+	is the precinct of a small Old World town's police department. The department is notoriously underfunded and unlikely to be particularly well staffed. Nonetheless, one of the officers is well known in the area for her adherence to the letter of the law despite her small town cop status.
+<<elseif $origin == "classical musician">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(36,43)>>
+	<<set $activeSlave.career = "a classical musician">>
+	<<set $activeSlave.prestige = 1>>
+	<<set $activeSlave.face = random(-20,0)>>
+	<<set $activeSlave.anus to 0>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.vaginalSkill = 0>>
+	<<set $activeSlave.analSkill = 0>>
+	<<set $activeSlave.oralSkill = 0>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 50>>
+	<<set $activeSlave.teeth = "normal">>
+	is the concert hall at the heart of an aristocratic Old World city. The concert hall itself would usually not be considered a choice target, except that tonight its stage is graced by a renowned orchestra. The pride of the orchestra's cast is a mature woman, whose skill with her instrument has been known to move listeners to tears.
+<<elseif $origin == "politician">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(35,$retirementAge-1)>>
+	<<set $activeSlave.career = "a politician">>
+	<<set $activeSlave.prestige = 2>>
+	<<set $activeSlave.face = random(15,100)>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 10>>
+	<<set $activeSlave.intelligence = 2>>
+	<<set $activeSlave.intelligenceImplant = 1>>
+	<<set $activeSlave.teeth = "normal">>
+	is a campaign rally for the reelection of an Old World politician. Though the rally will be an extremely public affair, the benefits of capturing a prestigious politician could outweigh the risks. 
+<<elseif $origin == "shut-in">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(37,$retirementAge-1)>>
+	<<set $activeSlave.career = "a shut-in">>
+	<<set $activeSlave.anus to 0>>
+	<<set $activeSlave.vagina to 0>>
+	<<set $activeSlave.face = random(15,100)>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 10>>
+	is the shack of a notorious shut-in located just outside your arcology. Not a particularly distinguished target, but it would save your mercenaries considerable time and effort. The shut-in herself has been a fixture of the landscape for decades, with many speculating that she remains a virgin despite her mature age.
 <</if>>
 
 <<set $activeSlave.origin = "Your $mercenariesTitle caught her while raiding; she was a $origin.">>
@@ -350,6 +411,14 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	Unfortunately for your mercenaries, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
 	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+	<<elseif $origin == "law enforcement officer">>
+	Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
+	<<elseif $origin == "classical musician">>
+	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+	<<elseif $origin == "politician">>
+	Your mercenaries clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+	<<elseif $origin == "shut-in">>
+	Your mercenaries pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
@@ -432,9 +501,37 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
 		<<set $seed = 0>>
 	<<else>>
-	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking in, each member is cuffed and escorted out the door to the waiting VTOL.
+	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
-<</if>>
+	<<elseif $origin == "law enforcement officer">>
+		<<if random(1,3) == 1>>
+		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
+	<</if>>
+	<<elseif $origin == "classical musician">>
+		<<if random(1,3) == 1>>
+		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
+		<<set $seed = 0>>
+	<<else>>
+	Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "politician">>
+		<<if random(1,3) == 1>>
+		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
+		<<set $seed = 0>>
+	<<else>>
+	With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "shut-in">>
+		<<if random(1,3) == 1>>
+		When your mercenaries break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
+		<<set $seed = 0>>
+	<<else>>
+	When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+	<</if>>
+	<</if>>
 <</if>>
 
 <<if $seed == 1>>
@@ -455,11 +552,19 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<elseif $origin == "nun">>
 	The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
 	<<elseif $origin == "journalist">>
-	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies ever brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
+	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies every brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
 	<<elseif $origin == "local news anchor">>
 	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
-	<<elseif $origin == "nun">>
+	<<elseif $origin == "classical dancer">>
 	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
+	<<elseif $origin == "law enforcement officer">>
+	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your mercenaries all around her. Before she exits the VTOL upon her arrival, she informs your mercenaries that she intends to bring each of them to justice for their supposed crimes.
+	<<elseif $origin == "classical musician">>
+	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
+	<<elseif $origin == "politician">>
+	The politician spends the VTOL ride quietly, only breaking her silence to ask your mercenaries about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
+	<<elseif $origin == "shut-in">>
+	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your mercenaries attempt to engage her in conversation but are granted no response.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>
@@ -502,7 +607,15 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	Unfortunately for your mercenaries, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
 	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
-<</if>>
+	<<elseif $origin == "law enforcement officer">>
+	Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
+	<<elseif $origin == "classical musician">>
+	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+	<<elseif $origin == "politician">>
+	Your mercenaries clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+	<<elseif $origin == "shut-in">>
+	Your mercenaries pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
 	<<set $seed = 1>>
@@ -584,9 +697,37 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
 		<<set $seed = 0>>
 	<<else>>
-	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking in, each member is cuffed and escorted out the door to the waiting VTOL.
+	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
-<</if>>
+	<<elseif $origin == "law enforcement officer">>
+		<<if random(1,3) == 1>>
+		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
+	<</if>>
+	<<elseif $origin == "classical musician">>
+		<<if random(1,3) == 1>>
+		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
+		<<set $seed = 0>>
+	<<else>>
+	Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "politician">>
+		<<if random(1,3) == 1>>
+		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
+		<<set $seed = 0>>
+	<<else>>
+	With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "shut-in">>
+		<<if random(1,3) == 1>>
+		When your mercenaries break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
+		<<set $seed = 0>>
+	<<else>>
+	When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+	<</if>>
+	<</if>>
 <</if>>
 
 <<if $seed == 1>>
@@ -607,11 +748,19 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<elseif $origin == "nun">>
 	The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
 	<<elseif $origin == "journalist">>
-	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies ever brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
+	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies every brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
 	<<elseif $origin == "local news anchor">>
 	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
-	<<elseif $origin == "nun">>
+	<<elseif $origin == "classical dancer">>
 	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
+	<<elseif $origin == "law enforcement officer">>
+	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your mercenaries all around her. Before she exits the VTOL upon her arrival, she informs your mercenaries that she intends to bring each of them to justice for their supposed crimes.
+	<<elseif $origin == "classical musician">>
+	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
+	<<elseif $origin == "politician">>
+	The politician spends the VTOL ride quietly, only breaking her silence to ask your mercenaries about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
+	<<elseif $origin == "shut-in">>
+	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your mercenaries attempt to engage her in conversation but are granted no response.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>
@@ -654,7 +803,15 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	Unfortunately for your mercenaries, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
 	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
-<</if>>
+	<<elseif $origin == "law enforcement officer">>
+	Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
+	<<elseif $origin == "classical musician">>
+	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+	<<elseif $origin == "politician">>
+	Your mercenaries clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+	<<elseif $origin == "shut-in">>
+	Your mercenaries pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
 	<<set $seed = 1>>
@@ -736,9 +893,37 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
 		<<set $seed = 0>>
 	<<else>>
-	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking in, each member is cuffed and escorted out the door to the waiting VTOL.
+	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
-<</if>>
+	<<elseif $origin == "law enforcement officer">>
+		<<if random(1,3) == 1>>
+		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
+		<<set $seed = 0>>
+	<<else>>
+	Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
+	<</if>>
+	<<elseif $origin == "classical musician">>
+		<<if random(1,3) == 1>>
+		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
+		<<set $seed = 0>>
+	<<else>>
+	Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "politician">>
+		<<if random(1,3) == 1>>
+		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
+		<<set $seed = 0>>
+	<<else>>
+	With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "shut-in">>
+		<<if random(1,3) == 1>>
+		When your mercenaries break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
+		<<set $seed = 0>>
+	<<else>>
+	When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+	<</if>>
+	<</if>>
 <</if>>
 
 <<if $seed == 1>>
@@ -759,11 +944,19 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<elseif $origin == "nun">>
 	The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
 	<<elseif $origin == "journalist">>
-	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies ever brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
+	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies every brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
 	<<elseif $origin == "local news anchor">>
 	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
-	<<elseif $origin == "nun">>
+	<<elseif $origin == "classical dancer">>
 	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
+	<<elseif $origin == "law enforcement officer">>
+	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your mercenaries all around her. Before she exits the VTOL upon her arrival, she informs your mercenaries that she intends to bring each of them to justice for their supposed crimes.
+	<<elseif $origin == "classical musician">>
+	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
+	<<elseif $origin == "politician">>
+	The politician spends the VTOL ride quietly, only breaking her silence to ask your mercenaries about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
+	<<elseif $origin == "shut-in">>
+	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your mercenaries attempt to engage her in conversation but are granted no response.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -72,7 +72,6 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<include "Generate XX Slave">>
 	<<set $activeSlave.age = random(35,$retirementAge-1)>>
 	<<set $activeSlave.career = "a professor">>
-	<<set $activeSlave.health = random(10,30)>>
 	<<set $activeSlave.face = random(15,100)>>
 	<<set $activeSlave.vagina = 1>>
 	<<set $activeSlave.oralSkill = 35>>
@@ -87,7 +86,6 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<include "Generate XX Slave">>
 	<<set $activeSlave.age = random(18,22)>>
 	<<set $activeSlave.career = "a student">>
-	<<set $activeSlave.health = random(-10,10)>>
 	<<set $activeSlave.face = random(-20,0)>>
 	<<set $activeSlave.anus to 0>>
 	<<set $activeSlave.vagina = 1>>
@@ -105,7 +103,6 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.age = random(26,$retirementAge-1)>>
 	<<set $activeSlave.career = "a military officer">>
 	<<set $activeSlave.prestige = 1>>
-	<<set $activeSlave.health = random(10,30)>>
 	<<set $activeSlave.face = random(15,100)>>
 	<<set $activeSlave.vagina = 1>>
 	<<set $activeSlave.oralSkill = 35>>
@@ -146,7 +143,6 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.age = random(18,25)>>
 	<<set $activeSlave.career = "a soldier">>
 	<<set $activeSlave.prestige = 1>>
-	<<set $activeSlave.health = random(10,30)>>
 	<<set $activeSlave.face = random(15,100)>>
 	<<set $activeSlave.vagina = 1>>
 	<<set $activeSlave.oralSkill = 35>>
@@ -161,7 +157,6 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<include "Generate XX Slave">>
 	<<set $activeSlave.age = random(28,$retirementAge-1)>>
 	<<set $activeSlave.career = "a doctor">>
-	<<set $activeSlave.health = random(10,30)>>
 	<<set $activeSlave.face = random(15,100)>>
 	<<set $activeSlave.vagina = 1>>
 	<<set $activeSlave.oralSkill = 35>>
@@ -195,7 +190,6 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.age = random(18,26)>>
 	<<set $activeSlave.career = "a journalist">>
 	<<set $activeSlave.prestige = 1>>
-	<<set $activeSlave.health = random(-10,10)>>
 	<<set $activeSlave.face = random(-20,0)>>
 	<<set $activeSlave.anus to 0>>
 	<<set $activeSlave.vagina = 1>>
@@ -234,7 +228,6 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.age = random(18,20)>>
 	<<set $activeSlave.career = "a classical dancer">>
 	<<set $activeSlave.prestige = 1>>
-	<<set $activeSlave.health = random(-10,10)>>
 	<<set $activeSlave.face = random(-20,0)>>
 	<<set $activeSlave.anus to 0>>
 	<<set $activeSlave.vagina = 1>>
@@ -267,14 +260,14 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	Their heavy musculature weighs them down.
 	<<set $targetEscape -= 1>>
 <<elseif $activeSlave.muscles <= 5>>
-	They're soft and toneless.
+	Their body is soft and toneless.
 	<<set $targetEscape -= 1>>
 <</if>>
 <<if $activeSlave.height >= 185>>
 	They're tall enough that their height makes them easy to spot and slow to escape.
 	<<set $targetEscape -= 2>>
 <<elseif $activeSlave.height < 150>>
-	They're short enough that their height makes them difficult to spot, though also slow to escape.
+	They're short enough that their height makes them difficult to spot while also slow to escape.
 	<<set $targetEscape -= 1>>
 <</if>>
 <<if $activeSlave.boobs >= 2000>>
@@ -302,7 +295,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 <</if>>
 
 <<if $i == 0>>
-	<<set $target = $activeSlave>>
+	<<set $target1 = $activeSlave>>
 	<<set $origin1 = $origin>>
 	<<set $targetEscape1 = $targetEscape>>
 <<elseif $i == 1>>
@@ -359,7 +352,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 	<</if>>
 <<else>>
-	The $mercenariesTitle manage to close in on the target and make their final preparations to apprehend them.
+	 The $mercenariesTitle are able to carry out their plan.
 	<<set $seed = 1>>
 <</if>>
 
@@ -511,7 +504,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 <</if>>
 <<else>>
-	The $mercenariesTitle manage to close in on the target and make their final preparations to apprehend them.
+	 The $mercenariesTitle are able to carry out their plan.
 	<<set $seed = 1>>
 <</if>>
 
@@ -663,7 +656,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 <</if>>
 <<else>>
-	The $mercenariesTitle manage to close in on the target and make their final preparations to apprehend them.
+	 The $mercenariesTitle are able to carry out their plan.
 	<<set $seed = 1>>
 <</if>>
 

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -463,229 +463,217 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 
 <<set $MercCapture = random(-4,4)>>
 
-<<if $targetEscape >= $MercCapture>>
-	<<if $origin == "housewife">>
-		Somehow the housewife manages to evade your mercenaries.
-	<<elseif $origin == "university professor">>
-		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
-	<<elseif $origin == "university student">>
-		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
-	<<elseif $origin == "female military officer">>
-		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
-	<<elseif $origin == "male military officer">>
-		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
-	<<elseif $origin == "military soldier">>
-		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your $mercenariesTitle are unable to capture any of the soldiers who escape on foot.
-	<<elseif $origin == "doctor">>
-		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
-	<<elseif $origin == "nun">>
-		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your $mercenariesTitle can close the distance, they retreat behind the walls of their community and seal the gate behind them.
-	<<elseif $origin == "journalist">>
-		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your $mercenariesTitle beat a hasty retreat.
-	<<elseif $origin == "local news anchor">>
-		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your $mercenariesTitle wisely retreat from the engagement.
-	<<elseif $origin == "classical dancer">>
-		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
-	<<elseif $origin == "law enforcement officer">>
-		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your $mercenariesTitle until reinforcements arrive and force your troops to retreat.
-	<<elseif $origin == "classical musician">>
-		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
-	<<elseif $origin == "politician">>
-		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your $mercenariesTitle can advance, they discover that the politician has already been evacuated.
-	<<elseif $origin == "shut-in">>
-		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your $mercenariesTitle coming.
-	<<elseif $origin == "procuress">>
-		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your $mercenariesTitle discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your $mercenariesTitle even arrived.
-	<<elseif $origin == "investor">>
-		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your $mercenariesTitle that she cited heightened security risks as the reason for her absence.
-	<<elseif $origin == "scientist">>
-		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your $mercenariesTitle are forced to retreat from the building, during which time the scientists make their own escape. When your $mercenariesTitle reenter the building, they find it abandoned.
-	<<elseif $origin == "lawyer">>
-		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
-	<</if>>
-<<else>>
-<<set _raidseed = 1>>
-<<if _raidseed == 1>>
-	<<if $origin == "housewife">>
-	<<if _raidescape == 1>>
+<<if $origin == "housewife">>
+	<<if $targetEscape >= $MercCapture>>
+		Somehow the housewife manages to evade your mercenaries.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle pry open the door to the manse's panic room and pull the protesting housewife from its depths.
-	<</if>>
-	<<elseif $origin == "university professor">>
-	<<if _raidescape == 1>>
+		The housewife watches in terror as your $mercenariesTitle slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "university professor">>
+	<<if $targetEscape >= $MercCapture>>
+		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
-	<</if>>
-	<<elseif $origin == "university student">>
-	<<if _raidescape == 1>>
+		The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "university student">>
+	<<if $targetEscape >= $MercCapture>>
+		A confrontation with the University's security team allows the students to escape capture by the $mercenariesTitle.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
-	<</if>>
-	<<elseif $origin == "female military officer">>
-	<<if _raidescape == 1>>
+		The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "female military officer">>
+	<<if $targetEscape >= $MercCapture>>
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
+	<<elseif _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
-		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
-	<</if>>
-	<<elseif $origin == "male military officer">>
-	<<if _raidescape == 1>>
+		The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "male military officer">>
+	<<if $targetEscape >= $MercCapture>>
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.	
+	<<elseif _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
-		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
-	<</if>>
-	<<elseif $origin == "military soldier">>
-		<<if _raidescape == 1>>
+		The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "military soldier">>
+	<<if $targetEscape >= $MercCapture>>
+		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your $mercenariesTitle are unable to capture any of the soldiers who escape on foot.	
+	<<elseif _raidescape == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
-		<<set _raidseed = 0>>
 	<<else>>
 		The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
-	<</if>>
-	<<elseif $origin == "doctor">>
-		<<if _raidescape == 1>>
+		The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "doctor">>
+	<<if $targetEscape >= $MercCapture>>
+		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 	
+	<<elseif _raidescape == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your $mercenariesTitle prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
-		<<set _raidseed = 0>>
 	<<else>>
 		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your $mercenariesTitle to take the doctors and their staff into custody with little fuss.
-	<</if>>
-	<<elseif $origin == "nun">>
-		<<if _raidescape == 1>>
+		The distinguished doctor spends the VTOL ride looking on at her colleagues and peers being raped by your mercenaries. She naively hopes that she has been spared from that fate out of a desire for her medical knowledge rather than her body.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "nun">>
+	<<if $targetEscape >= $MercCapture>>
+		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your $mercenariesTitle can close the distance, they retreat behind the walls of their community and seal the gate behind them.	
+	<<elseif _raidescape == 1>>
 		The nuns flee into their inner sanctum as your $mercenariesTitle approach and bar the doors behind them as they go. When the last barrier is pried open, your $mercenariesTitle discover the nuns have committed suicide as a group rather than be taken prisoner.
-		<<set _raidseed = 0>>
 	<<else>>
 		Unarmed and defenseless, the nuns are easily cowed by your $mercenariesTitle and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
-	<</if>>
-	<<elseif $origin == "journalist">>
-		<<if _raidescape == 1>>
+		The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "journalist">>
+	<<if $targetEscape >= $MercCapture>>
+		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your $mercenariesTitle beat a hasty retreat.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your $mercenariesTitle retreat from the building before law enforcement can arrive.
-		<<set _raidseed = 0>>
 	<<else>>
 		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "local news anchor">>
-		<<if _raidescape == 1>>
+		The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies every brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "local news anchor">>
+	<<if $targetEscape >= $MercCapture>>
+		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your $mercenariesTitle wisely retreat from the engagement.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
-		<<set _raidseed = 0>>
 	<<else>>
 		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "classical dancer">>
-		<<if _raidescape == 1>>
+		The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "classical dancer">>
+	<<if $targetEscape >= $MercCapture>>
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+	<<elseif _raidescape == 1>>
 		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your $mercenariesTitle exit the theater as chaos surges around them.
-		<<set _raidseed = 0>>
 	<<else>>
 		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "law enforcement officer">>
-		<<if _raidescape == 1>>
+		The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "law enforcement officer">>
+	<<if $targetEscape >= $MercCapture>>
+		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your $mercenariesTitle until reinforcements arrive and force your troops to retreat.
+	<<elseif _raidescape == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your $mercenariesTitle sought to capture is the last to fall, stifled by a hail of bullets.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
-	<</if>>
-	<<elseif $origin == "classical musician">>
-		<<if _raidescape == 1>>
+		The officer spends the VTOL ride watching impassively as her fellow officers are raped by your $mercenariesTitle all around her. Before she exits the VTOL upon her arrival, she informs your $mercenariesTitle that she intends to bring each of them to justice for their supposed crimes.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "classical musician">>
+	<<if $targetEscape >= $MercCapture>>
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+	<<elseif _raidescape == 1>>
 		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your $mercenariesTitle exit the concert hall as chaos surges around them.
-		<<set _raidseed = 0>>
 	<<else>>
 		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "politician">>
-		<<if _raidescape == 1>>
+		The musician spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "politician">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your $mercenariesTitle can advance, they discover that the politician has already been evacuated.
+	<<elseif _raidescape == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your $mercenariesTitle can do but exit the venue.
-		<<set _raidseed = 0>>
 	<<else>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "shut-in">>
-		<<if _raidescape == 1>>
+		The politician spends the VTOL ride quietly, only breaking her silence to ask your $mercenariesTitle about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "shut-in">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your $mercenariesTitle coming.
+	<<elseif _raidescape == 1>>
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
-		<<set _raidseed = 0>>
 	<<else>>
 		When your $mercenariesTitle break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed $mercenariesTitle and quietly accepts being escorted back to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "procuress">>
-		<<if _raidescape == 1>>
+		The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your $mercenariesTitle attempt to engage her in conversation but are granted no response.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "procuress">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your $mercenariesTitle discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your $mercenariesTitle even arrived.
+	<<elseif _raidescape == 1>>
 		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
-		<<set _raidseed = 0>>
 	<<else>>
 		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
-	<</if>>
-	<<elseif $origin == "investor">>
-		<<if _raidescape == 1>>
+		The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "investor">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your $mercenariesTitle that she cited heightened security risks as the reason for her absence.
+	<<elseif _raidescape == 1>>
 		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
-		<<set _raidseed = 0>>
 	<<else>>
 		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
-	<</if>>
-	<<elseif $origin == "scientist">>
-		<<if _raidescape == 1>>
+		The investor spends the VTOL ride practicing their sales pitches, techniques and speeches. It seems they haven't grasped what their destination is, nor the fate that awaits them upon arrival.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "scientist">>
+	<<if $targetEscape >= $MercCapture>>
+		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your $mercenariesTitle are forced to retreat from the building, during which time the scientists make their own escape. When your $mercenariesTitle reenter the building, they find it abandoned.
+	<<elseif _raidescape == 1>>
 		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your $mercenariesTitle suspect the liquid was intended to have a transformative effect rather than a suicidal one.
-		<<set _raidseed = 0>>
 	<<else>>
 		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
-	<</if>>
-	<<elseif $origin == "lawyer">>
-		<<if _raidescape == 1>>
+		The scientist spends the VTOL ride watching as her colleagues and peers are raped around her. That some of the earth's greatest minds have been reduced to sexual objects is disquieting enough, but the realization that she is not likely to be spared from such a fate brings the woman to tears.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "lawyer">>
+	<<if $targetEscape >= $MercCapture>>
+		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
-	<</if>>
-	<</if>>
+		The lawyer spends the VTOL ride scarcely sparing any attention to the rape of her staff all about her. Instead she seems almost lost in thought, as if concentrating on finding some loophole or legal means to escape the fate that has befallen her staff.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 <</if>>
 <</if>>
-
-<<if _raidseed == 1>>
-	<<if $origin == "housewife">>
-	The housewife watches in terror as your $mercenariesTitle slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
-	<<elseif $origin == "university professor">>
-	The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
-	<<elseif $origin == "university student">>
-	The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
-	<<elseif $origin == "female military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
-	<<elseif $origin == "male military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
-	<<elseif $origin == "military soldier">>
-	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
-	<<elseif $origin == "doctor">>
-	The distinguished doctor spends the VTOL ride looking on at her colleagues and peers being raped by your mercenaries. She naively hopes that she has been spared from that fate out of a desire for her medical knowledge rather than her body.
-	<<elseif $origin == "nun">>
-	The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
-	<<elseif $origin == "journalist">>
-	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies every brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
-	<<elseif $origin == "local news anchor">>
-	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
-	<<elseif $origin == "classical dancer">>
-	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
-	<<elseif $origin == "law enforcement officer">>
-	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your $mercenariesTitle all around her. Before she exits the VTOL upon her arrival, she informs your $mercenariesTitle that she intends to bring each of them to justice for their supposed crimes.
-	<<elseif $origin == "classical musician">>
-	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
-	<<elseif $origin == "politician">>
-	The politician spends the VTOL ride quietly, only breaking her silence to ask your $mercenariesTitle about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
-	<<elseif $origin == "shut-in">>
-	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your $mercenariesTitle attempt to engage her in conversation but are granted no response.
-	<<elseif $origin == "procuress">>
-	The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
-	<<elseif $origin == "investor">>
-	The investor spends the VTOL ride practicing their sales pitches, techniques and speeches. It seems they haven't grasped what their destination is, nor the fate that awaits them upon arrival.
-	<<elseif $origin == "scientist">>
-	The scientist spends the VTOL ride watching as her colleagues and peers are raped around her. That some of the earth's greatest minds have been reduced to sexual objects is disquieting enough, but the realization that she is not likely to be spared from such a fate brings the woman to tears.
-	<<elseif $origin == "lawyer">>
-	The lawyer spends the VTOL ride scarcely sparing any attention to the rape of her staff all about her. Instead she seems almost lost in thought, as if concentrating on finding some loophole or legal means to escape the fate that has befallen her staff.
-	<</if>>
-<<AddSlave $activeSlave>> /* skip New Slave Intro */	
-<<else>>
-	Your $mercenariesTitle return without their final prize, but are still in high spirits given their other successes out in the field.
+<<if ($targetEscape >= $MercCapture) || (_raidescape == 1)>>
+	Your $mercenariesTitle return without their final prize, but remain in high spirits given their other successes out in the field.
 <</if>>
 <</nobr>>
 <</replace>>
@@ -701,229 +689,217 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 
 <<set $MercCapture = random(-4,4)>>
 
-<<if $targetEscape >= $MercCapture>>
-	<<if $origin == "housewife">>
-		Somehow the housewife manages to evade your mercenaries.
-	<<elseif $origin == "university professor">>
-		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
-	<<elseif $origin == "university student">>
-		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
-	<<elseif $origin == "female military officer">>
-		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
-	<<elseif $origin == "male military officer">>
-		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
-	<<elseif $origin == "military soldier">>
-		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your $mercenariesTitle are unable to capture any of the soldiers who escape on foot.
-	<<elseif $origin == "doctor">>
-		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
-	<<elseif $origin == "nun">>
-		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your $mercenariesTitle can close the distance, they retreat behind the walls of their community and seal the gate behind them.
-	<<elseif $origin == "journalist">>
-		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your $mercenariesTitle beat a hasty retreat.
-	<<elseif $origin == "local news anchor">>
-		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your $mercenariesTitle wisely retreat from the engagement.
-	<<elseif $origin == "classical dancer">>
-		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
-	<<elseif $origin == "law enforcement officer">>
-		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your $mercenariesTitle until reinforcements arrive and force your troops to retreat.
-	<<elseif $origin == "classical musician">>
-		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
-	<<elseif $origin == "politician">>
-		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your $mercenariesTitle can advance, they discover that the politician has already been evacuated.
-	<<elseif $origin == "shut-in">>
-		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your $mercenariesTitle coming.
-	<<elseif $origin == "procuress">>
-		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your $mercenariesTitle discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your $mercenariesTitle even arrived.
-	<<elseif $origin == "investor">>
-		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your $mercenariesTitle that she cited heightened security risks as the reason for her absence.
-	<<elseif $origin == "scientist">>
-		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your $mercenariesTitle are forced to retreat from the building, during which time the scientists make their own escape. When your $mercenariesTitle reenter the building, they find it abandoned.
-	<<elseif $origin == "lawyer">>
-		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
-	<</if>>
-<<else>>
-<<set _raidseed = 1>>
-<<if _raidseed == 1>>
-	<<if $origin == "housewife">>
-	<<if _raidescape == 1>>
+<<if $origin == "housewife">>
+	<<if $targetEscape >= $MercCapture>>
+		Somehow the housewife manages to evade your mercenaries.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle pry open the door to the manse's panic room and pull the protesting housewife from its depths.
-	<</if>>
-	<<elseif $origin == "university professor">>
-	<<if _raidescape == 1>>
+		The housewife watches in terror as your $mercenariesTitle slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "university professor">>
+	<<if $targetEscape >= $MercCapture>>
+		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
-	<</if>>
-	<<elseif $origin == "university student">>
-	<<if _raidescape == 1>>
+		The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "university student">>
+	<<if $targetEscape >= $MercCapture>>
+		A confrontation with the University's security team allows the students to escape capture by the $mercenariesTitle.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
-	<</if>>
-	<<elseif $origin == "female military officer">>
-	<<if _raidescape == 1>>
+		The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "female military officer">>
+	<<if $targetEscape >= $MercCapture>>
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
+	<<elseif _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
-		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
-	<</if>>
-	<<elseif $origin == "male military officer">>
-	<<if _raidescape == 1>>
+		The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "male military officer">>
+	<<if $targetEscape >= $MercCapture>>
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.	
+	<<elseif _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
-		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
-	<</if>>
-	<<elseif $origin == "military soldier">>
-		<<if _raidescape == 1>>
+		The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "military soldier">>
+	<<if $targetEscape >= $MercCapture>>
+		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your $mercenariesTitle are unable to capture any of the soldiers who escape on foot.	
+	<<elseif _raidescape == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
-		<<set _raidseed = 0>>
 	<<else>>
 		The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
-	<</if>>
-	<<elseif $origin == "doctor">>
-		<<if _raidescape == 1>>
+		The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "doctor">>
+	<<if $targetEscape >= $MercCapture>>
+		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 	
+	<<elseif _raidescape == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your $mercenariesTitle prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
-		<<set _raidseed = 0>>
 	<<else>>
 		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your $mercenariesTitle to take the doctors and their staff into custody with little fuss.
-	<</if>>
-	<<elseif $origin == "nun">>
-		<<if _raidescape == 1>>
+		The distinguished doctor spends the VTOL ride looking on at her colleagues and peers being raped by your mercenaries. She naively hopes that she has been spared from that fate out of a desire for her medical knowledge rather than her body.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "nun">>
+	<<if $targetEscape >= $MercCapture>>
+		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your $mercenariesTitle can close the distance, they retreat behind the walls of their community and seal the gate behind them.	
+	<<elseif _raidescape == 1>>
 		The nuns flee into their inner sanctum as your $mercenariesTitle approach and bar the doors behind them as they go. When the last barrier is pried open, your $mercenariesTitle discover the nuns have committed suicide as a group rather than be taken prisoner.
-		<<set _raidseed = 0>>
 	<<else>>
 		Unarmed and defenseless, the nuns are easily cowed by your $mercenariesTitle and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
-	<</if>>
-	<<elseif $origin == "journalist">>
-		<<if _raidescape == 1>>
+		The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "journalist">>
+	<<if $targetEscape >= $MercCapture>>
+		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your $mercenariesTitle beat a hasty retreat.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your $mercenariesTitle retreat from the building before law enforcement can arrive.
-		<<set _raidseed = 0>>
 	<<else>>
 		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "local news anchor">>
-		<<if _raidescape == 1>>
+		The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies every brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "local news anchor">>
+	<<if $targetEscape >= $MercCapture>>
+		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your $mercenariesTitle wisely retreat from the engagement.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
-		<<set _raidseed = 0>>
 	<<else>>
 		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "classical dancer">>
-		<<if _raidescape == 1>>
+		The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "classical dancer">>
+	<<if $targetEscape >= $MercCapture>>
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+	<<elseif _raidescape == 1>>
 		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your $mercenariesTitle exit the theater as chaos surges around them.
-		<<set _raidseed = 0>>
 	<<else>>
 		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "law enforcement officer">>
-		<<if _raidescape == 1>>
+		The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "law enforcement officer">>
+	<<if $targetEscape >= $MercCapture>>
+		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your $mercenariesTitle until reinforcements arrive and force your troops to retreat.
+	<<elseif _raidescape == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your $mercenariesTitle sought to capture is the last to fall, stifled by a hail of bullets.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
-	<</if>>
-	<<elseif $origin == "classical musician">>
-		<<if _raidescape == 1>>
+		The officer spends the VTOL ride watching impassively as her fellow officers are raped by your $mercenariesTitle all around her. Before she exits the VTOL upon her arrival, she informs your $mercenariesTitle that she intends to bring each of them to justice for their supposed crimes.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "classical musician">>
+	<<if $targetEscape >= $MercCapture>>
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+	<<elseif _raidescape == 1>>
 		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your $mercenariesTitle exit the concert hall as chaos surges around them.
-		<<set _raidseed = 0>>
 	<<else>>
 		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "politician">>
-		<<if _raidescape == 1>>
+		The musician spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "politician">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your $mercenariesTitle can advance, they discover that the politician has already been evacuated.
+	<<elseif _raidescape == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your $mercenariesTitle can do but exit the venue.
-		<<set _raidseed = 0>>
 	<<else>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "shut-in">>
-		<<if _raidescape == 1>>
+		The politician spends the VTOL ride quietly, only breaking her silence to ask your $mercenariesTitle about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "shut-in">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your $mercenariesTitle coming.
+	<<elseif _raidescape == 1>>
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
-		<<set _raidseed = 0>>
 	<<else>>
 		When your $mercenariesTitle break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed $mercenariesTitle and quietly accepts being escorted back to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "procuress">>
-		<<if _raidescape == 1>>
+		The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your $mercenariesTitle attempt to engage her in conversation but are granted no response.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "procuress">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your $mercenariesTitle discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your $mercenariesTitle even arrived.
+	<<elseif _raidescape == 1>>
 		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
-		<<set _raidseed = 0>>
 	<<else>>
 		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
-	<</if>>
-	<<elseif $origin == "investor">>
-		<<if _raidescape == 1>>
+		The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "investor">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your $mercenariesTitle that she cited heightened security risks as the reason for her absence.
+	<<elseif _raidescape == 1>>
 		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
-		<<set _raidseed = 0>>
 	<<else>>
 		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
-	<</if>>
-	<<elseif $origin == "scientist">>
-		<<if _raidescape == 1>>
+		The investor spends the VTOL ride practicing their sales pitches, techniques and speeches. It seems they haven't grasped what their destination is, nor the fate that awaits them upon arrival.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "scientist">>
+	<<if $targetEscape >= $MercCapture>>
+		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your $mercenariesTitle are forced to retreat from the building, during which time the scientists make their own escape. When your $mercenariesTitle reenter the building, they find it abandoned.
+	<<elseif _raidescape == 1>>
 		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your $mercenariesTitle suspect the liquid was intended to have a transformative effect rather than a suicidal one.
-		<<set _raidseed = 0>>
 	<<else>>
 		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
-	<</if>>
-	<<elseif $origin == "lawyer">>
-		<<if _raidescape == 1>>
+		The scientist spends the VTOL ride watching as her colleagues and peers are raped around her. That some of the earth's greatest minds have been reduced to sexual objects is disquieting enough, but the realization that she is not likely to be spared from such a fate brings the woman to tears.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "lawyer">>
+	<<if $targetEscape >= $MercCapture>>
+		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
-	<</if>>
-	<</if>>
+		The lawyer spends the VTOL ride scarcely sparing any attention to the rape of her staff all about her. Instead she seems almost lost in thought, as if concentrating on finding some loophole or legal means to escape the fate that has befallen her staff.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 <</if>>
 <</if>>
-
-<<if _raidseed == 1>>
-	<<if $origin == "housewife">>
-	The housewife watches in terror as your $mercenariesTitle slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
-	<<elseif $origin == "university professor">>
-	The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
-	<<elseif $origin == "university student">>
-	The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
-	<<elseif $origin == "female military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
-	<<elseif $origin == "male military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
-	<<elseif $origin == "military soldier">>
-	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
-	<<elseif $origin == "doctor">>
-	The distinguished doctor spends the VTOL ride looking on at her colleagues and peers being raped by your mercenaries. She naively hopes that she has been spared from that fate out of a desire for her medical knowledge rather than her body.
-	<<elseif $origin == "nun">>
-	The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
-	<<elseif $origin == "journalist">>
-	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies every brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
-	<<elseif $origin == "local news anchor">>
-	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
-	<<elseif $origin == "classical dancer">>
-	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
-	<<elseif $origin == "law enforcement officer">>
-	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your $mercenariesTitle all around her. Before she exits the VTOL upon her arrival, she informs your $mercenariesTitle that she intends to bring each of them to justice for their supposed crimes.
-	<<elseif $origin == "classical musician">>
-	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
-	<<elseif $origin == "politician">>
-	The politician spends the VTOL ride quietly, only breaking her silence to ask your $mercenariesTitle about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
-	<<elseif $origin == "shut-in">>
-	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your $mercenariesTitle attempt to engage her in conversation but are granted no response.
-	<<elseif $origin == "procuress">>
-	The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
-	<<elseif $origin == "investor">>
-	The investor spends the VTOL ride practicing their sales pitches, techniques and speeches. It seems they haven't grasped what their destination is, nor the fate that awaits them upon arrival.
-	<<elseif $origin == "scientist">>
-	The scientist spends the VTOL ride watching as her colleagues and peers are raped around her. That some of the earth's greatest minds have been reduced to sexual objects is disquieting enough, but the realization that she is not likely to be spared from such a fate brings the woman to tears.
-	<<elseif $origin == "lawyer">>
-	The lawyer spends the VTOL ride scarcely sparing any attention to the rape of her staff all about her. Instead she seems almost lost in thought, as if concentrating on finding some loophole or legal means to escape the fate that has befallen her staff.
-	<</if>>
-<<AddSlave $activeSlave>> /* skip New Slave Intro */	
-<<else>>
-	Your $mercenariesTitle return without their final prize, but are still in high spirits given their other successes out in the field.
+<<if ($targetEscape >= $MercCapture) || (_raidescape == 1)>>
+	Your $mercenariesTitle return without their final prize, but remain in high spirits given their other successes out in the field.
 <</if>>
 <</nobr>>
 <</replace>>
@@ -939,229 +915,217 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 
 <<set $MercCapture = random(-4,4)>>
 
-<<if $targetEscape >= $MercCapture>>
-	<<if $origin == "housewife">>
-		Somehow the housewife manages to evade your mercenaries.
-	<<elseif $origin == "university professor">>
-		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
-	<<elseif $origin == "university student">>
-		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
-	<<elseif $origin == "female military officer">>
-		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
-	<<elseif $origin == "male military officer">>
-		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
-	<<elseif $origin == "military soldier">>
-		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your $mercenariesTitle are unable to capture any of the soldiers who escape on foot.
-	<<elseif $origin == "doctor">>
-		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
-	<<elseif $origin == "nun">>
-		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your $mercenariesTitle can close the distance, they retreat behind the walls of their community and seal the gate behind them.
-	<<elseif $origin == "journalist">>
-		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your $mercenariesTitle beat a hasty retreat.
-	<<elseif $origin == "local news anchor">>
-		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your $mercenariesTitle wisely retreat from the engagement.
-	<<elseif $origin == "classical dancer">>
-		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
-	<<elseif $origin == "law enforcement officer">>
-		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your $mercenariesTitle until reinforcements arrive and force your troops to retreat.
-	<<elseif $origin == "classical musician">>
-		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
-	<<elseif $origin == "politician">>
-		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your $mercenariesTitle can advance, they discover that the politician has already been evacuated.
-	<<elseif $origin == "shut-in">>
-		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your $mercenariesTitle coming.
-	<<elseif $origin == "procuress">>
-		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your $mercenariesTitle discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your $mercenariesTitle even arrived.
-	<<elseif $origin == "investor">>
-		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your $mercenariesTitle that she cited heightened security risks as the reason for her absence.
-	<<elseif $origin == "scientist">>
-		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your $mercenariesTitle are forced to retreat from the building, during which time the scientists make their own escape. When your $mercenariesTitle reenter the building, they find it abandoned.
-	<<elseif $origin == "lawyer">>
-		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
-	<</if>>
-<<else>>
-<<set _raidseed = 1>>
-<<if _raidseed == 1>>
-	<<if $origin == "housewife">>
-	<<if _raidescape == 1>>
+<<if $origin == "housewife">>
+	<<if $targetEscape >= $MercCapture>>
+		Somehow the housewife manages to evade your mercenaries.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle pry open the door to the manse's panic room and pull the protesting housewife from its depths.
-	<</if>>
-	<<elseif $origin == "university professor">>
-	<<if _raidescape == 1>>
+		The housewife watches in terror as your $mercenariesTitle slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "university professor">>
+	<<if $targetEscape >= $MercCapture>>
+		A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
-	<</if>>
-	<<elseif $origin == "university student">>
-	<<if _raidescape == 1>>
+		The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "university student">>
+	<<if $targetEscape >= $MercCapture>>
+		A confrontation with the University's security team allows the students to escape capture by the $mercenariesTitle.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
-	<</if>>
-	<<elseif $origin == "female military officer">>
-	<<if _raidescape == 1>>
+		The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "female military officer">>
+	<<if $targetEscape >= $MercCapture>>
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
+	<<elseif _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
-		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
-	<</if>>
-	<<elseif $origin == "male military officer">>
-	<<if _raidescape == 1>>
+		The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "male military officer">>
+	<<if $targetEscape >= $MercCapture>>
+		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.	
+	<<elseif _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
-		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
-	<</if>>
-	<<elseif $origin == "military soldier">>
-		<<if _raidescape == 1>>
+		The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "military soldier">>
+	<<if $targetEscape >= $MercCapture>>
+		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your $mercenariesTitle are unable to capture any of the soldiers who escape on foot.	
+	<<elseif _raidescape == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
-		<<set _raidseed = 0>>
 	<<else>>
 		The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
-	<</if>>
-	<<elseif $origin == "doctor">>
-		<<if _raidescape == 1>>
+		The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "doctor">>
+	<<if $targetEscape >= $MercCapture>>
+		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 	
+	<<elseif _raidescape == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your $mercenariesTitle prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
-		<<set _raidseed = 0>>
 	<<else>>
 		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your $mercenariesTitle to take the doctors and their staff into custody with little fuss.
-	<</if>>
-	<<elseif $origin == "nun">>
-		<<if _raidescape == 1>>
+		The distinguished doctor spends the VTOL ride looking on at her colleagues and peers being raped by your mercenaries. She naively hopes that she has been spared from that fate out of a desire for her medical knowledge rather than her body.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "nun">>
+	<<if $targetEscape >= $MercCapture>>
+		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your $mercenariesTitle can close the distance, they retreat behind the walls of their community and seal the gate behind them.	
+	<<elseif _raidescape == 1>>
 		The nuns flee into their inner sanctum as your $mercenariesTitle approach and bar the doors behind them as they go. When the last barrier is pried open, your $mercenariesTitle discover the nuns have committed suicide as a group rather than be taken prisoner.
-		<<set _raidseed = 0>>
 	<<else>>
 		Unarmed and defenseless, the nuns are easily cowed by your $mercenariesTitle and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
-	<</if>>
-	<<elseif $origin == "journalist">>
-		<<if _raidescape == 1>>
+		The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "journalist">>
+	<<if $targetEscape >= $MercCapture>>
+		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your $mercenariesTitle beat a hasty retreat.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your $mercenariesTitle retreat from the building before law enforcement can arrive.
-		<<set _raidseed = 0>>
 	<<else>>
 		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "local news anchor">>
-		<<if _raidescape == 1>>
+		The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies every brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "local news anchor">>
+	<<if $targetEscape >= $MercCapture>>
+		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your $mercenariesTitle wisely retreat from the engagement.	
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
-		<<set _raidseed = 0>>
 	<<else>>
 		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "classical dancer">>
-		<<if _raidescape == 1>>
+		The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "classical dancer">>
+	<<if $targetEscape >= $MercCapture>>
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+	<<elseif _raidescape == 1>>
 		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your $mercenariesTitle exit the theater as chaos surges around them.
-		<<set _raidseed = 0>>
 	<<else>>
 		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "law enforcement officer">>
-		<<if _raidescape == 1>>
+		The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "law enforcement officer">>
+	<<if $targetEscape >= $MercCapture>>
+		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your $mercenariesTitle until reinforcements arrive and force your troops to retreat.
+	<<elseif _raidescape == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your $mercenariesTitle sought to capture is the last to fall, stifled by a hail of bullets.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
-	<</if>>
-	<<elseif $origin == "classical musician">>
-		<<if _raidescape == 1>>
+		The officer spends the VTOL ride watching impassively as her fellow officers are raped by your $mercenariesTitle all around her. Before she exits the VTOL upon her arrival, she informs your $mercenariesTitle that she intends to bring each of them to justice for their supposed crimes.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "classical musician">>
+	<<if $targetEscape >= $MercCapture>>
+		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+	<<elseif _raidescape == 1>>
 		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your $mercenariesTitle exit the concert hall as chaos surges around them.
-		<<set _raidseed = 0>>
 	<<else>>
 		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "politician">>
-		<<if _raidescape == 1>>
+		The musician spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "politician">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your $mercenariesTitle can advance, they discover that the politician has already been evacuated.
+	<<elseif _raidescape == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your $mercenariesTitle can do but exit the venue.
-		<<set _raidseed = 0>>
 	<<else>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "shut-in">>
-		<<if _raidescape == 1>>
+		The politician spends the VTOL ride quietly, only breaking her silence to ask your $mercenariesTitle about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "shut-in">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your $mercenariesTitle coming.
+	<<elseif _raidescape == 1>>
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
-		<<set _raidseed = 0>>
 	<<else>>
 		When your $mercenariesTitle break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed $mercenariesTitle and quietly accepts being escorted back to the waiting VTOL.
-	<</if>>
-	<<elseif $origin == "procuress">>
-		<<if _raidescape == 1>>
+		The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your $mercenariesTitle attempt to engage her in conversation but are granted no response.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "procuress">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your $mercenariesTitle discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your $mercenariesTitle even arrived.
+	<<elseif _raidescape == 1>>
 		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
-		<<set _raidseed = 0>>
 	<<else>>
 		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
-	<</if>>
-	<<elseif $origin == "investor">>
-		<<if _raidescape == 1>>
+		The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "investor">>
+	<<if $targetEscape >= $MercCapture>>
+		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your $mercenariesTitle that she cited heightened security risks as the reason for her absence.
+	<<elseif _raidescape == 1>>
 		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
-		<<set _raidseed = 0>>
 	<<else>>
 		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
-	<</if>>
-	<<elseif $origin == "scientist">>
-		<<if _raidescape == 1>>
+		The investor spends the VTOL ride practicing their sales pitches, techniques and speeches. It seems they haven't grasped what their destination is, nor the fate that awaits them upon arrival.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "scientist">>
+	<<if $targetEscape >= $MercCapture>>
+		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your $mercenariesTitle are forced to retreat from the building, during which time the scientists make their own escape. When your $mercenariesTitle reenter the building, they find it abandoned.
+	<<elseif _raidescape == 1>>
 		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your $mercenariesTitle suspect the liquid was intended to have a transformative effect rather than a suicidal one.
-		<<set _raidseed = 0>>
 	<<else>>
 		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
-	<</if>>
-	<<elseif $origin == "lawyer">>
-		<<if _raidescape == 1>>
+		The scientist spends the VTOL ride watching as her colleagues and peers are raped around her. That some of the earth's greatest minds have been reduced to sexual objects is disquieting enough, but the realization that she is not likely to be spared from such a fate brings the woman to tears.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
+<</if>>
+<</if>>
+<<if $origin == "lawyer">>
+	<<if $targetEscape >= $MercCapture>>
+		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
+	<<elseif _raidescape == 1>>
 		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
-		<<set _raidseed = 0>>
 	<<else>>
 		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
-	<</if>>
-	<</if>>
+		The lawyer spends the VTOL ride scarcely sparing any attention to the rape of her staff all about her. Instead she seems almost lost in thought, as if concentrating on finding some loophole or legal means to escape the fate that has befallen her staff.
+		<<AddSlave $activeSlave>> /* skip New Slave Intro */
 <</if>>
 <</if>>
-
-<<if _raidseed == 1>>
-	<<if $origin == "housewife">>
-	The housewife watches in terror as your $mercenariesTitle slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
-	<<elseif $origin == "university professor">>
-	The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
-	<<elseif $origin == "university student">>
-	The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
-	<<elseif $origin == "female military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
-	<<elseif $origin == "male military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
-	<<elseif $origin == "military soldier">>
-	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
-	<<elseif $origin == "doctor">>
-	The distinguished doctor spends the VTOL ride looking on at her colleagues and peers being raped by your mercenaries. She naively hopes that she has been spared from that fate out of a desire for her medical knowledge rather than her body.
-	<<elseif $origin == "nun">>
-	The pious nun spends the VTOL ride engaged in fervent prayer as her sisters are raped by your mercenaries. She naively believes that her devotion and piety will see her spared from the same fate as her sisters.
-	<<elseif $origin == "journalist">>
-	The journalist spends the VTOL ride watching as her colleagues are raped by your mercenaries. She studies every brutal detail, records ever anguished scream in her mind, hoping that one day she might escape to produce an editorial to surpass all others.
-	<<elseif $origin == "local news anchor">>
-	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
-	<<elseif $origin == "classical dancer">>
-	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
-	<<elseif $origin == "law enforcement officer">>
-	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your $mercenariesTitle all around her. Before she exits the VTOL upon her arrival, she informs your $mercenariesTitle that she intends to bring each of them to justice for their supposed crimes.
-	<<elseif $origin == "classical musician">>
-	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
-	<<elseif $origin == "politician">>
-	The politician spends the VTOL ride quietly, only breaking her silence to ask your $mercenariesTitle about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
-	<<elseif $origin == "shut-in">>
-	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your $mercenariesTitle attempt to engage her in conversation but are granted no response.
-	<<elseif $origin == "procuress">>
-	The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
-	<<elseif $origin == "investor">>
-	The investor spends the VTOL ride practicing their sales pitches, techniques and speeches. It seems they haven't grasped what their destination is, nor the fate that awaits them upon arrival.
-	<<elseif $origin == "scientist">>
-	The scientist spends the VTOL ride watching as her colleagues and peers are raped around her. That some of the earth's greatest minds have been reduced to sexual objects is disquieting enough, but the realization that she is not likely to be spared from such a fate brings the woman to tears.
-	<<elseif $origin == "lawyer">>
-	The lawyer spends the VTOL ride scarcely sparing any attention to the rape of her staff all about her. Instead she seems almost lost in thought, as if concentrating on finding some loophole or legal means to escape the fate that has befallen her staff.
-	<</if>>
-<<AddSlave $activeSlave>> /* skip New Slave Intro */	
-<<else>>
-	Your $mercenariesTitle return without their final prize, but are still in high spirits given their other successes out in the field.
+<<if ($targetEscape >= $MercCapture) || (_raidescape == 1)>>
+	Your $mercenariesTitle return without their final prize, but remain in high spirits given their other successes out in the field.
 <</if>>
 <</nobr>>
 <</replace>>

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -8,7 +8,7 @@
 <<set $raided = $week>>
 <<set $raidseed = 0>>
 
-The leader of your $mercenariesTitle has contacted you from the world outside your arcology. It seems that your mercenaries have enjoyed a profitable series of raids in their time outside the arcology and have hence decided to push their luck by plundering one last location on their way back to the arcology. As your nominal leader, they ask your opinion of a small number of potential targets. Given the distance from the arcology and the time sensitivity of conducting such a mission, you have little to base your decision on besides a brief description.
+The leader of your $mercenariesTitle has contacted you from the world outside your arcology. It seems that your mercenaries have enjoyed a profitable series of raids in their time outside the arcology and have decided to push their luck by plundering one last location on their way back to the arcology. As their nominal leader, they ask your opinion of a small number of potential targets. Given the distance from the arcology and the time sensitivity of conducting such a mission, you have little to base your decision on besides a brief description.
 <br><br>
 Worthy of consideration is that although the $mercenariesTitle will enslave the lion's share of enslaved prisoners for the corporation, they will present you the finest slave captured as a gesture of respect for your high position.
 

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -6,7 +6,8 @@
 <<set $returnTo = "Scheduled Event">>
 <<set $nextButton = "Continue">>
 <<set $raided = $week>>
-<<set $raidseed = 0>>
+<<set _raidseed = 0>>
+<<set _raidescape = random(1,3)>>
 
 The leader of your $mercenariesTitle has contacted you from the world outside your arcology. It seems that your mercenaries have enjoyed a profitable series of raids in their time outside the arcology and have decided to push their luck by plundering one last location on their way back to the arcology. As their nominal leader, they ask your opinion of a small number of potential targets. Given the distance from the arcology and the time sensitivity of conducting such a mission, you have little to base your decision on besides a brief description.
 <br><br>
@@ -504,147 +505,147 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
-	<<set $raidseed = 1>>
+	<<set _raidseed = 1>>
 <</if>>
 
-<<if $raidseed == 1>>
+<<if _raidseed == 1>>
 	<<if $origin == "housewife">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "doctor">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "shut-in">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "procuress">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
 	<</if>>
 	<<elseif $origin == "investor">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
 	<</if>>
 	<<elseif $origin == "scientist">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
 	<</if>>
 	<<elseif $origin == "lawyer">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>
 
-<<if $raidseed == 1>>
+<<if _raidseed == 1>>
 	<<if $origin == "housewife">>
 	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
 	<<elseif $origin == "university professor">>
@@ -744,147 +745,147 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
-	<<set $raidseed = 1>>
+	<<set _raidseed = 1>>
 <</if>>
 
-<<if $raidseed == 1>>
+<<if _raidseed == 1>>
 	<<if $origin == "housewife">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "doctor">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "shut-in">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "procuress">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
 	<</if>>
 	<<elseif $origin == "investor">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
 	<</if>>
 	<<elseif $origin == "scientist">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
 	<</if>>
 	<<elseif $origin == "lawyer">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>
 
-<<if $raidseed == 1>>
+<<if _raidseed == 1>>
 	<<if $origin == "housewife">>
 	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
 	<<elseif $origin == "university professor">>
@@ -984,147 +985,147 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
-	<<set $raidseed = 1>>
+	<<set _raidseed = 1>>
 <</if>>
 
-<<if $raidseed == 1>>
+<<if _raidseed == 1>>
 	<<if $origin == "housewife">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
-	<<if random(1,3) == 1>>
+	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "doctor">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "shut-in">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "procuress">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
 	<</if>>
 	<<elseif $origin == "investor">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
 	<</if>>
 	<<elseif $origin == "scientist">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
 	<</if>>
 	<<elseif $origin == "lawyer">>
-		<<if random(1,3) == 1>>
+		<<if _raidescape == 1>>
 		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
-		<<set $raidseed = 0>>
+		<<set _raidseed = 0>>
 	<<else>>
 		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>
 
-<<if $raidseed == 1>>
+<<if _raidseed == 1>>
 	<<if $origin == "housewife">>
 	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
 	<<elseif $origin == "university professor">>

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -6,7 +6,7 @@
 <<set $returnTo = "Scheduled Event">>
 <<set $nextButton = "Continue">>
 <<set $raided = $week>>
-<<set $seed = 0>>
+<<set $raidseed = 0>>
 
 The leader of your $mercenariesTitle has contacted you from the world outside your arcology. It seems that your mercenaries have enjoyed a profitable series of raids in their time outside the arcology and have hence decided to push their luck by plundering one last location on their way back to the arcology. As your nominal leader, they ask your opinion of a small number of potential targets. Given the distance from the arcology and the time sensitivity of conducting such a mission, you have little to base your decision on besides a brief description.
 <br><br>
@@ -32,6 +32,10 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $origins.push("classical musician")>>
 	<<set $origins.push("politician")>>
 	<<set $origins.push("shut-in")>>
+	<<set $origins.push("procuress")>>
+	<<set $origins.push("investor")>>
+	<<set $origins.push("scientist")>>
+	<<set $origins.push("lawyer")>>
 <</if>>
 <<if $seeDicks != 0>>
 	<<set $origins.push("male military officer")>>	
@@ -71,7 +75,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.whoreSkill = 35>>
 	<<set $activeSlave.age = random(35,39)>>
 	<<set $activeSlave.career = either("a housewife", "a trophy wife")>>
-	is an idyllic manse in the countryside of an Old World Nation. It's owner is a businessman of some notoriety, but is often away from his expansive estate. A number of servants and maids are in residence, but the primary resident of the manse is his wife. From the sound of things, she is not a young woman but attractive enough in a fake sort of way.
+	is an idyllic manse in the countryside of an Old World nation. It's owner is a businessman of some notoriety, but is often away from his expansive estate. A number of servants and maids are in residence, but the primary resident of the manse is his wife. From the sound of things, she is not a young woman but attractive enough in a fake sort of way.
 <<elseif $origin == "university professor">>
 	<<include "Generate XX Slave">>
 	<<set $activeSlave.age = random(35,$retirementAge-1)>>
@@ -85,7 +89,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.intelligence = 2>>
 	<<set $activeSlave.intelligenceImplant = 1>>
 	<<set $activeSlave.teeth = "normal">>
-	is the department offices of a still operational Old World University. The University prides itself on a diverse and capable faculty, often touting its wealth of female professors as a symbol of its progressive agenda. Though they are unlikely to be young, these professors will be educated and quite intelligent. The head of the department is no exception, a woman of considerable academic credentials. 
+	is the department offices of a still operational Old World university. The University prides itself on a diverse and capable faculty, often touting its wealth of female professors as a symbol of its progressive agenda. Though they are unlikely to be young, these professors will be educated and quite intelligent. The head of the department is no exception, a woman of considerable academic credentials. 
 <<elseif $origin == "university student">>
 	<<include "Generate XX Slave">>
 	<<set $activeSlave.age = random(18,22)>>
@@ -101,7 +105,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.intelligence = random(1,2)>>
 	<<set $activeSlave.intelligenceImplant = 1>>
 	<<set $activeSlave.teeth = "normal">>
-	is the residence dormitories of a still operational Old World University. The University prides itself on a diverse and inspired student body, often touting its wealth of female students as a symbol of its progressive agenda. Though they are young, these students will likely have benefited from their education and fairly intelligent. By all accounts the prettiest of them is no exception, a student with a shining academic record. 
+	is the residence dormitories of a still operational Old World university. The University prides itself on a diverse and inspired student body, often touting its wealth of female students as a symbol of its progressive agenda. Though they are young, these students will likely have benefited from their education and fairly intelligent. By all accounts the prettiest of them is no exception, a student with a shining academic record. 
 <<elseif $origin == "female military officer">>
 	<<include "Generate XX Slave">>
 	<<set $activeSlave.age = random(26,$retirementAge-1)>>
@@ -188,7 +192,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.age to random(18,$retirementAge-1)>>
 	<<set $activeSlave.behavioralFlaw to "devout">>
 	<<set $activeSlave.sexualFlaw to "repressed">>
-	is a reclusive religious community in a mountain range between two currently contested territories. The members of the community have withdrawn from the collapsing social order of the world and established a commune in their mountain retreat, filling their days with peaceful reflection and prayer. Though the nuns have no true leader, one among them has emerged as the most pious of the sisters.
+	is a reclusive religious community in a mountain range between two current conflict zones. The members of the community have withdrawn from the collapsing social order of the world and established a commune in their mountain retreat, filling their days with peaceful reflection and prayer. Though the nuns have no true leader, one among them has emerged as the most pious of the sisters.
 <<elseif $origin == "journalist">>
 	<<include "Generate XX Slave">>
 	<<set $activeSlave.age = random(18,26)>>
@@ -299,6 +303,59 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.whoreSkill = 0>>
 	<<set $activeSlave.entertainSkill = 10>>
 	is the shack of a notorious shut-in located just outside your arcology. Not a particularly distinguished target, but it would save your mercenaries considerable time and effort. The shut-in herself has been a fixture of the landscape for decades, with many speculating that she remains a virgin despite her mature age.
+<<elseif $origin == "procuress">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(35,$retirementAge-1)>>
+	<<set $activeSlave.career = "a procuress">>
+	<<set $activeSlave.face = random(15,100)>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 25>>
+	<<set $activeSlave.entertainSkill = 25>>
+	<<set $activeSlave.intelligence = 2>>
+	is a halfway house for vulnerable woman operating in a nearby conflict zone. Far from being a wholesome institution, the proprietor of this halfway house is a notorious procuress who sells her guests into slavery. Raiding the halfway house avoids the procuress' fees on a new shipment of slaves, with the procuress herself as a tempting bonus.
+<<elseif $origin == "investor">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(35,$retirementAge-1)>>
+	<<set $activeSlave.career = "an investor">>
+	<<set $activeSlave.prestige = 1>>
+	<<set $activeSlave.face = random(15,100)>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 10>>
+	<<set $activeSlave.intelligence = 2>>
+	<<set $activeSlave.intelligenceImplant = 1>>
+	is one of the last remaining business expositions still operating in the Old World. In years past, such expositions were often a showcase for innovation and corporate development but in recent years have become a sad spectacle of industry stagnation. This particular exposition's keynote speaker is a reputable investor with decades of experience, hoping to breathe new life into some valuable yet dying firms.
+<<elseif $origin == "scientist">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(28,$retirementAge-1)>>
+	<<set $activeSlave.career = "a scientist">>
+	<<set $activeSlave.face = random(15,100)>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 10>>
+	<<set $activeSlave.intelligence = 2>>
+	<<set $activeSlave.intelligenceImplant = 1>>
+	<<set $activeSlave.teeth = "normal">>
+	is a research lab operating on the lawless fringe between the Old World and the Free Cities. Here, scientists push the boundaries of the known world without the burden of governmental oversight or moral restrictions. Their defacto leader is a fellow scientist, one of the first to leave the Old World behind in pursuit of knowledge.
+<<elseif $origin == "lawyer">>
+	<<include "Generate XX Slave">>
+	<<set $activeSlave.age = random(30,$retirementAge-1)>>
+	<<set $activeSlave.career = "a lawyer">>
+	<<set $activeSlave.face = random(15,100)>>
+	<<set $activeSlave.vagina = 1>>
+	<<set $activeSlave.oralSkill = 35>>
+	<<set $activeSlave.analSkill = 15>>
+	<<set $activeSlave.whoreSkill = 0>>
+	<<set $activeSlave.entertainSkill = 20>>
+	<<set $activeSlave.intelligence = 1>>
+	<<set $activeSlave.intelligenceImplant = 1>>
+	is the offices of a law firm operating on the boundary between the Old World and the Free Cities. The lawyers within profit from the shaky legal channels between Old World nations and new Free Cities, largely drawing up contracts or facilitating the transfer of goods, services, and slaves. The sole senior partner of the firm is one of the pioneers of this new field of legal work, having been a staunch corporate advocate for much of her life.
 <</if>>
 
 <<set $activeSlave.origin = "Your $mercenariesTitle caught her while raiding; she was a $origin.">>
@@ -409,149 +466,185 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<if $origin == "housewife">>
 	Somehow the housewife manages to evade your mercenaries
 	<<elseif $origin == "university professor">>
-	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "university student">>
-	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "female military officer">>
-	The officer's escort engages your mercenaries in a gunfight and in the confusion she manages to escape capture on foot.
+	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "male military officer">>
-	The officer's escort engages your mercenaries in a gunfight and in the confusion he manages to escape capture on foot.
+	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
-	The young soldiers fight valiantly against your mercenaries until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+	The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
 	<<elseif $origin == "doctor">>
-	The hospital's security staff alone would prove little match for your mercenaries, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
+	The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
 	<<elseif $origin == "nun">>
-	As your mercenaries close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+	As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
 	<<elseif $origin == "journalist">>
-	Though your mercenaries easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+	Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
 	<<elseif $origin == "local news anchor">>
-	Unfortunately for your mercenaries, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+	Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
-	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 	<<elseif $origin == "law enforcement officer">>
 	Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
 	<<elseif $origin == "classical musician">>
-	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
 	<<elseif $origin == "politician">>
-	Your mercenaries clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+	The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
 	<<elseif $origin == "shut-in">>
-	Your mercenaries pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+	The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+	<<elseif $origin == "procuress">>
+	The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
+	<<elseif $origin == "investor">>
+	The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
+	<<elseif $origin == "scientist">>
+	When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
+	<<elseif $origin == "lawyer">>
+	It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
-	<<set $seed = 1>>
+	<<set $raidseed = 1>>
 <</if>>
 
-<<if $seed == 1>>
+<<if $raidseed == 1>>
 	<<if $origin == "housewife">>
 	<<if random(1,3) == 1>>
 		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
 		<<if random(1,3) == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "doctor">>
 		<<if random(1,3) == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
 		<<if random(1,3) == 1>>
 		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
 		<<if random(1,3) == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
 		<<if random(1,3) == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "shut-in">>
 		<<if random(1,3) == 1>>
-		When your mercenaries break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
-		<<set $seed = 0>>
+		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
+		<<set $raidseed = 0>>
 	<<else>>
 	When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "procuress">>
+		<<if random(1,3) == 1>>
+		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
+		<<set $raidseed = 0>>
+	<<else>>
+	When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
+	<</if>>
+	<<elseif $origin == "investor">>
+		<<if random(1,3) == 1>>
+		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
+		<<set $raidseed = 0>>
+	<<else>>
+	When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
+	<</if>>
+	<<elseif $origin == "scientist">>
+		<<if random(1,3) == 1>>
+		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
+		<<set $raidseed = 0>>
+	<<else>>
+	The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
+	<</if>>
+	<<elseif $origin == "lawyer">>
+		<<if random(1,3) == 1>>
+		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
+		<<set $raidseed = 0>>
+	<<else>>
+	Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>
 
-<<if $seed == 1>>
+<<if $raidseed == 1>>
 	<<if $origin == "housewife">>
 	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
 	<<elseif $origin == "university professor">>
@@ -582,6 +675,14 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The politician spends the VTOL ride quietly, only breaking her silence to ask your mercenaries about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
 	<<elseif $origin == "shut-in">>
 	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your mercenaries attempt to engage her in conversation but are granted no response.
+	<<elseif $origin == "procuress">>
+	The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
+	<<elseif $origin == "investor">>
+	The investor spends the VTOL ride practicing their sales pitches, techniques and speeches. It seems they haven't grasped what their destination is, nor the fate that awaits them upon arrival.
+	<<elseif $origin == "scientist">>
+	The scientist spends the VTOL ride watching as her colleagues and peers are raped around her. That some of the earth's greatest minds have been reduced to sexual objects is disquieting enough, but the realization that she is not likely to be spared from such a fate brings the woman to tears.
+	<<elseif $origin == "lawyer">>
+	The lawyer spends the VTOL ride scarcely sparing any attention to the rape of her staff all about her. Instead she seems almost lost in thought, as if concentrating on finding some loophole or legal means to escape the fate that has befallen her staff.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>
@@ -605,149 +706,185 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<if $origin == "housewife">>
 	Somehow the housewife manages to evade your mercenaries
 	<<elseif $origin == "university professor">>
-	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "university student">>
-	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "female military officer">>
-	The officer's escort engages your mercenaries in a gunfight and in the confusion she manages to escape capture on foot.
+	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "male military officer">>
-	The officer's escort engages your mercenaries in a gunfight and in the confusion he manages to escape capture on foot.
+	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
-	The young soldiers fight valiantly against your mercenaries until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+	The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
 	<<elseif $origin == "doctor">>
-	The hospital's security staff alone would prove little match for your mercenaries, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
+	The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
 	<<elseif $origin == "nun">>
-	As your mercenaries close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+	As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
 	<<elseif $origin == "journalist">>
-	Though your mercenaries easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+	Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
 	<<elseif $origin == "local news anchor">>
-	Unfortunately for your mercenaries, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+	Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
-	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 	<<elseif $origin == "law enforcement officer">>
 	Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
 	<<elseif $origin == "classical musician">>
-	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
 	<<elseif $origin == "politician">>
-	Your mercenaries clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+	The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
 	<<elseif $origin == "shut-in">>
-	Your mercenaries pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+	The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+	<<elseif $origin == "procuress">>
+	The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
+	<<elseif $origin == "investor">>
+	The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
+	<<elseif $origin == "scientist">>
+	When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
+	<<elseif $origin == "lawyer">>
+	It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
-	<<set $seed = 1>>
+	<<set $raidseed = 1>>
 <</if>>
 
-<<if $seed == 1>>
+<<if $raidseed == 1>>
 	<<if $origin == "housewife">>
 	<<if random(1,3) == 1>>
 		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
 		<<if random(1,3) == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "doctor">>
 		<<if random(1,3) == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
 		<<if random(1,3) == 1>>
 		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
 		<<if random(1,3) == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
 		<<if random(1,3) == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "shut-in">>
 		<<if random(1,3) == 1>>
-		When your mercenaries break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
-		<<set $seed = 0>>
+		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
+		<<set $raidseed = 0>>
 	<<else>>
 	When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "procuress">>
+		<<if random(1,3) == 1>>
+		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
+		<<set $raidseed = 0>>
+	<<else>>
+	When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
+	<</if>>
+	<<elseif $origin == "investor">>
+		<<if random(1,3) == 1>>
+		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
+		<<set $raidseed = 0>>
+	<<else>>
+	When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
+	<</if>>
+	<<elseif $origin == "scientist">>
+		<<if random(1,3) == 1>>
+		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
+		<<set $raidseed = 0>>
+	<<else>>
+	The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
+	<</if>>
+	<<elseif $origin == "lawyer">>
+		<<if random(1,3) == 1>>
+		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
+		<<set $raidseed = 0>>
+	<<else>>
+	Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>
 
-<<if $seed == 1>>
+<<if $raidseed == 1>>
 	<<if $origin == "housewife">>
 	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
 	<<elseif $origin == "university professor">>
@@ -778,6 +915,14 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The politician spends the VTOL ride quietly, only breaking her silence to ask your mercenaries about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
 	<<elseif $origin == "shut-in">>
 	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your mercenaries attempt to engage her in conversation but are granted no response.
+	<<elseif $origin == "procuress">>
+	The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
+	<<elseif $origin == "investor">>
+	The investor spends the VTOL ride practicing their sales pitches, techniques and speeches. It seems they haven't grasped what their destination is, nor the fate that awaits them upon arrival.
+	<<elseif $origin == "scientist">>
+	The scientist spends the VTOL ride watching as her colleagues and peers are raped around her. That some of the earth's greatest minds have been reduced to sexual objects is disquieting enough, but the realization that she is not likely to be spared from such a fate brings the woman to tears.
+	<<elseif $origin == "lawyer">>
+	The lawyer spends the VTOL ride scarcely sparing any attention to the rape of her staff all about her. Instead she seems almost lost in thought, as if concentrating on finding some loophole or legal means to escape the fate that has befallen her staff.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>
@@ -801,149 +946,185 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<if $origin == "housewife">>
 	Somehow the housewife manages to evade your mercenaries
 	<<elseif $origin == "university professor">>
-	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "university student">>
-	A confrontation with the University's security team allows the professors to escape capture by your mercenaries.
+	A confrontation with the University's security team allows the professors to escape capture by the $mercenariesTitle.
 	<<elseif $origin == "female military officer">>
-	The officer's escort engages your mercenaries in a gunfight and in the confusion she manages to escape capture on foot.
+	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "male military officer">>
-	The officer's escort engages your mercenaries in a gunfight and in the confusion he manages to escape capture on foot.
+	The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
-	The young soldiers fight valiantly against your mercenaries until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+	The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
 	<<elseif $origin == "doctor">>
-	The hospital's security staff alone would prove little match for your mercenaries, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
+	The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
 	<<elseif $origin == "nun">>
-	As your mercenaries close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+	As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
 	<<elseif $origin == "journalist">>
-	Though your mercenaries easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+	Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
 	<<elseif $origin == "local news anchor">>
-	Unfortunately for your mercenaries, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+	Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
-	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
+	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 	<<elseif $origin == "law enforcement officer">>
 	Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
 	<<elseif $origin == "classical musician">>
-	Though they are excellent soldiers, your mercenaries are often crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
+	Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
 	<<elseif $origin == "politician">>
-	Your mercenaries clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+	The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
 	<<elseif $origin == "shut-in">>
-	Your mercenaries pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+	The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+	<<elseif $origin == "procuress">>
+	The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
+	<<elseif $origin == "investor">>
+	The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
+	<<elseif $origin == "scientist">>
+	When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
+	<<elseif $origin == "lawyer">>
+	It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
-	<<set $seed = 1>>
+	<<set $raidseed = 1>>
 <</if>>
 
-<<if $seed == 1>>
+<<if $raidseed == 1>>
 	<<if $origin == "housewife">>
 	<<if random(1,3) == 1>>
 		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if random(1,3) == 1>>
 		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
 	<<if random(1,3) == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
 		<<if random(1,3) == 1>>
 		The young soldiers are unfaltering in their conviction and fight to their last last. When the smoke clears, the barracks is chocked with corpses for none of the soldiers are left alive to capture.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	The young soldiers fight valiantly, but when the battle turns against them they decide to surrender. Their sergeant is cuffed with the remaining survivors and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "doctor">>
 		<<if random(1,3) == 1>>
 		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
 		<<if random(1,3) == 1>>
 		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
 		<<if random(1,3) == 1>>
 		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
 		<<if random(1,3) == 1>>
 		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
 		<<if random(1,3) == 1>>
 		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
 		<<if random(1,3) == 1>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
-		<<set $seed = 0>>
+		<<set $raidseed = 0>>
 	<<else>>
 	With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "shut-in">>
 		<<if random(1,3) == 1>>
-		When your mercenaries break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
-		<<set $seed = 0>>
+		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
+		<<set $raidseed = 0>>
 	<<else>>
 	When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+	<</if>>
+	<<elseif $origin == "procuress">>
+		<<if random(1,3) == 1>>
+		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
+		<<set $raidseed = 0>>
+	<<else>>
+	When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
+	<</if>>
+	<<elseif $origin == "investor">>
+		<<if random(1,3) == 1>>
+		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
+		<<set $raidseed = 0>>
+	<<else>>
+	When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
+	<</if>>
+	<<elseif $origin == "scientist">>
+		<<if random(1,3) == 1>>
+		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
+		<<set $raidseed = 0>>
+	<<else>>
+	The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
+	<</if>>
+	<<elseif $origin == "lawyer">>
+		<<if random(1,3) == 1>>
+		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
+		<<set $raidseed = 0>>
+	<<else>>
+	Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>
 
-<<if $seed == 1>>
+<<if $raidseed == 1>>
 	<<if $origin == "housewife">>
 	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
 	<<elseif $origin == "university professor">>
@@ -974,6 +1155,14 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	The politician spends the VTOL ride quietly, only breaking her silence to ask your mercenaries about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
 	<<elseif $origin == "shut-in">>
 	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your mercenaries attempt to engage her in conversation but are granted no response.
+	<<elseif $origin == "procuress">>
+	The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
+	<<elseif $origin == "investor">>
+	The investor spends the VTOL ride practicing their sales pitches, techniques and speeches. It seems they haven't grasped what their destination is, nor the fate that awaits them upon arrival.
+	<<elseif $origin == "scientist">>
+	The scientist spends the VTOL ride watching as her colleagues and peers are raped around her. That some of the earth's greatest minds have been reduced to sexual objects is disquieting enough, but the realization that she is not likely to be spared from such a fate brings the woman to tears.
+	<<elseif $origin == "lawyer">>
+	The lawyer spends the VTOL ride scarcely sparing any attention to the rape of her staff all about her. Instead she seems almost lost in thought, as if concentrating on finding some loophole or legal means to escape the fate that has befallen her staff.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -5,7 +5,7 @@
 <<set $nextLink = "Scheduled Event">>
 <<set $returnTo = "Scheduled Event">>
 <<set $nextButton = "Continue">>
-<<set $raided = 1>>
+<<set $raided = $week>>
 <<set $seed = 0>>
 
 The leader of your $mercenariesTitle has contacted you from the world outside your arcology. It seems that your mercenaries have enjoyed a profitable series of raids in their time outside the arcology and have hence decided to push their luck by plundering one last location on their way back to the arcology. As your nominal leader, they ask your opinion of a small number of potential targets. Given the distance from the arcology and the time sensitivity of conducting such a mission, you have little to base your decision on besides a brief description.

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -9,7 +9,7 @@
 <<set _raidseed = 0>>
 <<set _raidescape = random(1,3)>>
 
-The leader of your $mercenariesTitle has contacted you from the world outside your arcology. It seems that your mercenaries have enjoyed a profitable series of raids in their time outside the arcology and have decided to push their luck by plundering one last location on their way back to the arcology. As their nominal leader, they ask your opinion of a small number of potential targets. Given the distance from the arcology and the time sensitivity of conducting such a mission, you have little to base your decision on besides a brief description.
+The leader of your $mercenariesTitle has contacted you from the world outside your arcology. It seems that your $mercenariesTitle have enjoyed a profitable series of raids in their time outside the arcology and have decided to push their luck by plundering one last location on their way back to the arcology. As their nominal leader, they ask your opinion of a small number of potential targets. Given the distance from the arcology and the time sensitivity of conducting such a mission, you have little to base your decision on besides a brief description.
 <br><br>
 Worthy of consideration is that although the $mercenariesTitle will enslave the lion's share of enslaved prisoners for the corporation, they will present you the finest slave captured as a gesture of respect for your high position.
 
@@ -303,7 +303,7 @@ Worthy of consideration is that although the $mercenariesTitle will enslave the 
 	<<set $activeSlave.analSkill = 15>>
 	<<set $activeSlave.whoreSkill = 0>>
 	<<set $activeSlave.entertainSkill = 10>>
-	is the shack of a notorious shut-in located just outside your arcology. Not a particularly distinguished target, but it would save your mercenaries considerable time and effort. The shut-in herself has been a fixture of the landscape for decades, with many speculating that she remains a virgin despite her mature age.
+	is the shack of a notorious shut-in located just outside your arcology. Not a particularly distinguished target, but it would save your $mercenariesTitle considerable time and effort. The shut-in herself has been a fixture of the landscape for decades, with many speculating that she remains a virgin despite her mature age.
 <<elseif $origin == "procuress">>
 	<<include "Generate XX Slave">>
 	<<set $activeSlave.age = random(35,$retirementAge-1)>>
@@ -475,33 +475,33 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<elseif $origin == "male military officer">>
 		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
-		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your $mercenariesTitle are unable to capture any of the soldiers who escape on foot.
 	<<elseif $origin == "doctor">>
 		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
 	<<elseif $origin == "nun">>
-		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your $mercenariesTitle can close the distance, they retreat behind the walls of their community and seal the gate behind them.
 	<<elseif $origin == "journalist">>
-		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your $mercenariesTitle beat a hasty retreat.
 	<<elseif $origin == "local news anchor">>
-		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your $mercenariesTitle wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
 		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 	<<elseif $origin == "law enforcement officer">>
-		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
+		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your $mercenariesTitle until reinforcements arrive and force your troops to retreat.
 	<<elseif $origin == "classical musician">>
 		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
 	<<elseif $origin == "politician">>
-		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your $mercenariesTitle can advance, they discover that the politician has already been evacuated.
 	<<elseif $origin == "shut-in">>
-		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your $mercenariesTitle coming.
 	<<elseif $origin == "procuress">>
-		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
+		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your $mercenariesTitle discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your $mercenariesTitle even arrived.
 	<<elseif $origin == "investor">>
-		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
+		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your $mercenariesTitle that she cited heightened security risks as the reason for her absence.
 	<<elseif $origin == "scientist">>
-		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
+		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your $mercenariesTitle are forced to retreat from the building, during which time the scientists make their own escape. When your $mercenariesTitle reenter the building, they find it abandoned.
 	<<elseif $origin == "lawyer">>
-		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
+		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
@@ -511,38 +511,38 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 <<if _raidseed == 1>>
 	<<if $origin == "housewife">>
 	<<if _raidescape == 1>>
-		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
+		Your $mercenariesTitle pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
+		Your $mercenariesTitle pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if _raidescape == 1>>
-		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
+		Your $mercenariesTitle are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
+		Your $mercenariesTitle corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if _raidescape == 1>>
-		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
+		Your $mercenariesTitle are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
+		Your $mercenariesTitle corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
 	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
 		<<set _raidseed = 0>>
 	<<else>>
-		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
 	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
 		<<set _raidseed = 0>>
 	<<else>>
-		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
 		<<if _raidescape == 1>>
@@ -553,56 +553,56 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 	<<elseif $origin == "doctor">>
 		<<if _raidescape == 1>>
-		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
+		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your $mercenariesTitle prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
 		<<set _raidseed = 0>>
 	<<else>>
-		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
+		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your $mercenariesTitle to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
 		<<if _raidescape == 1>>
-		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
+		The nuns flee into their inner sanctum as your $mercenariesTitle approach and bar the doors behind them as they go. When the last barrier is pried open, your $mercenariesTitle discover the nuns have committed suicide as a group rather than be taken prisoner.
 		<<set _raidseed = 0>>
 	<<else>>
-		Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
+		Unarmed and defenseless, the nuns are easily cowed by your $mercenariesTitle and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
 		<<if _raidescape == 1>>
-		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
+		Your $mercenariesTitle are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your $mercenariesTitle retreat from the building before law enforcement can arrive.
 		<<set _raidseed = 0>>
 	<<else>>
 		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
 		<<if _raidescape == 1>>
-		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
+		Your $mercenariesTitle are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
 		<<set _raidseed = 0>>
 	<<else>>
 		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
 		<<if _raidescape == 1>>
-		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
+		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your $mercenariesTitle exit the theater as chaos surges around them.
 		<<set _raidseed = 0>>
 	<<else>>
-		Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
 		<<if _raidescape == 1>>
-		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
+		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your $mercenariesTitle sought to capture is the last to fall, stifled by a hail of bullets.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
+		Your $mercenariesTitle break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
 		<<if _raidescape == 1>>
-		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
+		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your $mercenariesTitle exit the concert hall as chaos surges around them.
 		<<set _raidseed = 0>>
 	<<else>>
-		Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
 		<<if _raidescape == 1>>
-		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
+		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your $mercenariesTitle can do but exit the venue.
 		<<set _raidseed = 0>>
 	<<else>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
@@ -612,50 +612,50 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
 		<<set _raidseed = 0>>
 	<<else>>
-		When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+		When your $mercenariesTitle break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed $mercenariesTitle and quietly accepts being escorted back to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "procuress">>
 		<<if _raidescape == 1>>
-		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
+		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
 		<<set _raidseed = 0>>
 	<<else>>
-		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
+		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
 	<</if>>
 	<<elseif $origin == "investor">>
 		<<if _raidescape == 1>>
-		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
+		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
 		<<set _raidseed = 0>>
 	<<else>>
-		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
+		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
 	<</if>>
 	<<elseif $origin == "scientist">>
 		<<if _raidescape == 1>>
-		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
+		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your $mercenariesTitle suspect the liquid was intended to have a transformative effect rather than a suicidal one.
 		<<set _raidseed = 0>>
 	<<else>>
-		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
+		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
 	<</if>>
 	<<elseif $origin == "lawyer">>
 		<<if _raidescape == 1>>
-		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
+		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
+		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>
 
 <<if _raidseed == 1>>
 	<<if $origin == "housewife">>
-	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
+	The housewife watches in terror as your $mercenariesTitle slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
 	<<elseif $origin == "university professor">>
 	The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
 	<<elseif $origin == "university student">>
 	The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
 	<<elseif $origin == "female military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
+	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "male military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
+	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "military soldier">>
 	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
 	<<elseif $origin == "doctor">>
@@ -667,15 +667,15 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<elseif $origin == "local news anchor">>
 	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
 	<<elseif $origin == "classical dancer">>
-	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
+	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
 	<<elseif $origin == "law enforcement officer">>
-	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your mercenaries all around her. Before she exits the VTOL upon her arrival, she informs your mercenaries that she intends to bring each of them to justice for their supposed crimes.
+	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your $mercenariesTitle all around her. Before she exits the VTOL upon her arrival, she informs your $mercenariesTitle that she intends to bring each of them to justice for their supposed crimes.
 	<<elseif $origin == "classical musician">>
-	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
+	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
 	<<elseif $origin == "politician">>
-	The politician spends the VTOL ride quietly, only breaking her silence to ask your mercenaries about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
+	The politician spends the VTOL ride quietly, only breaking her silence to ask your $mercenariesTitle about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
 	<<elseif $origin == "shut-in">>
-	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your mercenaries attempt to engage her in conversation but are granted no response.
+	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your $mercenariesTitle attempt to engage her in conversation but are granted no response.
 	<<elseif $origin == "procuress">>
 	The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
 	<<elseif $origin == "investor">>
@@ -687,7 +687,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>
-	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
+	Your $mercenariesTitle return without their final prize, but are still in high spirits given their other successes out in the field.
 <</if>>
 <</nobr>>
 <</replace>>
@@ -715,33 +715,33 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<elseif $origin == "male military officer">>
 		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
-		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your $mercenariesTitle are unable to capture any of the soldiers who escape on foot.
 	<<elseif $origin == "doctor">>
 		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
 	<<elseif $origin == "nun">>
-		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your $mercenariesTitle can close the distance, they retreat behind the walls of their community and seal the gate behind them.
 	<<elseif $origin == "journalist">>
-		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your $mercenariesTitle beat a hasty retreat.
 	<<elseif $origin == "local news anchor">>
-		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your $mercenariesTitle wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
 		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 	<<elseif $origin == "law enforcement officer">>
-		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
+		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your $mercenariesTitle until reinforcements arrive and force your troops to retreat.
 	<<elseif $origin == "classical musician">>
 		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
 	<<elseif $origin == "politician">>
-		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your $mercenariesTitle can advance, they discover that the politician has already been evacuated.
 	<<elseif $origin == "shut-in">>
-		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your $mercenariesTitle coming.
 	<<elseif $origin == "procuress">>
-		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
+		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your $mercenariesTitle discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your $mercenariesTitle even arrived.
 	<<elseif $origin == "investor">>
-		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
+		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your $mercenariesTitle that she cited heightened security risks as the reason for her absence.
 	<<elseif $origin == "scientist">>
-		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
+		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your $mercenariesTitle are forced to retreat from the building, during which time the scientists make their own escape. When your $mercenariesTitle reenter the building, they find it abandoned.
 	<<elseif $origin == "lawyer">>
-		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
+		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
@@ -751,38 +751,38 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 <<if _raidseed == 1>>
 	<<if $origin == "housewife">>
 	<<if _raidescape == 1>>
-		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
+		Your $mercenariesTitle pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
+		Your $mercenariesTitle pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if _raidescape == 1>>
-		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
+		Your $mercenariesTitle are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
+		Your $mercenariesTitle corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if _raidescape == 1>>
-		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
+		Your $mercenariesTitle are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
+		Your $mercenariesTitle corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
 	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
 		<<set _raidseed = 0>>
 	<<else>>
-		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
 	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
 		<<set _raidseed = 0>>
 	<<else>>
-		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
 		<<if _raidescape == 1>>
@@ -793,56 +793,56 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 	<<elseif $origin == "doctor">>
 		<<if _raidescape == 1>>
-		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
+		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your $mercenariesTitle prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
 		<<set _raidseed = 0>>
 	<<else>>
-		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
+		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your $mercenariesTitle to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
 		<<if _raidescape == 1>>
-		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
+		The nuns flee into their inner sanctum as your $mercenariesTitle approach and bar the doors behind them as they go. When the last barrier is pried open, your $mercenariesTitle discover the nuns have committed suicide as a group rather than be taken prisoner.
 		<<set _raidseed = 0>>
 	<<else>>
-		Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
+		Unarmed and defenseless, the nuns are easily cowed by your $mercenariesTitle and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
 		<<if _raidescape == 1>>
-		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
+		Your $mercenariesTitle are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your $mercenariesTitle retreat from the building before law enforcement can arrive.
 		<<set _raidseed = 0>>
 	<<else>>
 		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
 		<<if _raidescape == 1>>
-		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
+		Your $mercenariesTitle are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
 		<<set _raidseed = 0>>
 	<<else>>
 		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
 		<<if _raidescape == 1>>
-		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
+		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your $mercenariesTitle exit the theater as chaos surges around them.
 		<<set _raidseed = 0>>
 	<<else>>
-		Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
 		<<if _raidescape == 1>>
-		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
+		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your $mercenariesTitle sought to capture is the last to fall, stifled by a hail of bullets.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
+		Your $mercenariesTitle break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
 		<<if _raidescape == 1>>
-		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
+		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your $mercenariesTitle exit the concert hall as chaos surges around them.
 		<<set _raidseed = 0>>
 	<<else>>
-		Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
 		<<if _raidescape == 1>>
-		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
+		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your $mercenariesTitle can do but exit the venue.
 		<<set _raidseed = 0>>
 	<<else>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
@@ -852,50 +852,50 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
 		<<set _raidseed = 0>>
 	<<else>>
-		When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+		When your $mercenariesTitle break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed $mercenariesTitle and quietly accepts being escorted back to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "procuress">>
 		<<if _raidescape == 1>>
-		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
+		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
 		<<set _raidseed = 0>>
 	<<else>>
-		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
+		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
 	<</if>>
 	<<elseif $origin == "investor">>
 		<<if _raidescape == 1>>
-		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
+		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
 		<<set _raidseed = 0>>
 	<<else>>
-		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
+		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
 	<</if>>
 	<<elseif $origin == "scientist">>
 		<<if _raidescape == 1>>
-		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
+		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your $mercenariesTitle suspect the liquid was intended to have a transformative effect rather than a suicidal one.
 		<<set _raidseed = 0>>
 	<<else>>
-		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
+		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
 	<</if>>
 	<<elseif $origin == "lawyer">>
 		<<if _raidescape == 1>>
-		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
+		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
+		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>
 
 <<if _raidseed == 1>>
 	<<if $origin == "housewife">>
-	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
+	The housewife watches in terror as your $mercenariesTitle slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
 	<<elseif $origin == "university professor">>
 	The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
 	<<elseif $origin == "university student">>
 	The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
 	<<elseif $origin == "female military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
+	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "male military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
+	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "military soldier">>
 	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
 	<<elseif $origin == "doctor">>
@@ -907,15 +907,15 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<elseif $origin == "local news anchor">>
 	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
 	<<elseif $origin == "classical dancer">>
-	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
+	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
 	<<elseif $origin == "law enforcement officer">>
-	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your mercenaries all around her. Before she exits the VTOL upon her arrival, she informs your mercenaries that she intends to bring each of them to justice for their supposed crimes.
+	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your $mercenariesTitle all around her. Before she exits the VTOL upon her arrival, she informs your $mercenariesTitle that she intends to bring each of them to justice for their supposed crimes.
 	<<elseif $origin == "classical musician">>
-	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
+	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
 	<<elseif $origin == "politician">>
-	The politician spends the VTOL ride quietly, only breaking her silence to ask your mercenaries about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
+	The politician spends the VTOL ride quietly, only breaking her silence to ask your $mercenariesTitle about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
 	<<elseif $origin == "shut-in">>
-	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your mercenaries attempt to engage her in conversation but are granted no response.
+	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your $mercenariesTitle attempt to engage her in conversation but are granted no response.
 	<<elseif $origin == "procuress">>
 	The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
 	<<elseif $origin == "investor">>
@@ -927,7 +927,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>
-	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
+	Your $mercenariesTitle return without their final prize, but are still in high spirits given their other successes out in the field.
 <</if>>
 <</nobr>>
 <</replace>>
@@ -955,33 +955,33 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<elseif $origin == "male military officer">>
 		The officer's escort engages the $mercenariesTitle in a gunfight and in the confusion the officer manages to escape capture on foot.
 	<<elseif $origin == "military soldier">>
-		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your mercenaries are unable to capture any of the soldiers who escape on foot.
+		The young soldiers fight valiantly against the $mercenariesTitle until they are routed. Despite defeating them in the field, your $mercenariesTitle are unable to capture any of the soldiers who escape on foot.
 	<<elseif $origin == "doctor">>
 		The hospital's security staff alone would prove little match for the $mercenariesTitle, but just as they are about to be overrun an uneasy coalition of rival gangster and criminals who had been committed as patients join the fray and turn the tide of battle. 
 	<<elseif $origin == "nun">>
-		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your mercenaries can close the distance, they retreat behind the walls of their community and seal the gate behind them.
+		As the $mercenariesTitle close in on the commune, they are spotted by a group of young nuns tending to their grounds. Before your $mercenariesTitle can close the distance, they retreat behind the walls of their community and seal the gate behind them.
 	<<elseif $origin == "journalist">>
-		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your mercenaries beat a hasty retreat.
+		Though the $mercenariesTitle easily overwhelm the single security guard posted at the firm, they are unable to do so before he triggers an alarm. Faced with the prospect of local law enforcement arriving, your $mercenariesTitle beat a hasty retreat.
 	<<elseif $origin == "local news anchor">>
-		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your mercenaries wisely retreat from the engagement.
+		Unfortunately for the $mercenariesTitle, the news channel appears to have been interviewing members of the local militia garrison at the time of the raid. Upon encountering more firepower than they had anticipated, your $mercenariesTitle wisely retreat from the engagement.
 	<<elseif $origin == "classical dancer">>
 		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the dance troupe the warning need to make an escape from the theater.
 	<<elseif $origin == "law enforcement officer">>
-		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your mercenaries until reinforcements arrive and force your troops to retreat.
+		Despite the lack of staff, it seems this particular precinct has been the recipient of an alarming quantity of military grade equipment. With their overwhelming firepower, the officers are able to hold off your $mercenariesTitle until reinforcements arrive and force your troops to retreat.
 	<<elseif $origin == "classical musician">>
 		Though they are excellent soldiers, the $mercenariesTitle are crude and uncultured. They are unable to blend into the audience and are soon discovered, giving the orchestra the warning need to make an escape from the concert hall.
 	<<elseif $origin == "politician">>
-		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your mercenaries can advance, they discover that the politician has already been evacuated.
+		The $mercenariesTitle clash with the politician's security detail amidst a maelstrom of terrified civilians and the confrontation drags out for some time. By the time your $mercenariesTitle can advance, they discover that the politician has already been evacuated.
 	<<elseif $origin == "shut-in">>
-		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your mercenaries coming.
+		The $mercenariesTitle pry open the shut-in's door to discover an empty shack. From the cooked meal still steaming on the dining room table and the remarkable absence of dust, it seems she left only recently. Somehow the crafty old minx must have seen your $mercenariesTitle coming.
 	<<elseif $origin == "procuress">>
-		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your mercenaries discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your mercenaries even arrived.
+		The $mercenariesTitle break down the door to the halfway home to discover a throng of sniffling young women, who cling to their boots and beg for rescue. Once they have been accounted for, your $mercenariesTitle discover the procuress is nowhere to be found. It seems the wily old minx has somehow made her escape before your $mercenariesTitle even arrived.
 	<<elseif $origin == "investor">>
-		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your mercenaries that she cited heightened security risks as the reason for her absence.
+		The $mercenariesTitle raid the business exposition and thoroughly search the premises, only to discover that the investor never arrived. A terrified businessman informs your $mercenariesTitle that she cited heightened security risks as the reason for her absence.
 	<<elseif $origin == "scientist">>
-		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your mercenaries are forced to retreat from the building, during which time the scientists make their own escape. When your mercenaries reenter the building, they find it abandoned.
+		When the $mercenariesTitle make an explosive entrance into the lab with their guns drawn, the chief scientist throws a vial of some mysterious liquid in front of them. The resultant smoke is so thick and choking that your $mercenariesTitle are forced to retreat from the building, during which time the scientists make their own escape. When your $mercenariesTitle reenter the building, they find it abandoned.
 	<<elseif $origin == "lawyer">>
-		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your mercenaries cut their losses and retreat back to their VTOLs.
+		It seems the lawyer had anticipated the possibility of conflict on the frontier on the outer rim of the Old World, so the $mercenariesTitle are able to do little more than enter the building before the law firm's offices seal themselves off. Faced with the prospect of lingering in a conflict zone, your $mercenariesTitle cut their losses and retreat back to their VTOLs.
 	<</if>>
 <<else>>
 	 The $mercenariesTitle are able to carry out their plan.
@@ -991,38 +991,38 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 <<if _raidseed == 1>>
 	<<if $origin == "housewife">>
 	<<if _raidescape == 1>>
-		Your mercenaries pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
+		Your $mercenariesTitle pry open the door to the manse's panic room to find that the woman has hung herself to escape capture. A waste.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries pry open the door to the manse's panic room and pull the protesting housewife from its depths.
+		Your $mercenariesTitle pry open the door to the manse's panic room and pull the protesting housewife from its depths.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if _raidescape == 1>>
-		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
+		Your $mercenariesTitle are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
+		Your $mercenariesTitle corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if _raidescape == 1>>
-		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
+		Your $mercenariesTitle are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
+		Your $mercenariesTitle corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
 	<</if>>
 	<<elseif $origin == "female military officer">>
 	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple and pulls the trigger. A waste.
 		<<set _raidseed = 0>>
 	<<else>>
-		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, she promptly puts her service weapon to her temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from her stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "male military officer">>
 	<<if _raidescape == 1>>
 		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple and pulls the trigger. A waste.
 		<<set _raidseed = 0>>
 	<<else>>
-		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your mercenaries is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
+		As your mecenaries gain the upper hand on the officer's escort, he promptly puts his service weapon to his temple but hesitates. Luckily one of your $mercenariesTitle is close by and able to pluck the pistol from his stiff fingers. The despondent officer is cuffed and taken back to the VTOL for transport.
 	<</if>>
 	<<elseif $origin == "military soldier">>
 		<<if _raidescape == 1>>
@@ -1033,56 +1033,56 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 	<<elseif $origin == "doctor">>
 		<<if _raidescape == 1>>
-		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your mercenaries prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
+		The hospital's security staff alone would prove little match for your mercenaries, but they are joined by an uneasy coalition of rival gangster and criminals who had been committed as patients. Though your $mercenariesTitle prevail, they discover to their chagrin that the doctors and their staff were slain during the wanton exchange of fire. 
 		<<set _raidseed = 0>>
 	<<else>>
-		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your mercenaries to take the doctors and their staff into custody with little fuss.
+		The security staff of the hospital is easily overpowered and surrender rapidly, allowing your $mercenariesTitle to take the doctors and their staff into custody with little fuss.
 	<</if>>
 	<<elseif $origin == "nun">>
 		<<if _raidescape == 1>>
-		The nuns flee into their inner sanctum as your mercenaries approach and bar the doors behind them as they go. When the last barrier is pried open, your mercenaries discover the nuns have committed suicide as a group rather than be taken prisoner.
+		The nuns flee into their inner sanctum as your $mercenariesTitle approach and bar the doors behind them as they go. When the last barrier is pried open, your $mercenariesTitle discover the nuns have committed suicide as a group rather than be taken prisoner.
 		<<set _raidseed = 0>>
 	<<else>>
-		Unarmed and defenseless, the nuns are easily cowed by your mercenaries and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
+		Unarmed and defenseless, the nuns are easily cowed by your $mercenariesTitle and taken away one by one to the VTOLs. The most pious sister prays vehemently until she is dragged out of the inner sanctum in cuffs.
 	<</if>>
 	<<elseif $origin == "journalist">>
 		<<if _raidescape == 1>>
-		Your mercenaries are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your mercenaries retreat from the building before law enforcement can arrive.
+		Your $mercenariesTitle are met with fierce resistance by the staff of the newspaper firm, who take the raid as an opportunity to turn their abolitionist words into violent action. Eventually, your $mercenariesTitle retreat from the building before law enforcement can arrive.
 		<<set _raidseed = 0>>
 	<<else>>
 		Once the lone security guard is subdued, the journalists and editors of the firm quietly accept their restraints and file out of the building and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "local news anchor">>
 		<<if _raidescape == 1>>
-		Your mercenaries are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
+		Your $mercenariesTitle are able to subdue the news anchor and bid a hasty exit from the recording studio. Before they can board the waiting VTOL however, the anchor is struck in the head by a bullet fired by a man who was her longtime fan turned stalker. It seems if he cannot have her, neither can you. 
 		<<set _raidseed = 0>>
 	<<else>>
 		The news anchor is subdued without issue and quietly escorted out of the recording studio and into the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "classical dancer">>
 		<<if _raidescape == 1>>
-		As your mercenaries close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your mercenaries exit the theater as chaos surges around them.
+		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the darling star of the dance troupe loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the troupe hysterical, while your $mercenariesTitle exit the theater as chaos surges around them.
 		<<set _raidseed = 0>>
 	<<else>>
-		Once your mercenaries close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the dance troupe promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "law enforcement officer">>
 		<<if _raidescape == 1>>
-		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your mercenaries sought to capture is the last to fall, stifled by a hail of bullets.
+		Despite being outnumbered and outgunned, the officers stand their ground to the last. The sterling officer of the law your $mercenariesTitle sought to capture is the last to fall, stifled by a hail of bullets.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
+		Your $mercenariesTitle break through the door of the precinct with their guns drawn. The precinct is so understaffed that each officer has a number of weapons drawn on them from every angle, so its no surprise when the precinct's sterling policewoman formally surrenders the precinct and its officers to your mercenaries.
 	<</if>>
 	<<elseif $origin == "classical musician">>
 		<<if _raidescape == 1>>
-		As your mercenaries close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your mercenaries exit the concert hall as chaos surges around them.
+		As your $mercenariesTitle close in on the stage and reveal their concealed weapons, the crown jewel of the orchestra loses her footing in shock and tumbles off the stage. The sharp crack as she hits the ground drives the crowd and remaining members of the orchestra hysterical, while your $mercenariesTitle exit the concert hall as chaos surges around them.
 		<<set _raidseed = 0>>
 	<<else>>
-		Once your mercenaries close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
+		Once your $mercenariesTitle close in on the stage and reveal their concealed weapons, the orchestra promptly surrenders. With the shocked audience looking on, each member is cuffed and escorted out the door to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "politician">>
 		<<if _raidescape == 1>>
-		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your mercenaries can do but exit the venue.
+		With their security detail defeated and their crowd of supporters offering no protection, the politician tries to take up one of her fallen protector's pistols to defend herself. Unfortunately for her and for your mercenaries, the politician has a staggeringly poor understanding of firearms and manages to shoot themselves in the face when they discharge the weapon. With the politician dead, there is little your $mercenariesTitle can do but exit the venue.
 		<<set _raidseed = 0>>
 	<<else>>
 		With their security detail defeated and their crowd of supporters offering no protection, the politician promptly surrenders in the hopes that they won't be harmed and is escorted to the waiting VTOL.
@@ -1092,50 +1092,50 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 		When the $mercenariesTitle break down the door to the shut-in's shack, they are met with a terrible stench of dust and decay. Judging by the body hanging limply from the banisters, the shut-in took their own life some time ago.
 		<<set _raidseed = 0>>
 	<<else>>
-		When your mercenaries break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed mercenaries and quietly accepts being escorted back to the waiting VTOL.
+		When your $mercenariesTitle break down the door to to the shut-in's shack, they are met with a surprised and somewhat unkempt woman staring at them. Despite their lack of social interaction, they know better than to argue with a small army of armed $mercenariesTitle and quietly accepts being escorted back to the waiting VTOL.
 	<</if>>
 	<<elseif $origin == "procuress">>
 		<<if _raidescape == 1>>
-		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
+		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women go berserk with the prospect of freedom and break into the procuress' office to tear her apart with their bare hands.
 		<<set _raidseed = 0>>
 	<<else>>
-		When your mercenaries enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your mercenaries can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
+		When your $mercenariesTitle enter the halfway house, the impoverished women within mistake them for an international rescue mission. Before your $mercenariesTitle can say otherwise, the women band together and drag the procuress out of her office and restrain her themselves. The $mercenariesTitle have to do little more than escort the grinning women to the waiting VTOLs, while they drag the protesting procuress with them.
 	<</if>>
 	<<elseif $origin == "investor">>
 		<<if _raidescape == 1>>
-		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
+		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. Before she can be subdued, the investor swallows a concealed pill and crumples to the ground dead.
 		<<set _raidseed = 0>>
 	<<else>>
-		When your mercenaries corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
+		When your $mercenariesTitle corner the investor in the exposition, she seemingly mistakes them for international police intent on taking her in for prior economic crimes. She begrudgingly surrenders and is subsequently escorted back to a waiting VTOL.
 	<</if>>
 	<<elseif $origin == "scientist">>
 		<<if _raidescape == 1>>
-		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your mercenaries suspect the liquid was intended to have a transformative effect rather than a suicidal one.
+		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. From the triumphant look on her face as she keels over dead, your $mercenariesTitle suspect the liquid was intended to have a transformative effect rather than a suicidal one.
 		<<set _raidseed = 0>>
 	<<else>>
-		The bulk of the scientists surrender shortly after your mercenaries make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
+		The bulk of the scientists surrender shortly after your $mercenariesTitle make an explosive entrance into their lab. Before she can be cuffed, the chief scientist takes a swig from some mysterious beaker of liquid. As the triumphant look on her face fades, it becomes clear that the liquid did not have the transformative effect that she desired.
 	<</if>>
 	<<elseif $origin == "lawyer">>
 		<<if _raidescape == 1>>
-		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
+		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. From the quantity of pill bottles evident on her desk, it seems she found the sole loophole to escape capture.
 		<<set _raidseed = 0>>
 	<<else>>
-		Your mercenaries capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
+		Your $mercenariesTitle capture the law firm's staff without much difficulty, but when they open the door to the lawyer's office they find her frothing from the mouth and unresponsive. Despite her attempts to drug herself into suicide, the effects are temporary and the lawyer  soon finds herself being hauled off to a waiting VTOL with her staff.
 	<</if>>
 	<</if>>
 <</if>>
 
 <<if _raidseed == 1>>
 	<<if $origin == "housewife">>
-	The housewife watches in terror as your mercenaries slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
+	The housewife watches in terror as your $mercenariesTitle slake their lust on her servants and maids, knowing that her respite from a brutal rape must only be a temporary blessing.
 	<<elseif $origin == "university professor">>
 	The department head spends the VTOL ride back to your arcology watching in terror as her colleagues and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
 	<<elseif $origin == "university student">>
 	The peerless student spends the VTOL ride back to your arcology watching in terror as her friends and peers are raped wholesale by your mercenaries. With her educated mind, she knows that being singled out from a similar fate must mean she is being saved for someone and worries about who that might be.
 	<<elseif $origin == "female military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
+	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape her defeated subordinates. Given their brutal treatment, she doubts her respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "male military officer">>
-	The officer spends the VTOL ride back to your arcology watching as your mercenaries rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
+	The officer spends the VTOL ride back to your arcology watching as your $mercenariesTitle rape his defeated subordinates. Given their brutal treatment, he doubts his respite from such a fate is due to any battlefield rules of conduct.
 	<<elseif $origin == "military soldier">>
 	The sergeant spends the VTOL ride back to the arcology watching as her childhood friends turned comrades in arms are raped by your mercenaries. She wonders why she has been spared this seemingly shared fate, but suspects it has little to do with her nominally higher rank.
 	<<elseif $origin == "doctor">>
@@ -1147,15 +1147,15 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<<elseif $origin == "local news anchor">>
 	The anchor is initially resistant during the VTOL ride, but soon grows complacent when she is told of the luxury of your penthouse.
 	<<elseif $origin == "classical dancer">>
-	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
+	The dancer spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her dancing talent rather than her body.
 	<<elseif $origin == "law enforcement officer">>
-	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your mercenaries all around her. Before she exits the VTOL upon her arrival, she informs your mercenaries that she intends to bring each of them to justice for their supposed crimes.
+	The officer spends the VTOL ride watching impassively as her fellow officers are raped by your $mercenariesTitle all around her. Before she exits the VTOL upon her arrival, she informs your $mercenariesTitle that she intends to bring each of them to justice for their supposed crimes.
 	<<elseif $origin == "classical musician">>
-	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your mercenaries all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
+	The musician spends the VTOL ride in abject terror as her friends and peers are raped by your $mercenariesTitle all around her. She clings to the hope that she is being spared from the same fate out of a desire for her musical talent rather than her body.
 	<<elseif $origin == "politician">>
-	The politician spends the VTOL ride quietly, only breaking her silence to ask your mercenaries about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
+	The politician spends the VTOL ride quietly, only breaking her silence to ask your $mercenariesTitle about where she is being brought and why. When they do not answer she simply fusses with her outfit, as if headed to an important interview.
 	<<elseif $origin == "shut-in">>
-	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your mercenaries attempt to engage her in conversation but are granted no response.
+	The shut-in spends the VTOL ride sitting quietly in their seat. Confused by her silence, your $mercenariesTitle attempt to engage her in conversation but are granted no response.
 	<<elseif $origin == "procuress">>
 	The procuress spends the VTOL ride watching uneasily as the girls she intended to sell into slavery are raped by your mercenaries. Far from having a conscience, she realizes that her own capture indicates that she will not be long spared from such treatment. The revelation brings her to weep tears down her mature face, doomed to the same fate she herself sent many girls to.
 	<<elseif $origin == "investor">>
@@ -1167,7 +1167,7 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 <<AddSlave $activeSlave>> /* skip New Slave Intro */	
 <<else>>
-	Your mercenaries return without their final prize, but are still in high spirits given their other successes out in the field.
+	Your $mercenariesTitle return without their final prize, but are still in high spirits given their other successes out in the field.
 <</if>>
 <</nobr>>
 <</replace>>

--- a/src/uncategorized/seRaiding.tw
+++ b/src/uncategorized/seRaiding.tw
@@ -517,14 +517,14 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if random(1,3) == 1>>
-		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
+		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set $raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if random(1,3) == 1>>
-		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
+		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set $raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
@@ -757,14 +757,14 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if random(1,3) == 1>>
-		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
+		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set $raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if random(1,3) == 1>>
-		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
+		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set $raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.
@@ -997,14 +997,14 @@ You make your selection and direct your $mercenariesTitle to attack the target.
 	<</if>>
 	<<elseif $origin == "university professor">>
 	<<if random(1,3) == 1>>
-		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers
+		Your mercenaries are met with surprising resistance by the university's professors and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set $raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the professors and their department head in one of the university's many conference rooms, hauling them off to the VTOLs when the academics promptly surrender.
 	<</if>>
 	<<elseif $origin == "university student">>
 	<<if random(1,3) == 1>>
-		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers
+		Your mercenaries are met with surprising resistance by the university's students and are forced to bid a hasty retreat before security can arrive in greater numbers.
 		<<set $raidseed = 0>>
 	<<else>>
 		Your mercenaries corner the students in their rooms, hauling them off one by one to the VTOLs as they protest feebly.


### PR DESCRIPTION
It's a rough framework and largely taken from the coursing association, but this adds a policy that should unlock after the event where the Mercs offer to help out the corporation. If you allow them, every few weeks you'll get an event to select a target for the mercs to enslave. Again, it's a little rough and a little low on content at the moment but it should be pretty easy to add. Each new target only requires a slave gen and about three-four sentences of text. Numbers may need some rebalancing too. Some of the text could use some sharpening as well.

Edit: Did a couple of test playthroughs with the current build and everything seems to fire properly and be working right. Hopefully, unless there are any outstanding issues, that means this is in a good place at the moment.

Current targets:
University Professor/Student. Male/Female military officer. Rich housewife. Military soldier.
Also added: Doctor, nun, journalist, news anchor and classical dancer.
Politician, law enforcement officer, shut-in and classical musician.
Procuress, investor, scientist, lawyer.

As might be evident from the careers above, this event also provides a way for end-game players to target slaves with affinities for various facility management roles.
