### PR TITLE
Bodymodra sorting, layout only

### DIFF
--- a/src/uncategorized/bodyModRulesAssistantSettings.tw
+++ b/src/uncategorized/bodyModRulesAssistantSettings.tw
@@ -858,21 +858,6 @@ Facial tattoos: ''
 <<RAChangeFaceTattoos>>
 <</link>>
 |
-<<link "Permanent makeup">>
-<<set $currentRule.lipsTat = "permanent makeup">>
-<<RAChangeFaceTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.lipsTat = "Asian art">>
-<<RAChangeFaceTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.lipsTat = "degradation">>
-<<RAChangeFaceTattoos>>
-<</link>>
-|
 <<link "Counting">>
 <<set $currentRule.lipsTat = "counting">>
 <<RAChangeFaceTattoos>>
@@ -888,10 +873,26 @@ Facial tattoos: ''
 <<RAChangeFaceTattoos>>
 <</link>>
 |
+<<link "Degradation">>
+<<set $currentRule.lipsTat = "degradation">>
+<<RAChangeFaceTattoos>>
+<</link>>
+|
 <<link "Bovine patterns">>
 <<set $currentRule.lipsTat = "bovine patterns">>
 <<RAChangeFaceTattoos>>
 <</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.lipsTat = "Asian art">>
+<<RAChangeFaceTattoos>>
+<</link>>
+|
+<<link "Permanent makeup">>
+<<set $currentRule.lipsTat = "permanent makeup">>
+<<RAChangeFaceTattoos>>
+<</link>>
+
 <br>
 
 Shoulder tattoos: ''
@@ -919,21 +920,6 @@ Shoulder tattoos: ''
 <<RAChangeShoulderTattoos>>
 <</link>>
 |
-<<link "Scenes">>
-<<set $currentRule.shouldersTat = "scenes">>
-<<RAChangeShoulderTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.shouldersTat = "Asian art">>
-<<RAChangeShoulderTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.shouldersTat = "degradation">>
-<<RAChangeShoulderTattoos>>
-<</link>>
-|
 <<link "Counting">>
 <<set $currentRule.shouldersTat = "counting">>
 <<RAChangeShoulderTattoos>>
@@ -948,6 +934,27 @@ Shoulder tattoos: ''
 <<set $currentRule.shouldersTat = "rude words">>
 <<RAChangeShoulderTattoos>>
 <</link>>
+|
+<<link "Degradation">>
+<<set $currentRule.shouldersTat = "degradation">>
+<<RAChangeShoulderTattoos>>
+<</link>>
+|
+<<link "Bovine patterns">>
+<<set $currentRule.shouldersTat = "bovine patterns">>
+<<RAChangeShoulderTattoos>>
+<</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.shouldersTat = "Asian art">>
+<<RAChangeShoulderTattoos>>
+<</link>>
+|
+<<link "Scenes">>
+<<set $currentRule.shouldersTat = "scenes">>
+<<RAChangeShoulderTattoos>>
+<</link>>
+
 <br>
 
 Chest tattoos: ''
@@ -976,21 +983,6 @@ Chest tattoos: ''
 <<RAChangeChestTattoos>>
 <</link>>
 |
-<<link "Scenes">>
-<<set $currentRule.boobsTat = "scenes">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.boobsTat = "Asian art">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.boobsTat = "degradation">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
 <<link "Counting">>
 <<set $currentRule.boobsTat = "counting">>
 <<RAChangeChestTattoos>>
@@ -1006,10 +998,26 @@ Chest tattoos: ''
 <<RAChangeChestTattoos>>
 <</link>>
 |
+<<link "Degradation">>
+<<set $currentRule.boobsTat = "degradation">>
+<<RAChangeChestTattoos>>
+<</link>>
+|
 <<link "Bovine patterns">>
 <<set $currentRule.boobsTat = "bovine patterns">>
 <<RAChangeChestTattoos>>
 <</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.boobsTat = "Asian art">>
+<<RAChangeChestTattoos>>
+<</link>>
+|
+<<link "Scenes">>
+<<set $currentRule.boobsTat = "scenes">>
+<<RAChangeChestTattoos>>
+<</link>>
+
 <br>
 
 Arm tattoos: ''
@@ -1037,21 +1045,6 @@ Arm tattoos: ''
 <<RAChangeArmTattoos>>
 <</link>>
 |
-<<link "Scenes">>
-<<set $currentRule.armsTat = "scenes">>
-<<RAChangeArmTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.armsTat = "Asian art">>
-<<RAChangeArmTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.armsTat = "degradation">>
-<<RAChangeArmTattoos>>
-<</link>>
-|
 <<link "Counting">>
 <<set $currentRule.armsTat = "counting">>
 <<RAChangeArmTattoos>>
@@ -1067,10 +1060,26 @@ Arm tattoos: ''
 <<RAChangeArmTattoos>>
 <</link>>
 |
+<<link "Degradation">>
+<<set $currentRule.armsTat = "degradation">>
+<<RAChangeArmTattoos>>
+<</link>>
+|
 <<link "Bovine patterns">>
 <<set $currentRule.armsTat = "bovine patterns">>
 <<RAChangeArmTattoos>>
 <</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.armsTat = "Asian art">>
+<<RAChangeArmTattoos>>
+<</link>>
+|
+<<link "Scenes">>
+<<set $currentRule.armsTat = "scenes">>
+<<RAChangeArmTattoos>>
+<</link>>
+
 <br>
 
 Upper back tattoo: ''
@@ -1098,21 +1107,6 @@ Upper back tattoo: ''
 <<RAChangeBackTattoos>>
 <</link>>
 |
-<<link "Scenes">>
-<<set $currentRule.backTat = "scenes">>
-<<RAChangeBackTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.backTat = "Asian art">>
-<<RAChangeBackTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.backTat = "degradation">>
-<<RAChangeBackTattoos>>
-<</link>>
-|
 <<link "Counting">>
 <<set $currentRule.backTat = "counting">>
 <<RAChangeBackTattoos>>
@@ -1128,10 +1122,26 @@ Upper back tattoo: ''
 <<RAChangeBackTattoos>>
 <</link>>
 |
+<<link "Degradation">>
+<<set $currentRule.backTat = "degradation">>
+<<RAChangeBackTattoos>>
+<</link>>
+|
 <<link "Bovine patterns">>
 <<set $currentRule.backTat = "bovine patterns">>
 <<RAChangeBackTattoos>>
 <</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.backTat = "Asian art">>
+<<RAChangeBackTattoos>>
+<</link>>
+|
+<<link "Scenes">>
+<<set $currentRule.backTat = "scenes">>
+<<RAChangeBackTattoos>>
+<</link>>
+
 <br>
 
 Lower back tattoo: ''
@@ -1160,21 +1170,6 @@ Lower back tattoo: ''
 <<RAChangeStampTattoos>>
 <</link>>
 |
-<<link "Scenes">>
-<<set $currentRule.stampTat = "scenes">>
-<<RAChangeStampTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.stampTat = "Asian art">>
-<<RAChangeStampTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.stampTat = "degradation">>
-<<RAChangeStampTattoos>>
-<</link>>
-|
 <<link "Counting">>
 <<set $currentRule.stampTat = "counting">>
 <<RAChangeStampTattoos>>
@@ -1190,10 +1185,26 @@ Lower back tattoo: ''
 <<RAChangeStampTattoos>>
 <</link>>
 |
+<<link "Degradation">>
+<<set $currentRule.stampTat = "degradation">>
+<<RAChangeStampTattoos>>
+<</link>>
+|
 <<link "Bovine patterns">>
 <<set $currentRule.stampTat = "bovine patterns">>
 <<RAChangeStampTattoos>>
 <</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.stampTat = "Asian art">>
+<<RAChangeStampTattoos>>
+<</link>>
+|
+<<link "Scenes">>
+<<set $currentRule.stampTat = "scenes">>
+<<RAChangeStampTattoos>>
+<</link>>
+
 <br>
 
 Abdominal tattoo: ''
@@ -1221,21 +1232,6 @@ Abdominal tattoo: ''
 <<RAChangeVaginaTattoos>>
 <</link>>
 |
-<<link "Scenes">>
-<<set $currentRule.vaginaTat = "scenes">>
-<<RAChangeVaginaTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.vaginaTat = "Asian art">>
-<<RAChangeVaginaTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.vaginaTat = "degradation">>
-<<RAChangeVaginaTattoos>>
-<</link>>
-|
 <<link "Counting">>
 <<set $currentRule.vaginaTat = "counting">>
 <<RAChangeVaginaTattoos>>
@@ -1251,8 +1247,23 @@ Abdominal tattoo: ''
 <<RAChangeVaginaTattoos>>
 <</link>>
 |
+<<link "Degradation">>
+<<set $currentRule.vaginaTat = "degradation">>
+<<RAChangeVaginaTattoos>>
+<</link>>
+|
 <<link "Bovine patterns">>
 <<set $currentRule.vaginaTat = "bovine patterns">>
+<<RAChangeVaginaTattoos>>
+<</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.vaginaTat = "Asian art">>
+<<RAChangeVaginaTattoos>>
+<</link>>
+|
+<<link "Scenes">>
+<<set $currentRule.vaginaTat = "scenes">>
 <<RAChangeVaginaTattoos>>
 <</link>>
 
@@ -1283,16 +1294,6 @@ Dick tattoo: ''
 <<RAChangeDickTattoos>>
 <</link>>
 |
-<<link "Asian art">>
-<<set $currentRule.dickTat = "Asian art">>
-<<RAChangeDickTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.dickTat = "degradation">>
-<<RAChangeDickTattoos>>
-<</link>>
-|
 <<link "Counting">>
 <<set $currentRule.dickTat = "counting">>
 <<RAChangeDickTattoos>>
@@ -1308,8 +1309,18 @@ Dick tattoo: ''
 <<RAChangeDickTattoos>>
 <</link>>
 |
+<<link "Degradation">>
+<<set $currentRule.dickTat = "degradation">>
+<<RAChangeDickTattoos>>
+<</link>>
+|
 <<link "Bovine patterns">>
 <<set $currentRule.dickTat = "bovine patterns">>
+<<RAChangeDickTattoos>>
+<</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.dickTat = "Asian art">>
 <<RAChangeDickTattoos>>
 <</link>>
 <</if>>
@@ -1342,21 +1353,6 @@ Buttock tattoos: ''
 <<RAChangeButtTattoos>>
 <</link>>
 |
-<<link "Scenes">>
-<<set $currentRule.buttTat = "scenes">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.buttTat = "Asian art">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.buttTat = "degradation">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
 <<link "Counting">>
 <<set $currentRule.buttTat = "counting">>
 <<RAChangeButtTattoos>>
@@ -1372,10 +1368,26 @@ Buttock tattoos: ''
 <<RAChangeButtTattoos>>
 <</link>>
 |
+<<link "Degradation">>
+<<set $currentRule.buttTat = "degradation">>
+<<RAChangeButtTattoos>>
+<</link>>
+|
 <<link "Bovine patterns">>
 <<set $currentRule.buttTat = "bovine patterns">>
 <<RAChangeButtTattoos>>
 <</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.buttTat = "Asian art">>
+<<RAChangeButtTattoos>>
+<</link>>
+|
+<<link "Scenes">>
+<<set $currentRule.buttTat = "scenes">>
+<<RAChangeButtTattoos>>
+<</link>>
+
 <br>
 
 Anal tattoo or bleaching: ''
@@ -1393,11 +1405,6 @@ Anal tattoo or bleaching: ''
 <<RAChangeAnusTattoos>>
 <</link>>
 |
-<<link "Bleached">>
-<<set $currentRule.anusTat = "bleached">>
-<<RAChangeAnusTattoos>>
-<</link>>
-|
 <<link "Tribal pattern">>
 <<set $currentRule.anusTat = "tribal patterns">>
 <<RAChangeAnusTattoos>>
@@ -1405,11 +1412,6 @@ Anal tattoo or bleaching: ''
 |
 <<link "Flowers">>
 <<set $currentRule.anusTat = "flowers">>
-<<RAChangeAnusTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.anusTat = "degradation">>
 <<RAChangeAnusTattoos>>
 <</link>>
 |
@@ -1428,8 +1430,18 @@ Anal tattoo or bleaching: ''
 <<RAChangeAnusTattoos>>
 <</link>>
 |
+<<link "Degradation">>
+<<set $currentRule.anusTat = "degradation">>
+<<RAChangeAnusTattoos>>
+<</link>>
+|
 <<link "Bovine patterns">>
 <<set $currentRule.anusTat = "bovine patterns">>
+<<RAChangeAnusTattoos>>
+<</link>>
+|
+<<link "Bleached">>
+<<set $currentRule.anusTat = "bleached">>
 <<RAChangeAnusTattoos>>
 <</link>>
 
@@ -1460,21 +1472,6 @@ Leg tattoos: ''
 <<RAChangeLegTattoos>>
 <</link>>
 |
-<<link "Scenes">>
-<<set $currentRule.legsTat = "scenes">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.legsTat = "Asian art">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.legsTat = "degradation">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
 <<link "Counting">>
 <<set $currentRule.legsTat = "counting">>
 <<RAChangeLegTattoos>>
@@ -1490,7 +1487,22 @@ Leg tattoos: ''
 <<RAChangeLegTattoos>>
 <</link>>
 |
+<<link "Degradation">>
+<<set $currentRule.legsTat = "degradation">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
 <<link "Bovine patterns">>
 <<set $currentRule.legsTat = "bovine patterns">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.legsTat = "Asian art">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "Scenes">>
+<<set $currentRule.legsTat = "scenes">>
 <<RAChangeLegTattoos>>
 <</link>>

--- a/src/uncategorized/bodyModRulesAssistantSettings.tw
+++ b/src/uncategorized/bodyModRulesAssistantSettings.tw
@@ -832,128 +832,6 @@ Custom brand design: <<textbox "$brandDesign" $brandDesign "Body Mod Rules Assis
 
 __Rule $r tattoos__
 <br>
-Chest tattoos: ''
-<span id = "chesttattoo">
-<<if $currentRule.boobsTat == 0>>none<<else>>$currentRule.boobsTat<</if>>.
-</span>
-'' <br>&nbsp;&nbsp;&nbsp;&nbsp;
-
-<<link "No default setting">>
-<<set $currentRule.boobsTat = "no default setting">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "None">>
-<<set $currentRule.boobsTat = 0>>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "Tribal patterns">>
-<<set $currentRule.boobsTat = "tribal patterns">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "Flowers">>
-<<set $currentRule.boobsTat = "flowers">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "Scenes">>
-<<set $currentRule.boobsTat = "scenes">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.boobsTat = "Asian art">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.boobsTat = "degradation">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "Counting">>
-<<set $currentRule.boobsTat = "counting">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "Advertisements">>
-<<set $currentRule.boobsTat = "advertisements">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "Rude words">>
-<<set $currentRule.boobsTat = "rude words">>
-<<RAChangeChestTattoos>>
-<</link>>
-|
-<<link "Bovine patterns">>
-<<set $currentRule.boobsTat = "bovine patterns">>
-<<RAChangeChestTattoos>>
-<</link>>
-<br>
-
-Buttock tattoos: ''
-<span id = "butttattoo">
-<<if $currentRule.buttTat == 0>>none<<else>>$currentRule.buttTat<</if>>.
-</span>
-'' <br>&nbsp;&nbsp;&nbsp;&nbsp;
-<<link "No default setting">>
-<<set $currentRule.buttTat = "no default setting">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "None">>
-<<set $currentRule.buttTat = 0>>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "Tribal patterns">>
-<<set $currentRule.buttTat = "tribal patterns">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "Flowers">>
-<<set $currentRule.buttTat = "flowers">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "Scenes">>
-<<set $currentRule.buttTat = "scenes">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.buttTat = "Asian art">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.buttTat = "degradation">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "Counting">>
-<<set $currentRule.buttTat = "counting">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "Advertisements">>
-<<set $currentRule.buttTat = "advertisements">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "Rude words">>
-<<set $currentRule.buttTat = "rude words">>
-<<RAChangeButtTattoos>>
-<</link>>
-|
-<<link "Bovine patterns">>
-<<set $currentRule.buttTat = "bovine patterns">>
-<<RAChangeButtTattoos>>
-<</link>>
-<br>
 
 Facial tattoos: ''
 <span id = "facetattoo">
@@ -1072,6 +950,68 @@ Shoulder tattoos: ''
 <</link>>
 <br>
 
+Chest tattoos: ''
+<span id = "chesttattoo">
+<<if $currentRule.boobsTat == 0>>none<<else>>$currentRule.boobsTat<</if>>.
+</span>
+'' <br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+<<link "No default setting">>
+<<set $currentRule.boobsTat = "no default setting">>
+<<RAChangeChestTattoos>>
+<</link>>
+|
+<<link "None">>
+<<set $currentRule.boobsTat = 0>>
+<<RAChangeChestTattoos>>
+<</link>>
+|
+<<link "Tribal patterns">>
+<<set $currentRule.boobsTat = "tribal patterns">>
+<<RAChangeChestTattoos>>
+<</link>>
+|
+<<link "Flowers">>
+<<set $currentRule.boobsTat = "flowers">>
+<<RAChangeChestTattoos>>
+<</link>>
+|
+<<link "Scenes">>
+<<set $currentRule.boobsTat = "scenes">>
+<<RAChangeChestTattoos>>
+<</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.boobsTat = "Asian art">>
+<<RAChangeChestTattoos>>
+<</link>>
+|
+<<link "Degradation">>
+<<set $currentRule.boobsTat = "degradation">>
+<<RAChangeChestTattoos>>
+<</link>>
+|
+<<link "Counting">>
+<<set $currentRule.boobsTat = "counting">>
+<<RAChangeChestTattoos>>
+<</link>>
+|
+<<link "Advertisements">>
+<<set $currentRule.boobsTat = "advertisements">>
+<<RAChangeChestTattoos>>
+<</link>>
+|
+<<link "Rude words">>
+<<set $currentRule.boobsTat = "rude words">>
+<<RAChangeChestTattoos>>
+<</link>>
+|
+<<link "Bovine patterns">>
+<<set $currentRule.boobsTat = "bovine patterns">>
+<<RAChangeChestTattoos>>
+<</link>>
+<br>
+
 Arm tattoos: ''
 <span id = "armtattoo">
 <<if $currentRule.armsTat == 0>>none<<else>>$currentRule.armsTat<</if>>.
@@ -1130,67 +1070,6 @@ Arm tattoos: ''
 <<link "Bovine patterns">>
 <<set $currentRule.armsTat = "bovine patterns">>
 <<RAChangeArmTattoos>>
-<</link>>
-<br>
-
-Leg tattoos: ''
-<span id = "legtattoo">
-<<if $currentRule.legsTat == 0>>none<<else>>$currentRule.legsTat<</if>>.
-</span>
-'' <br>&nbsp;&nbsp;&nbsp;&nbsp;
-<<link "No default setting">>
-<<set $currentRule.legsTat = "no default setting">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "None">>
-<<set $currentRule.legsTat = 0>>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "Tribal patterns">>
-<<set $currentRule.legsTat = "tribal patterns">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "Flowers">>
-<<set $currentRule.legsTat = "flowers">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "Scenes">>
-<<set $currentRule.legsTat = "scenes">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "Asian art">>
-<<set $currentRule.legsTat = "Asian art">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "Degradation">>
-<<set $currentRule.legsTat = "degradation">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "Counting">>
-<<set $currentRule.legsTat = "counting">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "Advertisements">>
-<<set $currentRule.legsTat = "advertisements">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "Rude words">>
-<<set $currentRule.legsTat = "rude words">>
-<<RAChangeLegTattoos>>
-<</link>>
-|
-<<link "Bovine patterns">>
-<<set $currentRule.legsTat = "bovine patterns">>
-<<RAChangeLegTattoos>>
 <</link>>
 <br>
 
@@ -1437,6 +1316,68 @@ Dick tattoo: ''
 
 <br>
 
+
+Buttock tattoos: ''
+<span id = "butttattoo">
+<<if $currentRule.buttTat == 0>>none<<else>>$currentRule.buttTat<</if>>.
+</span>
+'' <br>&nbsp;&nbsp;&nbsp;&nbsp;
+<<link "No default setting">>
+<<set $currentRule.buttTat = "no default setting">>
+<<RAChangeButtTattoos>>
+<</link>>
+|
+<<link "None">>
+<<set $currentRule.buttTat = 0>>
+<<RAChangeButtTattoos>>
+<</link>>
+|
+<<link "Tribal patterns">>
+<<set $currentRule.buttTat = "tribal patterns">>
+<<RAChangeButtTattoos>>
+<</link>>
+|
+<<link "Flowers">>
+<<set $currentRule.buttTat = "flowers">>
+<<RAChangeButtTattoos>>
+<</link>>
+|
+<<link "Scenes">>
+<<set $currentRule.buttTat = "scenes">>
+<<RAChangeButtTattoos>>
+<</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.buttTat = "Asian art">>
+<<RAChangeButtTattoos>>
+<</link>>
+|
+<<link "Degradation">>
+<<set $currentRule.buttTat = "degradation">>
+<<RAChangeButtTattoos>>
+<</link>>
+|
+<<link "Counting">>
+<<set $currentRule.buttTat = "counting">>
+<<RAChangeButtTattoos>>
+<</link>>
+|
+<<link "Advertisements">>
+<<set $currentRule.buttTat = "advertisements">>
+<<RAChangeButtTattoos>>
+<</link>>
+|
+<<link "Rude words">>
+<<set $currentRule.buttTat = "rude words">>
+<<RAChangeButtTattoos>>
+<</link>>
+|
+<<link "Bovine patterns">>
+<<set $currentRule.buttTat = "bovine patterns">>
+<<RAChangeButtTattoos>>
+<</link>>
+<br>
+
 Anal tattoo or bleaching: ''
 <span id = "anustattoo">
 <<if $currentRule.anusTat == 0>>none<<else>>$currentRule.anusTat<</if>>.
@@ -1490,4 +1431,66 @@ Anal tattoo or bleaching: ''
 <<link "Bovine patterns">>
 <<set $currentRule.anusTat = "bovine patterns">>
 <<RAChangeAnusTattoos>>
+<</link>>
+
+<br>
+
+Leg tattoos: ''
+<span id = "legtattoo">
+<<if $currentRule.legsTat == 0>>none<<else>>$currentRule.legsTat<</if>>.
+</span>
+'' <br>&nbsp;&nbsp;&nbsp;&nbsp;
+<<link "No default setting">>
+<<set $currentRule.legsTat = "no default setting">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "None">>
+<<set $currentRule.legsTat = 0>>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "Tribal patterns">>
+<<set $currentRule.legsTat = "tribal patterns">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "Flowers">>
+<<set $currentRule.legsTat = "flowers">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "Scenes">>
+<<set $currentRule.legsTat = "scenes">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.legsTat = "Asian art">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "Degradation">>
+<<set $currentRule.legsTat = "degradation">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "Counting">>
+<<set $currentRule.legsTat = "counting">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "Advertisements">>
+<<set $currentRule.legsTat = "advertisements">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "Rude words">>
+<<set $currentRule.legsTat = "rude words">>
+<<RAChangeLegTattoos>>
+<</link>>
+|
+<<link "Bovine patterns">>
+<<set $currentRule.legsTat = "bovine patterns">>
+<<RAChangeLegTattoos>>
 <</link>>

--- a/src/uncategorized/bodyModRulesAssistantSettings.tw
+++ b/src/uncategorized/bodyModRulesAssistantSettings.tw
@@ -375,213 +375,237 @@ Automatic branding is
 <span id = "brandtarget">
 Your preferred location for brands is the ''$brandTarget.''
 </span>
-<<link "Right buttock">>
-<<set $brandTarget = "right buttock">>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Ears:
+<<link "Left">>
+<<set $brandTarget = "left ear">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
-<<link "Right thigh">>
-<<set $brandTarget = "right thigh">>
+<<link "Right">>
+<<set $brandTarget = "right ear">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
-<<link "Right calf">>
-<<set $brandTarget = "right calf">>
+<<link "Both">>
+<<set $brandTarget = "ears">>
 <<RAChangeBrandTarget>>
 <</link>>
-|
-<<link "Right ankle">>
-<<set $brandTarget = "right ankle">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right foot">>
-<<set $brandTarget = "right foot">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left buttock">>
-<<set $brandTarget = "left buttock">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left thigh">>
-<<set $brandTarget = "left thigh">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left calf">>
-<<set $brandTarget = "left calf">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left ankle">>
-<<set $brandTarget = "left ankle">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left foot">>
-<<set $brandTarget = "left foot">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both buttocks">>
-<<set $brandTarget = "buttocks">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both thighs">>
-<<set $brandTarget = "thighs">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both calves">>
-<<set $brandTarget = "calves">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both ankles">>
-<<set $brandTarget = "ankles">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both feet">>
-<<set $brandTarget = "feet">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right breast">>
-<<set $brandTarget = "right breast">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right shoulder">>
-<<set $brandTarget = "right shoulder">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right upper arm">>
-<<set $brandTarget = "right upper arm">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right lower arm">>
-<<set $brandTarget = "right lower arm">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right wrist">>
-<<set $brandTarget = "right wrist">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right hand">>
-<<set $brandTarget = "right hand">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left breast">>
-<<set $brandTarget = "left breast">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left shoulder">>
-<<set $brandTarget = "left shoulder">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left upper arm">>
-<<set $brandTarget = "left upper arm">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left lower arm">>
-<<set $brandTarget = "left lower arm">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left wrist">>
-<<set $brandTarget = "left wrist">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left hand">>
-<<set $brandTarget = "left hand">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both breasts">>
-<<set $brandTarget = "breasts">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both shoulders">>
-<<set $brandTarget = "shoulders">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both upper arms">>
-<<set $brandTarget = "upper arms">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both lower arms">>
-<<set $brandTarget = "lower left arms">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both wrists">>
-<<set $brandTarget = "wrists">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both hands">>
-<<set $brandTarget = "hands">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Back">>
-<<set $brandTarget = "back">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Chest">>
-<<set $brandTarget = "chest">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right cheek">>
-<<set $brandTarget = "right cheek">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left cheek">>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Cheeks:
+<<link "Left">>
 <<set $brandTarget = "left cheek">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
-<<link "Both cheeks">>
-<<set $brandTarget = "cheeks">>
+<<link "Right">>
+<<set $brandTarget = "right cheek">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
+<<link "Both">>
+<<set $brandTarget = "cheeks">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Shoulders:
+<<link "Left">>
+<<set $brandTarget = "left shoulder">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right shoulder">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "shoulders">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Breasts:
+<<link "Right">>
+<<set $brandTarget = "right breast">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Left">>
+<<set $brandTarget = "left breast">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "breasts">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Arm, upper:
+<<link "Left">>
+<<set $brandTarget = "left upper arm">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right upper arm">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "upper arms">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Arm, lower:
+<<link "Left">>
+<<set $brandTarget = "left lower arm">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right lower arm">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "lower left arms">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Wrist:
+<<link "Left">>
+<<set $brandTarget = "left wrist">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right wrist">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "wrists">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Hand:
+<<link "Left">>
+<<set $brandTarget = "left hand">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right hand">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "hands">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Buttocks:
+<<link "Left">>
+<<set $brandTarget = "left buttock">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right buttock">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "buttocks">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Thigh: 
+<<link "Left">>
+<<set $brandTarget = "left thigh">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right thigh">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "thighs">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Calf: 
+<<link "Left">>
+<<set $brandTarget = "left calf">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right calf">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "calves">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Ankle: 
+<<link "Left">>
+<<set $brandTarget = "left ankle">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right ankle">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "ankles">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Feet:
+<<link "Left">>
+<<set $brandTarget = "left foot">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right foot">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "feet">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Other:
 <<link "Neck">>
 <<set $brandTarget = "neck">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
-<<link "Right ear">>
-<<set $brandTarget = "right ear">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left ear">>
-<<set $brandTarget = "left ear">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both ears">>
-<<set $brandTarget = "ears">>
+<<link "Chest">>
+<<set $brandTarget = "chest">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
@@ -594,11 +618,18 @@ Your preferred location for brands is the ''$brandTarget.''
 <<set $brandTarget = "pubic mound">>
 <<RAChangeBrandTarget>>
 <</link>>
+|
+<<link "Back">>
+<<set $brandTarget = "back">>
+<<RAChangeBrandTarget>>
+<</link>>
 <br>
 
 <span id = "branddesign">
 Your brand design is ''$brandDesign.''
 </span>
+
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
 
 <<link "Your slaving emblem">>
 <<set $brandDesign = "your personal symbol">>

--- a/src/uncategorized/bodyModification.tw
+++ b/src/uncategorized/bodyModification.tw
@@ -561,209 +561,6 @@ __Apply full-body tattoos:__
 
 <<goto "Body Modification">>
 <</link>>
-| <<link "Scenes">>
-
-<<if $activeSlave.boobsTat == 0>>
-	<<set $activeSlave.boobsTat = "scenes">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.buttTat == 0>>
-	<<set $activeSlave.buttTat = "scenes">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.vaginaTat == 0>>
-	<<set $activeSlave.vaginaTat = "scenes">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.lipsTat == 0>>
-	<<set $activeSlave.lipsTat = "permanent makeup">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if ($activeSlave.anusTat == 0)>>
-	<<set $activeSlave.anusTat = "bleached">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.shouldersTat == 0>>
-	<<set $activeSlave.shouldersTat = "scenes">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.backTat == 0>>
-	<<set $activeSlave.backTat = "scenes">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.amp != 1>>
-<<if $activeSlave.armsTat == 0>>
-	<<set $activeSlave.armsTat = "scenes">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-<<if $activeSlave.legsTat == 0>>
-	<<set $activeSlave.legsTat = "scenes">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-<</if>>
-
-<<if $activeSlave.stampTat == 0>>
-	<<set $activeSlave.stampTat = "scenes">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<goto "Body Modification">>
-<</link>>
-| <<link "Asian art">>
-
-<<if $activeSlave.boobsTat == 0>>
-	<<set $activeSlave.boobsTat = "Asian art">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.buttTat == 0>>
-	<<set $activeSlave.buttTat = "Asian art">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.vaginaTat == 0>>
-	<<set $activeSlave.vaginaTat = "Asian art">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.lipsTat == 0>>
-	<<set $activeSlave.lipsTat = "permanent makeup">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if ($activeSlave.anusTat == 0)>>
-	<<set $activeSlave.anusTat = "bleached">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.shouldersTat == 0>>
-	<<set $activeSlave.shouldersTat = "Asian art">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.backTat == 0>>
-	<<set $activeSlave.backTat = "Asian art">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.amp != 1>>
-<<if $activeSlave.armsTat == 0>>
-	<<set $activeSlave.armsTat = "Asian art">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-<<if $activeSlave.legsTat == 0>>
-	<<set $activeSlave.legsTat = "Asian art">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-<</if>>
-
-<<if $activeSlave.stampTat == 0>>
-	<<set $activeSlave.stampTat = "Asian art">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<goto "Body Modification">>
-<</link>>
-| <<link "Degradation">>
-
-<<if $activeSlave.boobsTat == 0>>
-	<<set $activeSlave.boobsTat = "degradation">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.buttTat == 0>>
-	<<set $activeSlave.buttTat = "degradation">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.vaginaTat == 0>>
-	<<set $activeSlave.vaginaTat = "degradation">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.dick > 0>>
-<<if $activeSlave.dickTat == 0>>
-	<<set $activeSlave.dickTat = "degradation">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-<</if>>
-
-<<if $activeSlave.lipsTat == 0>>
-	<<set $activeSlave.lipsTat = "degradation">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if ($activeSlave.anusTat == 0) || ($activeSlave.anusTat == "bleached")>>
-	<<set $activeSlave.anusTat = "degradation">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.shouldersTat == 0>>
-	<<set $activeSlave.shouldersTat = "degradation">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.backTat == 0>>
-	<<set $activeSlave.backTat = "degradation">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<if $activeSlave.amp != 1>>
-<<if $activeSlave.armsTat == 0>>
-	<<set $activeSlave.armsTat = "degradation">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-<<if $activeSlave.legsTat == 0>>
-	<<set $activeSlave.legsTat = "degradation">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-<</if>>
-
-<<if $activeSlave.stampTat == 0>>
-	<<set $activeSlave.stampTat = "degradation">>
-	<<set $cash -= $modCost>>
-	<<set $degradation += 1>>
-<</if>>
-
-<<goto "Body Modification">>
-<</link>>
 | <<link "Counting">>
 
 <<if $activeSlave.boobsTat == 0>>
@@ -984,7 +781,80 @@ __Apply full-body tattoos:__
 
 <<goto "Body Modification">>
 <</link>>
-| <<link "Cow patterns">>
+| <<link "Degradation">>
+
+<<if $activeSlave.boobsTat == 0>>
+	<<set $activeSlave.boobsTat = "degradation">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.buttTat == 0>>
+	<<set $activeSlave.buttTat = "degradation">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.vaginaTat == 0>>
+	<<set $activeSlave.vaginaTat = "degradation">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.dick > 0>>
+<<if $activeSlave.dickTat == 0>>
+	<<set $activeSlave.dickTat = "degradation">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+<</if>>
+
+<<if $activeSlave.lipsTat == 0>>
+	<<set $activeSlave.lipsTat = "degradation">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if ($activeSlave.anusTat == 0) || ($activeSlave.anusTat == "bleached")>>
+	<<set $activeSlave.anusTat = "degradation">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.shouldersTat == 0>>
+	<<set $activeSlave.shouldersTat = "degradation">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.backTat == 0>>
+	<<set $activeSlave.backTat = "degradation">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.amp != 1>>
+<<if $activeSlave.armsTat == 0>>
+	<<set $activeSlave.armsTat = "degradation">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+<<if $activeSlave.legsTat == 0>>
+	<<set $activeSlave.legsTat = "degradation">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+<</if>>
+
+<<if $activeSlave.stampTat == 0>>
+	<<set $activeSlave.stampTat = "degradation">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<goto "Body Modification">>
+<</link>>
+| <<link "Bovine patterns">>
 
 	<<set $activeSlave.boobsTat = "bovine patterns">>
 	<<set $cash -= $modCost>>
@@ -1039,6 +909,136 @@ __Apply full-body tattoos:__
 
 <<if $activeSlave.stampTat == 0>>
 	<<set $activeSlave.stampTat = "bovine patterns">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<goto "Body Modification">>
+<</link>>
+| <<link "Asian art">>
+
+<<if $activeSlave.boobsTat == 0>>
+	<<set $activeSlave.boobsTat = "Asian art">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.buttTat == 0>>
+	<<set $activeSlave.buttTat = "Asian art">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.vaginaTat == 0>>
+	<<set $activeSlave.vaginaTat = "Asian art">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.lipsTat == 0>>
+	<<set $activeSlave.lipsTat = "permanent makeup">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if ($activeSlave.anusTat == 0)>>
+	<<set $activeSlave.anusTat = "bleached">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.shouldersTat == 0>>
+	<<set $activeSlave.shouldersTat = "Asian art">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.backTat == 0>>
+	<<set $activeSlave.backTat = "Asian art">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.amp != 1>>
+<<if $activeSlave.armsTat == 0>>
+	<<set $activeSlave.armsTat = "Asian art">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+<<if $activeSlave.legsTat == 0>>
+	<<set $activeSlave.legsTat = "Asian art">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+<</if>>
+
+<<if $activeSlave.stampTat == 0>>
+	<<set $activeSlave.stampTat = "Asian art">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<goto "Body Modification">>
+<</link>>
+| <<link "Scenes">>
+
+<<if $activeSlave.boobsTat == 0>>
+	<<set $activeSlave.boobsTat = "scenes">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.buttTat == 0>>
+	<<set $activeSlave.buttTat = "scenes">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.vaginaTat == 0>>
+	<<set $activeSlave.vaginaTat = "scenes">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.lipsTat == 0>>
+	<<set $activeSlave.lipsTat = "permanent makeup">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if ($activeSlave.anusTat == 0)>>
+	<<set $activeSlave.anusTat = "bleached">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.shouldersTat == 0>>
+	<<set $activeSlave.shouldersTat = "scenes">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.backTat == 0>>
+	<<set $activeSlave.backTat = "scenes">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+
+<<if $activeSlave.amp != 1>>
+<<if $activeSlave.armsTat == 0>>
+	<<set $activeSlave.armsTat = "scenes">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+<<if $activeSlave.legsTat == 0>>
+	<<set $activeSlave.legsTat = "scenes">>
+	<<set $cash -= $modCost>>
+	<<set $degradation += 1>>
+<</if>>
+<</if>>
+
+<<if $activeSlave.stampTat == 0>>
+	<<set $activeSlave.stampTat = "scenes">>
 	<<set $cash -= $modCost>>
 	<<set $degradation += 1>>
 <</if>>

--- a/src/uncategorized/bodyModification.tw
+++ b/src/uncategorized/bodyModification.tw
@@ -1048,49 +1048,6 @@ __Apply full-body tattoos:__
 <br>
 <</if>>
 
-<<if $activeSlave.boobsTat == 0>>
-	$possessiveCap chest and breasts are not tattooed.
-<<else>>
-	$possessiveCap chest and breasts are tattooed with $activeSlave.boobsTat.
-<</if>>
-<<if $activeSlave.boobsTat == 0>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	[[Tribal patterns|Body Modification][$activeSlave.boobsTat = "tribal patterns",$cash -= $modCost]]
-	 | [[Flowers|Body Modification][$activeSlave.boobsTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.boobsTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.boobsTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.boobsTat = "degradation",$cash -= $modCost,$degradation += 1]]
-	 | [[Counting|Body Modification][$activeSlave.boobsTat = "counting",$cash -= $modCost,$degradation += 1]]
-	 | [[Advertisements|Body Modification][$activeSlave.boobsTat = "advertisements",$cash -= $modCost,$degradation += 1]]
-	 | [[Rude words|Body Modification][$activeSlave.boobsTat = "rude words",$cash -= $modCost,$degradation += 1]]
-<</if>>
-<<if $activeSlave.boobsTat != 0>>
-	//[[Remove tattoos|Body Modification][$activeSlave.boobsTat = 0,$cash -= $modCost]]//
-<</if>>
-
-<br>
-<<if $activeSlave.buttTat == 0>>
-	$possessiveCap buttocks are not tattooed.
-<<else>>
-	$possessiveCap buttocks are tattooed with $activeSlave.buttTat.
-<</if>>
-<<if $activeSlave.buttTat == 0>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	[[Tribal patterns|Body Modification][$activeSlave.buttTat = "tribal patterns",$cash -= $modCost]]
-	 | [[Flowers|Body Modification][$activeSlave.buttTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.buttTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.buttTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.buttTat = "degradation",$cash -= $modCost,$degradation += 1]]
-	 | [[Counting|Body Modification][$activeSlave.buttTat = "counting",$cash -= $modCost,$degradation += 1]]
-	 | [[Advertisements|Body Modification][$activeSlave.buttTat = "advertisements",$cash -= $modCost,$degradation += 1]]
-	 | [[Rude words|Body Modification][$activeSlave.buttTat = "rude words",$cash -= $modCost,$degradation += 1]]
-<</if>>
-<<if $activeSlave.buttTat != 0>>
-	//[[Remove tattoos|Body Modification][$activeSlave.buttTat = 0,$cash -= $modCost]]//
-<</if>>
-
-<br>
-
 <<if $activeSlave.lipsTat == 0>>
 	$pronounCap has no facial tattoos.
 <<else>>
@@ -1134,24 +1091,24 @@ __Apply full-body tattoos:__
 
 <br>
 
-<<if $activeSlave.backTat == 0>>
-	$pronounCap has no back tattoo.
+<<if $activeSlave.boobsTat == 0>>
+	$possessiveCap chest and breasts are not tattooed.
 <<else>>
-	$possessiveCap back is tattooed with $activeSlave.backTat.
+	$possessiveCap chest and breasts are tattooed with $activeSlave.boobsTat.
 <</if>>
-<<if $activeSlave.backTat == 0>>
+<<if $activeSlave.boobsTat == 0>>
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	[[Tribal patterns|Body Modification][$activeSlave.backTat = "tribal patterns",$cash -= $modCost]]
-	 | [[Flowers|Body Modification][$activeSlave.backTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.backTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.backTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.backTat = "degradation",$cash -= $modCost,$degradation += 1]]
-	 | [[Counting|Body Modification][$activeSlave.backTat = "counting",$cash -= $modCost,$degradation += 1]]
-	 | [[Advertisements|Body Modification][$activeSlave.backTat = "advertisements",$cash -= $modCost,$degradation += 1]]
-	 | [[Rude words|Body Modification][$activeSlave.backTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	[[Tribal patterns|Body Modification][$activeSlave.boobsTat = "tribal patterns",$cash -= $modCost]]
+	 | [[Flowers|Body Modification][$activeSlave.boobsTat = "flowers",$cash -= $modCost]]
+	 | [[Scenes|Body Modification][$activeSlave.boobsTat = "scenes",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.boobsTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.boobsTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Counting|Body Modification][$activeSlave.boobsTat = "counting",$cash -= $modCost,$degradation += 1]]
+	 | [[Advertisements|Body Modification][$activeSlave.boobsTat = "advertisements",$cash -= $modCost,$degradation += 1]]
+	 | [[Rude words|Body Modification][$activeSlave.boobsTat = "rude words",$cash -= $modCost,$degradation += 1]]
 <</if>>
-<<if $activeSlave.backTat != 0>>
-	//[[Remove tattoos|Body Modification][$activeSlave.backTat = 0,$cash -= $modCost]]//
+<<if $activeSlave.boobsTat != 0>>
+	//[[Remove tattoos|Body Modification][$activeSlave.boobsTat = 0,$cash -= $modCost]]//
 <</if>>
 
 <br>
@@ -1180,26 +1137,24 @@ __Apply full-body tattoos:__
 
 <br>
 
-<<if $activeSlave.amp != 1>>
-<<if $activeSlave.legsTat == 0>>
-	$pronounCap has no leg tattoos.
+<<if $activeSlave.backTat == 0>>
+	$pronounCap has no back tattoo.
 <<else>>
-	$possessiveCap <<if $activeSlave.amp < 0>>prosthetic <</if>>legs are <<if $activeSlave.amp < 0>>indelibly marked<<else>>tattooed<</if>> with $activeSlave.legsTat.
+	$possessiveCap back is tattooed with $activeSlave.backTat.
 <</if>>
-<<if $activeSlave.legsTat == 0>>
+<<if $activeSlave.backTat == 0>>
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	[[Tribal patterns|Body Modification][$activeSlave.legsTat = "tribal patterns",$cash -= $modCost]]
-	 | [[Flowers|Body Modification][$activeSlave.legsTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.legsTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.legsTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.legsTat = "degradation",$cash -= $modCost,$degradation += 1]]
-	 | [[Counting|Body Modification][$activeSlave.legsTat = "counting",$cash -= $modCost,$degradation += 1]]
-	 | [[Advertisements|Body Modification][$activeSlave.legsTat = "advertisements",$cash -= $modCost,$degradation += 1]]
-	 | [[Rude words|Body Modification][$activeSlave.legsTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	[[Tribal patterns|Body Modification][$activeSlave.backTat = "tribal patterns",$cash -= $modCost]]
+	 | [[Flowers|Body Modification][$activeSlave.backTat = "flowers",$cash -= $modCost]]
+	 | [[Scenes|Body Modification][$activeSlave.backTat = "scenes",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.backTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.backTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Counting|Body Modification][$activeSlave.backTat = "counting",$cash -= $modCost,$degradation += 1]]
+	 | [[Advertisements|Body Modification][$activeSlave.backTat = "advertisements",$cash -= $modCost,$degradation += 1]]
+	 | [[Rude words|Body Modification][$activeSlave.backTat = "rude words",$cash -= $modCost,$degradation += 1]]
 <</if>>
-<<if $activeSlave.legsTat != 0>>
-	//[[Remove tattoos|Body Modification][$activeSlave.legsTat = 0,$cash -= $modCost]]//
-<</if>>
+<<if $activeSlave.backTat != 0>>
+	//[[Remove tattoos|Body Modification][$activeSlave.backTat = 0,$cash -= $modCost]]//
 <</if>>
 
 <br>
@@ -1269,6 +1224,28 @@ __Apply full-body tattoos:__
 
 <br>
 
+<<if $activeSlave.buttTat == 0>>
+	$possessiveCap buttocks are not tattooed.
+<<else>>
+	$possessiveCap buttocks are tattooed with $activeSlave.buttTat.
+<</if>>
+<<if $activeSlave.buttTat == 0>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	[[Tribal patterns|Body Modification][$activeSlave.buttTat = "tribal patterns",$cash -= $modCost]]
+	 | [[Flowers|Body Modification][$activeSlave.buttTat = "flowers",$cash -= $modCost]]
+	 | [[Scenes|Body Modification][$activeSlave.buttTat = "scenes",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.buttTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.buttTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Counting|Body Modification][$activeSlave.buttTat = "counting",$cash -= $modCost,$degradation += 1]]
+	 | [[Advertisements|Body Modification][$activeSlave.buttTat = "advertisements",$cash -= $modCost,$degradation += 1]]
+	 | [[Rude words|Body Modification][$activeSlave.buttTat = "rude words",$cash -= $modCost,$degradation += 1]]
+<</if>>
+<<if $activeSlave.buttTat != 0>>
+	//[[Remove tattoos|Body Modification][$activeSlave.buttTat = 0,$cash -= $modCost]]//
+<</if>>
+
+<br>
+
 <<if $activeSlave.anusTat == 0>>
 	$possessiveCap anus is brown and unbleached.
 <<elseif $activeSlave.anusTat == "bleached">>
@@ -1289,6 +1266,30 @@ __Apply full-body tattoos:__
 <</if>>
 <<if ($activeSlave.anusTat != 0) && ($activeSlave.anusTat != "bleached")>>
 	//[[Remove tattoo|Body Modification][$activeSlave.anusTat = "bleached",$cash -= $modCost]]//
+<</if>>
+
+<br>
+
+<<if $activeSlave.amp != 1>>
+<<if $activeSlave.legsTat == 0>>
+	$pronounCap has no leg tattoos.
+<<else>>
+	$possessiveCap <<if $activeSlave.amp < 0>>prosthetic <</if>>legs are <<if $activeSlave.amp < 0>>indelibly marked<<else>>tattooed<</if>> with $activeSlave.legsTat.
+<</if>>
+<<if $activeSlave.legsTat == 0>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	[[Tribal patterns|Body Modification][$activeSlave.legsTat = "tribal patterns",$cash -= $modCost]]
+	 | [[Flowers|Body Modification][$activeSlave.legsTat = "flowers",$cash -= $modCost]]
+	 | [[Scenes|Body Modification][$activeSlave.legsTat = "scenes",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.legsTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.legsTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Counting|Body Modification][$activeSlave.legsTat = "counting",$cash -= $modCost,$degradation += 1]]
+	 | [[Advertisements|Body Modification][$activeSlave.legsTat = "advertisements",$cash -= $modCost,$degradation += 1]]
+	 | [[Rude words|Body Modification][$activeSlave.legsTat = "rude words",$cash -= $modCost,$degradation += 1]]
+<</if>>
+<<if $activeSlave.legsTat != 0>>
+	//[[Remove tattoos|Body Modification][$activeSlave.legsTat = 0,$cash -= $modCost]]//
+<</if>>
 <</if>>
 
 <br>

--- a/src/uncategorized/bodyModification.tw
+++ b/src/uncategorized/bodyModification.tw
@@ -1057,11 +1057,11 @@ __Apply full-body tattoos:__
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	[[Tribal patterns|Body Modification][$activeSlave.lipsTat = "tribal patterns",$cash -= $modCost]]
 	 | [[Flowers|Body Modification][$activeSlave.lipsTat = "flowers",$cash -= $modCost]]
-	 | [[Permanent makeup|Body Modification][$activeSlave.lipsTat = "permanent makeup",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.lipsTat = "degradation",$cash -= $modCost,$degradation += 1]]
 	 | [[Counting|Body Modification][$activeSlave.lipsTat = "counting",$cash -= $modCost,$degradation += 1]]
 	 | [[Advertisements|Body Modification][$activeSlave.lipsTat = "advertisements",$cash -= $modCost,$degradation += 1]]
 	 | [[Rude words|Body Modification][$activeSlave.lipsTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.lipsTat = "degradation",$cash -= $modCost,$degradation += 1]]
+ 	 | [[Permanent makeup|Body Modification][$activeSlave.lipsTat = "permanent makeup",$cash -= $modCost,$degradation += 1]]
 <</if>>
 <<if $activeSlave.lipsTat != 0>>
 	//[[Remove tattoos|Body Modification][$activeSlave.lipsTat = 0,$cash -= $modCost]]//
@@ -1078,12 +1078,13 @@ __Apply full-body tattoos:__
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	[[Tribal patterns|Body Modification][$activeSlave.shouldersTat = "tribal patterns",$cash -= $modCost]]
 	 | [[Flowers|Body Modification][$activeSlave.shouldersTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.shouldersTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.shouldersTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.shouldersTat = "degradation",$cash -= $modCost,$degradation += 1]]
 	 | [[Counting|Body Modification][$activeSlave.shouldersTat = "counting",$cash -= $modCost,$degradation += 1]]
 	 | [[Advertisements|Body Modification][$activeSlave.shouldersTat = "advertisements",$cash -= $modCost,$degradation += 1]]
 	 | [[Rude words|Body Modification][$activeSlave.shouldersTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.shouldersTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.shouldersTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Scenes|Body Modification][$activeSlave.shouldersTat = "scenes",$cash -= $modCost,$degradation += 1]]
+
 <</if>>
 <<if $activeSlave.shouldersTat != 0>>
 	//[[Remove tattoos|Body Modification][$activeSlave.shouldersTat = 0,$cash -= $modCost]]//
@@ -1100,12 +1101,12 @@ __Apply full-body tattoos:__
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	[[Tribal patterns|Body Modification][$activeSlave.boobsTat = "tribal patterns",$cash -= $modCost]]
 	 | [[Flowers|Body Modification][$activeSlave.boobsTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.boobsTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.boobsTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.boobsTat = "degradation",$cash -= $modCost,$degradation += 1]]
 	 | [[Counting|Body Modification][$activeSlave.boobsTat = "counting",$cash -= $modCost,$degradation += 1]]
 	 | [[Advertisements|Body Modification][$activeSlave.boobsTat = "advertisements",$cash -= $modCost,$degradation += 1]]
 	 | [[Rude words|Body Modification][$activeSlave.boobsTat = "rude words",$cash -= $modCost,$degradation += 1]]
+ 	 | [[Degradation|Body Modification][$activeSlave.boobsTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.boobsTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Scenes|Body Modification][$activeSlave.boobsTat = "scenes",$cash -= $modCost,$degradation += 1]]
 <</if>>
 <<if $activeSlave.boobsTat != 0>>
 	//[[Remove tattoos|Body Modification][$activeSlave.boobsTat = 0,$cash -= $modCost]]//
@@ -1123,12 +1124,12 @@ __Apply full-body tattoos:__
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	[[Tribal patterns|Body Modification][$activeSlave.armsTat = "tribal patterns",$cash -= $modCost]]
 	 | [[Flowers|Body Modification][$activeSlave.armsTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.armsTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.armsTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.armsTat = "degradation",$cash -= $modCost,$degradation += 1]]
 	 | [[Counting|Body Modification][$activeSlave.armsTat = "counting",$cash -= $modCost,$degradation += 1]]
 	 | [[Advertisements|Body Modification][$activeSlave.armsTat = "advertisements",$cash -= $modCost,$degradation += 1]]
 	 | [[Rude words|Body Modification][$activeSlave.armsTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.armsTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.armsTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Scenes|Body Modification][$activeSlave.armsTat = "scenes",$cash -= $modCost,$degradation += 1]]
 <</if>>
 <<if $activeSlave.armsTat != 0>>
 	//[[Remove tattoos|Body Modification][$activeSlave.armsTat = 0,$cash -= $modCost]]//
@@ -1146,12 +1147,12 @@ __Apply full-body tattoos:__
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	[[Tribal patterns|Body Modification][$activeSlave.backTat = "tribal patterns",$cash -= $modCost]]
 	 | [[Flowers|Body Modification][$activeSlave.backTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.backTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.backTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.backTat = "degradation",$cash -= $modCost,$degradation += 1]]
 	 | [[Counting|Body Modification][$activeSlave.backTat = "counting",$cash -= $modCost,$degradation += 1]]
 	 | [[Advertisements|Body Modification][$activeSlave.backTat = "advertisements",$cash -= $modCost,$degradation += 1]]
 	 | [[Rude words|Body Modification][$activeSlave.backTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.backTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.backTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Scenes|Body Modification][$activeSlave.backTat = "scenes",$cash -= $modCost,$degradation += 1]]		 
 <</if>>
 <<if $activeSlave.backTat != 0>>
 	//[[Remove tattoos|Body Modification][$activeSlave.backTat = 0,$cash -= $modCost]]//
@@ -1168,12 +1169,13 @@ __Apply full-body tattoos:__
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	[[Tribal patterns|Body Modification][$activeSlave.stampTat = "tribal patterns",$cash -= $modCost]]
 	 | [[Flowers|Body Modification][$activeSlave.stampTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.stampTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.stampTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.stampTat = "degradation",$cash -= $modCost,$degradation += 1]]
 	 | [[Counting|Body Modification][$activeSlave.stampTat = "counting",$cash -= $modCost,$degradation += 1]]
 	 | [[Advertisements|Body Modification][$activeSlave.stampTat = "advertisements",$cash -= $modCost,$degradation += 1]]
 	 | [[Rude words|Body Modification][$activeSlave.stampTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.stampTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.stampTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Scenes|Body Modification][$activeSlave.stampTat = "scenes",$cash -= $modCost,$degradation += 1]]
+
 <</if>>
 <<if $activeSlave.stampTat != 0>>
 	//[[Remove tattoos|Body Modification][$activeSlave.stampTat = 0,$cash -= $modCost]]//
@@ -1190,12 +1192,12 @@ __Apply full-body tattoos:__
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	[[Tribal patterns|Body Modification][$activeSlave.vaginaTat = "tribal patterns",$cash -= $modCost]]
 	 | [[Flowers|Body Modification][$activeSlave.vaginaTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.vaginaTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.vaginaTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.vaginaTat = "degradation",$cash -= $modCost,$degradation += 1]]
 	 | [[Counting|Body Modification][$activeSlave.vaginaTat = "counting",$cash -= $modCost,$degradation += 1]]
 	 | [[Advertisements|Body Modification][$activeSlave.vaginaTat = "advertisements",$cash -= $modCost,$degradation += 1]]
 	 | [[Rude words|Body Modification][$activeSlave.vaginaTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.vaginaTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.vaginaTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Scenes|Body Modification][$activeSlave.vaginaTat = "scenes",$cash -= $modCost,$degradation += 1]]
 <</if>>
 <<if $activeSlave.vaginaTat != 0>>
 	//[[Remove tattoos|Body Modification][$activeSlave.vaginaTat = 0,$cash -= $modCost]]//
@@ -1212,10 +1214,10 @@ __Apply full-body tattoos:__
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	[[Tribal patterns|Body Modification][$activeSlave.dickTat = "tribal patterns",$cash -= $modCost]]
 	 | [[Flowers|Body Modification][$activeSlave.dickTat = "flowers",$cash -= $modCost]]
-	 | [[Degradation|Body Modification][$activeSlave.dickTat = "degradation",$cash -= $modCost,$degradation += 1]]
 	 | [[Counting|Body Modification][$activeSlave.dickTat = "counting",$cash -= $modCost,$degradation += 1]]
 	 | [[Advertisements|Body Modification][$activeSlave.dickTat = "advertisements",$cash -= $modCost,$degradation += 1]]
 	 | [[Rude words|Body Modification][$activeSlave.dickTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.dickTat = "degradation",$cash -= $modCost,$degradation += 1]]
 <</if>>
 <<if $activeSlave.dickTat != 0>>
 	//[[Remove tattoos|Body Modification][$activeSlave.dickTat = 0,$cash -= $modCost]]//
@@ -1233,12 +1235,12 @@ __Apply full-body tattoos:__
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	[[Tribal patterns|Body Modification][$activeSlave.buttTat = "tribal patterns",$cash -= $modCost]]
 	 | [[Flowers|Body Modification][$activeSlave.buttTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.buttTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.buttTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.buttTat = "degradation",$cash -= $modCost,$degradation += 1]]
 	 | [[Counting|Body Modification][$activeSlave.buttTat = "counting",$cash -= $modCost,$degradation += 1]]
 	 | [[Advertisements|Body Modification][$activeSlave.buttTat = "advertisements",$cash -= $modCost,$degradation += 1]]
 	 | [[Rude words|Body Modification][$activeSlave.buttTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.buttTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.buttTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Scenes|Body Modification][$activeSlave.buttTat = "scenes",$cash -= $modCost,$degradation += 1]]
 <</if>>
 <<if $activeSlave.buttTat != 0>>
 	//[[Remove tattoos|Body Modification][$activeSlave.buttTat = 0,$cash -= $modCost]]//
@@ -1259,10 +1261,10 @@ __Apply full-body tattoos:__
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	[[Tribal pattern|Body Modification][$activeSlave.anusTat = "tribal patterns",$cash -= $modCost,$degradation += 1]]
 	 | [[Flowers|Body Modification][$activeSlave.anusTat = "flowers",$cash -= $modCost]]
-	 | [[Degradation|Body Modification][$activeSlave.anusTat = "degradation",$cash -= $modCost,$degradation += 1]]
 	 | [[Counting|Body Modification][$activeSlave.anusTat = "counting",$cash -= $modCost,$degradation += 1]]
 	 | [[Advertisements|Body Modification][$activeSlave.anusTat = "advertisements",$cash -= $modCost,$degradation += 1]]
 	 | [[Rude words|Body Modification][$activeSlave.anusTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.anusTat = "degradation",$cash -= $modCost,$degradation += 1]]
 <</if>>
 <<if ($activeSlave.anusTat != 0) && ($activeSlave.anusTat != "bleached")>>
 	//[[Remove tattoo|Body Modification][$activeSlave.anusTat = "bleached",$cash -= $modCost]]//
@@ -1280,12 +1282,12 @@ __Apply full-body tattoos:__
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	[[Tribal patterns|Body Modification][$activeSlave.legsTat = "tribal patterns",$cash -= $modCost]]
 	 | [[Flowers|Body Modification][$activeSlave.legsTat = "flowers",$cash -= $modCost]]
-	 | [[Scenes|Body Modification][$activeSlave.legsTat = "scenes",$cash -= $modCost,$degradation += 1]]
-	 | [[Asian art|Body Modification][$activeSlave.legsTat = "Asian art",$cash -= $modCost,$degradation += 1]]
-	 | [[Degradation|Body Modification][$activeSlave.legsTat = "degradation",$cash -= $modCost,$degradation += 1]]
 	 | [[Counting|Body Modification][$activeSlave.legsTat = "counting",$cash -= $modCost,$degradation += 1]]
 	 | [[Advertisements|Body Modification][$activeSlave.legsTat = "advertisements",$cash -= $modCost,$degradation += 1]]
 	 | [[Rude words|Body Modification][$activeSlave.legsTat = "rude words",$cash -= $modCost,$degradation += 1]]
+	 | [[Degradation|Body Modification][$activeSlave.legsTat = "degradation",$cash -= $modCost,$degradation += 1]]
+	 | [[Asian art|Body Modification][$activeSlave.legsTat = "Asian art",$cash -= $modCost,$degradation += 1]]
+	 | [[Scenes|Body Modification][$activeSlave.legsTat = "scenes",$cash -= $modCost,$degradation += 1]]
 <</if>>
 <<if $activeSlave.legsTat != 0>>
 	//[[Remove tattoos|Body Modification][$activeSlave.legsTat = 0,$cash -= $modCost]]//


### PR DESCRIPTION
Went with the cleaner "Ears: Left | Right | Both" format instead of the ol' wall of text. Should be easier to parse and hey, now they match.

Also modRA matches autoMod now for order of tattoo areas, and they are in the same 'head to toe'  order that the brand locations from the same page have.