### PR TITLE
Revamping the corporate development

### DIFF
--- a/src/uncategorized/corporationDevelopments.tw
+++ b/src/uncategorized/corporationDevelopments.tw
@@ -230,8 +230,26 @@ General asset prices are
 		<</replace>>
 	<</if>>
 <</link>>
-
-
+/* Divest Half command rounds down. This means that on odd numbers a fraction of the asset is lost.
+I can't be arsed to care. At this point that amount of money is insignificant.*/
+| <<link "Divest Half">>
+	<<if $generalAssets >= 100000>>
+		<<set $generalAssets = Math.trunc($generalAssets/2)>>
+		<<set $corpCash += $generalAssets*$generalAssetPrice>>
+		<<replace "#cashOnHand">>
+			¤<<print $corpCash>>
+		<</replace>>
+		<<replace "#genAssets">>
+			¤<<print $generalAssetPrice*$generalAssets>>
+		<</replace>>
+		<<replace "#update">>
+		<</replace>>
+	<<else>>
+		<<replace "#update">>
+			You don't have enough assets to justify bulk divestment.
+		<</replace>>
+	<</if>>
+<</link>>
 
 <br>
 <<set $slaveAssetPrice = Math.trunc(10*$slaveCostFactor)>>
@@ -290,6 +308,24 @@ Slave prices are
 	<<else>>
 		<<replace "#update">>
 			You cannot sell any more assets.
+		<</replace>>
+	<</if>>
+<</link>>
+| <<link "Divest Half">>
+	<<if $slaveAssets >= 100000>>
+		<<set $slaveAssets = Math.trunc($slaveAssets/2)>>
+		<<set $corpCash += $slaveAssets*$slaveAssetPrice>>
+		<<replace "#cashOnHand">>
+			¤<<print $corpCash>>
+		<</replace>>
+		<<replace "#slavAssets">>
+			¤<<print $slaveAssetPrice*$slaveAssets>>
+		<</replace>>
+		<<replace "#update">>
+		<</replace>>
+	<<else>>
+		<<replace "#update">>
+			You don't have enough assets to justify bulk divestment.
 		<</replace>>
 	<</if>>
 <</link>>
@@ -374,7 +410,24 @@ Legal enslavement asset prices are
 		<</replace>>
 	<</if>>
 <</link>>
-
+| <<link "Divest Half">>
+	<<if $entrapmentAssets >= 100000>>
+		<<set $entrapmentAssets = Math.trunc($entrapmentAssets/2)>>
+		<<set $corpCash += $entrapmentAssets*$entrapmentAssetPrice>>
+		<<replace "#cashOnHand">>
+			¤<<print $corpCash>>
+		<</replace>>
+		<<replace "#trapAssets">>
+			¤<<print $entrapmentAssetPrice*$entrapmentAssets>>
+		<</replace>>
+		<<replace "#update">>
+		<</replace>>
+	<<else>>
+		<<replace "#update">>
+			You don't have enough assets to justify bulk divestment.
+		<</replace>>
+	<</if>>
+<</link>>
 
 <br>
 <<if $captureAssetPrice > 10>>
@@ -453,6 +506,24 @@ Extralegal enslavement asset prices are
 	<<else>>
 		<<replace "#update">>
 			You cannot sell any more assets.
+		<</replace>>
+	<</if>>
+<</link>>
+| <<link "Divest Half">>
+	<<if $captureAssets >= 100000>>
+		<<set $captureAssets = Math.trunc($captureAssets/2)>>
+		<<set $corpCash += $captureAssets*$captureAssetPrice>>
+		<<replace "#cashOnHand">>
+			¤<<print $corpCash>>
+		<</replace>>
+		<<replace "#capAssets">>
+			¤<<print $captureAssetPrice*$captureAssets>>
+		<</replace>>
+		<<replace "#update">>
+		<</replace>>
+	<<else>>
+		<<replace "#update">>
+			You don't have enough assets to justify bulk divestment.
 		<</replace>>
 	<</if>>
 <</link>>
@@ -537,6 +608,24 @@ Slave training asset prices are
 		<</replace>>
 	<</if>>
 <</link>>
+| <<link "Divest Half">>
+	<<if $trainingAssets >= 100000>>
+		<<set $trainingAssets = Math.trunc($trainingAssets/2)>>
+		<<set $corpCash += $trainingAssets*$trainingAssetPrice>>
+		<<replace "#cashOnHand">>
+			¤<<print $corpCash>>
+		<</replace>>
+		<<replace "#trainAssets">>
+			¤<<print $trainingAssetPrice*$trainingAssets>>
+		<</replace>>
+		<<replace "#update">>
+		<</replace>>
+	<<else>>
+		<<replace "#update">>
+			You don't have enough assets to justify bulk divestment.
+		<</replace>>
+	<</if>>
+<</link>>
 
 <br>
 <<if $surgicalAssetPrice > 10>>
@@ -618,6 +707,25 @@ Surgical asset prices are
 		<</replace>>
 	<</if>>
 <</link>>
+| <<link "Divest Half">>
+	<<if $surgicalAssets >= 100000>>
+		<<set $surgicalAssets = Math.trunc($surgicalAssets/2)>>
+		<<set $corpCash += $surgicalAssets*$surgicalAssetPrice>>
+		<<replace "#cashOnHand">>
+			¤<<print $corpCash>>
+		<</replace>>
+		<<replace "#surgAssets">>
+			¤<<print $surgicalAssetPrice*$surgicalAssets>>
+		<</replace>>
+		<<replace "#update">>
+		<</replace>>
+	<<else>>
+		<<replace "#update">>
+			You don't have enough assets to justify bulk divestment.
+		<</replace>>
+	<</if>>
+<</link>>
+<br>
 
 <br>
 <<if $drugAssetPrice > 10>>
@@ -699,9 +807,27 @@ Drug asset prices are
 		<</replace>>
 	<</if>>
 <</link>>
-
+| <<link "Divest Half">>
+	<<if $drugAssets >= 100000>>
+		<<set $drugAssets = Math.trunc($drugAssets/2)>>
+		<<set $corpCash += $drugAssets*$drugAssetPrice>>
+		<<replace "#cashOnHand">>
+			¤<<print $corpCash>>
+		<</replace>>
+		<<replace "#drAssets">>
+			¤<<print $drugAssetPrice*$drugAssets>>
+		<</replace>>
+		<<replace "#update">>
+		<</replace>>
+	<<else>>
+		<<replace "#update">>
+			You don't have enough assets to justify bulk divestment.
+		<</replace>>
+	<</if>>
+<</link>>
 </span>
 
+<br>
 <span id="direction">
 
 <<if $generalAssets >= 2000>>
@@ -712,12 +838,27 @@ Drug asset prices are
 		| <<link "No focus">><<set $generalUpgradeBreaking = "none">><<replace "#direction">><br><<print "You directed the corporation to focus on whatever training methods work best.">><</replace>><</link>>
 	<</if>>
 <</if>>
+<<if $generalUpgradeBreaking != "unselected">>
+	<br>
+	<<if $generalUpgradeBreaking == "brutality">>The corporation does not hesitate from using brutality to break slaves.
+		<<elseif $generalUpgradeBreaking == "care">>The corporation uses care in training their slaves.
+		<<else>>The corporation uses both care and brutality when training their slaves.
+	<</if>>
+	<<link "Refocus">><<set $generalUpgradeBreaking = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
+<</if>>
 <<if $generalAssets >= 5000>>
 	<<if $generalUpgradeWeight == "unselected">>
 		<br>The corporation has enough general expertise to specialize. Manage slaves' diets to an
 		<<link "Attractive weight">><<set $generalUpgradeWeight = "attractive">><<replace "#direction">><br><<print "You directed the corporation to slim fat slaves and feed thin ones.">><</replace>><</link>>
 		| <<link "No dieting">><<set $generalUpgradeWeight = "none">><<replace "#direction">><br><<print "You directed the corporation not to focus on slaves' weight.">><</replace>><</link>>
 	<</if>>
+<</if>>
+<<if $generalUpgradeWeight != "unselected">>
+	<br>
+	<<if $generalUpgradeWeight == "attractive">>The corporation manages the slaves' diets to ensure they aren't too thin or too fat.
+		<<else>>The corporation does not try to change the slaves' weights.
+	<</if>>
+	<<link "Refocus">><<set $generalUpgradeWeight = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
 <</if>>
 <<if $generalAssets >= 10000>>
 	<<if $generalUpgradeMuscle == "unselected">>
@@ -726,6 +867,14 @@ Drug asset prices are
 		| <<link "Ripped">><<set $generalUpgradeMuscle = "ripped">><<replace "#direction">><br><<print "You directed the corporation to train slaves until they're ripped.">><</replace>><</link>>
 		| <<link "No training">><<set $generalUpgradeMuscle = "none">><<replace "#direction">><br><<print "You directed the corporation not to focus on slaves' fitness.">><</replace>><</link>>
 	<</if>>
+<</if>>
+<<if $generalUpgradeMuscle != "unselected">>
+	<br>
+	<<if $generalUpgradeMuscle == "toned">>The corporation's slaves are made to exercise until they are toned.
+		<<elseif $generalUpgradeMuscle == "ripped">>The corporation's slaves are made to exercise until they are ripped.
+		<<else>>The corporation does not try to manage their slaves' fitness.
+	<</if>>
+	<<link "Refocus">><<set $generalUpgradeMuscle = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
 <</if>>
 <<if $entrapmentAssets >= 2000>>
 	<<if $entrapmentUpgradeDevotionOne == "unselected">>
@@ -741,6 +890,14 @@ Drug asset prices are
 		| <<link "No focus">><<set $entrapmentUpgradeDevotionTwo = "none">><<replace "#direction">><br><<print "You directed the corporation to train slaves regardless of devotion.">><</replace>><</link>>
 	<</if>>
 <</if>>
+<<if $entrapmentUpgradeDevotionTwo != "unselected" || $entrapmentUpgradeDevotionOne != "unselected">>
+	<br>
+	<<if $entrapmentUpgradeDevotionTwo == "devotion">>The corporation selects slaves who are predisposed to devotion.
+	<<elseif $entrapmentUpgradeDevotionOne == "obedience">>The corporation selects slaves who are predisposed to obedience.
+		<<else>>The corporation trains slaves regardless of obedience.
+	<</if>>
+	<<link "Refocus">><<set $entrapmentUpgradeDevotionTwo = "unselected">><<set $entrapmentUpgradeDevotionOne = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
+<</if>>
 <<if $entrapmentAssets >= 10000>>
 	<<if $entrapmentUpgradeIntelligence == "unselected">>
 		<br>The corporation is entrapping enough slaves to specialize. Focus on slaves who are
@@ -748,6 +905,14 @@ Drug asset prices are
 		| <<link "Stupid">><<set $entrapmentUpgradeIntelligence = "stupid">><<replace "#direction">><br><<print "You directed the corporation to retain stupid slaves.">><</replace>><</link>>
 		| <<link "No focus">><<set $entrapmentUpgradeIntelligence = "none">><<replace "#direction">><br><<print "You directed the corporation to train slaves regardless of intelligence.">><</replace>><</link>>
 	<</if>>
+<</if>>
+<<if $entrapmentUpgradeIntelligence != "unselected">>
+	<br>
+	<<if $entrapmentUpgradeIntelligence == "intelligent">>The corporation only retains smart slaves.
+		<<elseif $entrapmentUpgradeIntelligence == "stupid">>The corporation only retains stupid slaves.
+		<<else>>The corporation does not care how smart/stupid a slave is.
+	<</if>>
+	<<link "Refocus">><<set $entrapmentUpgradeIntelligence = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
 <</if>>
 <<if $captureAssets >= 2000>>
 	<<if $seeDicks != 0>>
@@ -759,6 +924,14 @@ Drug asset prices are
 	<</if>>
 	<</if>>
 <</if>>
+<<if $captureUpgradeGender != "unselected">>
+	<br>
+	<<if $captureUpgradeGender == "XX">>The corporation only retains slaves with pussies.
+		<<elseif $captureUpgradeGender == "XY">>The corporation only retains slaves with dicks.
+		<<else>>The corporation retains any promising slave regardless of whether she has a dick or a pussy.
+	<</if>>
+	<<link "Refocus">><<set $captureUpgradeGender = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
+<</if>>
 <<if $captureAssets >= 5000>>
 	<<if $captureUpgradeAge == "unselected">>
 		<br>The corporation captures enough slaves to specialize. Focus on training slaves who are
@@ -766,6 +939,14 @@ Drug asset prices are
 		| <<link "Older">><<set $captureUpgradeAge = "old">><<replace "#direction">><br><<print "You directed the corporation to retain older slaves for training.">><</replace>><</link>>
 		| <<link "No focus">><<set $captureUpgradeAge = "none">><<replace "#direction">><br><<print "You directed the corporation to retain any promising slave for training.">><</replace>><</link>>
 	<</if>>
+<</if>>
+<<if $captureUpgradeAge != "unselected">>
+	<br>
+	<<if $captureUpgradeAge == "young">>The corporation is focusing on capturing younger slaves.
+		<<elseif $captureUpgradeAge == "old">>The corporation is focusing on capturing older slaves.
+		<<else>>The corporation is not focusing on capturing slaves of any particular age.
+	<</if>>
+	<<link "Refocus">><<set $captureUpgradeAge = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
 <</if>>
 <<if $captureAssets >= 10000>>
 	<<if $captureUpgradeRace == "unselected">>
@@ -785,6 +966,13 @@ Drug asset prices are
 		| <<link "No focus">><<set $captureUpgradeRace = "none">><<replace "#direction">><br><<print "You directed the corporation to retain any promising slave for training.">><</replace>><</link>>
 	<</if>>
 <</if>>
+<<if $captureUpgradeRace != "unselected">>
+	<br>
+	<<if $captureUpgradeRace == "none">>The corporation retains any promising slave regardless of race.
+		<<else>>The corporation retains only $captureUpgradeRace slaves.
+	<</if>>
+	<<link "Refocus">><<set $captureUpgradeRace = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
+<</if>>
 <<if $trainingAssets >= 2000>>
 	<<if $trainingUpgradeAccent == "unselected">>
 		<br>The corporation has enough training expertise to specialize. Focus on linguistic training to
@@ -793,12 +981,27 @@ Drug asset prices are
 		| <<link "No training">><<set $trainingUpgradeAccent = "none">><<replace "#direction">><br><<print "You directed the corporation not to focus on linguistic training.">><</replace>><</link>>
 	<</if>>
 <</if>>
+<<if $trainingUpgradeAccent != "unselected">>
+	<br>
+	<<if $trainingUpgradeAccent == "accents">>Slaves are taught the lingua franca but are allowed to retain their accents.
+		<<elseif $trainingUpgradeAccent == "eliminate">>Slaves are taught the lingua franca until they can speak it without accent.
+		<<else>>The corporation does not expend any special effort teaching language.
+	<</if>>
+	<<link "Refocus">><<set $trainingUpgradeAccent = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
+<</if>>
 <<if $trainingAssets >= 5000>>
 	<<if $trainingUpgradeEducation == "unselected">>
 		<br>The corporation has enough training expertise to specialize. Train slaves with
 		<<link "Basic educations">><<set $trainingUpgradeEducation = "basic">><<replace "#direction">><br><<print "You directed the corporation to focus on ensuring slaves are properly educated.">><</replace>><</link>>
 		| <<link "No training">><<set $trainingUpgradeEducation = "none">><<replace "#direction">><br><<print "You directed the corporation to focus on getting slaves broken, not educated.">><</replace>><</link>>
 	<</if>>
+<</if>>
+<<if $trainingUpgradeEducation != "unselected">>
+	<br>
+	<<if $trainingUpgradeEducation == "basic">>Slaves are given basic slave education.
+		<<else>>The corporation does not waste money with slave education.
+	<</if>>
+	<<link "Refocus">><<set $trainingUpgradeEducation = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
 <</if>>
 <<if $trainingAssets >= 10000>>
 	<<if $trainingUpgradeSexEd == "unselected">>
@@ -808,12 +1011,27 @@ Drug asset prices are
 		| <<link "No training">><<set $trainingUpgradeSexEd = "none">><<replace "#direction">><br><<print "You directed the corporation to focus on getting slaves trained rather than skilled.">><</replace>><</link>>
 	<</if>>
 <</if>>
+<<if $trainingUpgradeSexEd != "unselected">>
+	<br>
+	<<if $trainingUpgradeSexEd == "competence">>Slaves are taught basic sexual skills.
+		<<elseif $trainingUpgradeSexEd == "highly skilled">>The corporation makes sure the slaves are sexually skilled.
+		<<else>>The corporation does not spend any effort in teaching the slaves sexual skills.
+	<</if>>
+	<<link "Refocus">><<set $trainingUpgradeSexEd = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
+<</if>>
 <<if $surgicalAssets >= 2000>>
 	<<if $surgicalUpgradeCosmetics == "unselected">>
 		<br>The corporation has enough surgical expertise to specialize. Straightforward cosmetic procedures should be
 		<<link "Applied">><<set $surgicalUpgradeCosmetics = "applied">><<replace "#direction">><br><<print "You directed the corporation to give slaves straightforward cosmetic surgeries.">><</replace>><</link>>
 		| <<link "Not applied">><<set $surgicalUpgradeCosmetics = "none">><<replace "#direction">><br><<print "You directed the corporation to leave slaves surgically unaltered.">><</replace>><</link>>
 	<</if>>
+<</if>>
+<<if $surgicalUpgradeCosmetics != "unselected">>
+	<br>
+	<<if $surgicalUpgradeCosmetics == "applied">>Slaves are given straightforward cosmetic surgeries before being marketed.
+		<<else>>The corporation does not bother with straightforward cosmetic surgery for slaves.
+	<</if>>
+	<<link "Refocus">><<set $surgicalUpgradeCosmetics = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
 <</if>>
 <<if $surgicalAssets >= 5000>>
 	<<if $surgicalUpgradeImplants == "unselected">>
@@ -822,6 +1040,14 @@ Drug asset prices are
 		| <<link "Absurd">><<set $surgicalUpgradeImplants = "absurd">><<replace "#direction">><br><<print "You directed the corporation to give slaves absurd implants.">><</replace>><</link>>
 		| <<link "Not applied">><<set $surgicalUpgradeImplants = "none">><<replace "#direction">><br><<print "You directed the corporation to leave slaves without implants.">><</replace>><</link>>
 	<</if>>
+<</if>>
+<<if $surgicalUpgradeImplants != "unselected">>
+	<br>
+	<<if $surgicalUpgradeImplants == "applied">>Slaves are given basic implants before being marketed.
+		<<elseif $surgicalUpgradeImplants == "applied">>Slaves are given absurd-sized implants before being marketed.
+		<<else>>The corporation does not bother with straightforward cosmetic surgery for slaves.
+	<</if>>
+	<<link "Refocus">><<set $surgicalUpgradeImplants = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
 <</if>>
 <<if $surgicalAssets >= 10000>>
 	<<if $seeDicks != 0>>
@@ -836,6 +1062,15 @@ Drug asset prices are
 	<</if>>
 	<</if>>
 <</if>>
+<<if $surgicalUpgradeGenitalia != "unselected">>
+	<br>
+	<<if $surgicalUpgradeGenitalia == "futanari">>Slaves are turned into futanari prior to market.
+		<<elseif $surgicalUpgradeGenitalia == "gelded">>Slaves are gelded prior to market.
+		<<elseif $surgicalUpgradeGenitalia == "fucknugget">>The corporation sells only mindbroken fuckdolls.
+		<<else>>The corporation leaves the slaves' genitals alone.
+	<</if>>
+	<<link "Refocus">><<set $surgicalUpgradeGenitalia = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
+<</if>>
 <<if $drugAssets >= 2000>>
 	<<if $drugUpgradeHormones == "unselected">>
 		<br>The corporation has surplus pharmaceutical fabrication to specialize. Hormones should be applied to
@@ -843,6 +1078,14 @@ Drug asset prices are
 		| <<link "Masculinize">><<set $drugUpgradeHormones = "XY">><<replace "#direction">><br><<print "You directed the corporation to treat slaves with male hormones.">><</replace>><</link>>
 		| <<link "Not applied">><<set $drugUpgradeHormones = "none">><<replace "#direction">><br><<print "You directed the corporation not to apply hormones.">><</replace>><</link>>
 	<</if>>
+<</if>>
+<<if $drugUpgradeHormones != "unselected">>
+	<br>
+	<<if $drugUpgradeHormones == "XX">>Slaves are given females hormones.
+		<<elseif $drugUpgradeHormones == "XY">>Slaves are given male hormones.
+		<<else>>The corporation does not apply any hormones to the slaves.
+	<</if>>
+	<<link "Refocus">><<set $drugUpgradeHormones = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
 <</if>>
 <<if $drugAssets >= 5000>>
 	<<if $drugUpgradeInjectionOne == "unselected">>
@@ -852,6 +1095,14 @@ Drug asset prices are
 		| <<link "Not applied">><<set $drugUpgradeInjectionOne = "none">><<replace "#direction">><br><<print "You directed the corporation not to apply growth injections.">><</replace>><</link>>
 	<</if>>
 <</if>>
+<<if $drugUpgradeInjectionOne != "unselected">>
+	<br>
+	<<if $drugUpgradeInjectionOne == "tasteful">>Growth injections are applied until slaves' assets are moderate-sized..
+		<<elseif $drugUpgradeInjectionOne == "huge">>Growth injections are applied until slaves' assets are huge.
+		<<else>>The corporation does not give the slaves any growth injections.
+	<</if>>
+	<<link "Refocus">><<set $drugUpgradeInjectionOne = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
+<</if>>
 <<if $drugAssets >= 10000>>
 	<<if $drugUpgradeInjectionTwo == "unselected">>
 		<br>The corporation has surplus pharmaceutical fabrication to specialize. Advanced growth injections should be
@@ -859,6 +1110,14 @@ Drug asset prices are
 		| <<link "Pastoral">><<set $drugUpgradeInjectionTwo = "pastoral">><<replace "#direction">><br><<print "You directed the corporation to apply growth injections focused on milk<<if $seeDicks > 0>> and cum<</if>> production.">><</replace>><</link>>
 		| <<link "Not applied">><<set $drugUpgradeInjectionTwo = "none">><<replace "#direction">><br><<print "You directed the corporation not to apply advanced growth injections.">><</replace>><</link>>
 	<</if>>
+<</if>>
+<<if $drugUpgradeInjectionTwo != "unselected">>
+	<br>
+	<<if $drugUpgradeInjectionTwo == "supermassive">>The corporation uses advanced growth injections to make the slaves' assets supermassive.
+		<<elseif $drugUpgradeInjectionTwo == "pastoral">>The corporation uses advanced growth injections to make the slaves' assets very productive.
+		<<else>>The corporation does not give the slaves advanced growth injections.
+	<</if>>
+	<<link "Refocus">><<set $drugUpgradeInjectionTwo = "unselected">><<replace "#direction">><br><<print "You direct the corporation to halt the current focus and prepare for a change in direction.">><</replace>><</link>>
 <</if>>
 
 </span>


### PR DESCRIPTION
The ability to sell a lot of corporate assets at once have been requested a couple of times. I added the Divest Half that basically sells half of a specific corporate asset. Also added the Refocus option so people who wants to change the corporate market's direction can do so. I thought about making refocusing costing 5% of the relevant corporate asset but decided that will just add complexity without adding to the game.

Please test it. I tested it and it seems to work fine, but I can't test every possible combination.