### PR TITLE
Auto salon appearance tweaks

### DIFF
--- a/src/uncategorized/bodyModRulesAssistantSettings.tw
+++ b/src/uncategorized/bodyModRulesAssistantSettings.tw
@@ -375,213 +375,237 @@ Automatic branding is
 <span id = "brandtarget">
 Your preferred location for brands is the ''$brandTarget.''
 </span>
-<<link "Right buttock">>
-<<set $brandTarget = "right buttock">>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Ears:
+<<link "Left">>
+<<set $brandTarget = "left ear">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
-<<link "Right thigh">>
-<<set $brandTarget = "right thigh">>
+<<link "Right">>
+<<set $brandTarget = "right ear">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
-<<link "Right calf">>
-<<set $brandTarget = "right calf">>
+<<link "Both">>
+<<set $brandTarget = "ears">>
 <<RAChangeBrandTarget>>
 <</link>>
-|
-<<link "Right ankle">>
-<<set $brandTarget = "right ankle">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right foot">>
-<<set $brandTarget = "right foot">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left buttock">>
-<<set $brandTarget = "left buttock">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left thigh">>
-<<set $brandTarget = "left thigh">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left calf">>
-<<set $brandTarget = "left calf">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left ankle">>
-<<set $brandTarget = "left ankle">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left foot">>
-<<set $brandTarget = "left foot">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both buttocks">>
-<<set $brandTarget = "buttocks">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both thighs">>
-<<set $brandTarget = "thighs">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both calves">>
-<<set $brandTarget = "calves">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both ankles">>
-<<set $brandTarget = "ankles">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both feet">>
-<<set $brandTarget = "feet">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right breast">>
-<<set $brandTarget = "right breast">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right shoulder">>
-<<set $brandTarget = "right shoulder">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right upper arm">>
-<<set $brandTarget = "right upper arm">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right lower arm">>
-<<set $brandTarget = "right lower arm">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right wrist">>
-<<set $brandTarget = "right wrist">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right hand">>
-<<set $brandTarget = "right hand">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left breast">>
-<<set $brandTarget = "left breast">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left shoulder">>
-<<set $brandTarget = "left shoulder">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left upper arm">>
-<<set $brandTarget = "left upper arm">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left lower arm">>
-<<set $brandTarget = "left lower arm">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left wrist">>
-<<set $brandTarget = "left wrist">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left hand">>
-<<set $brandTarget = "left hand">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both breasts">>
-<<set $brandTarget = "breasts">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both shoulders">>
-<<set $brandTarget = "shoulders">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both upper arms">>
-<<set $brandTarget = "upper arms">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both lower arms">>
-<<set $brandTarget = "lower left arms">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both wrists">>
-<<set $brandTarget = "wrists">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both hands">>
-<<set $brandTarget = "hands">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Back">>
-<<set $brandTarget = "back">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Chest">>
-<<set $brandTarget = "chest">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Right cheek">>
-<<set $brandTarget = "right cheek">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left cheek">>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Cheeks:
+<<link "Left">>
 <<set $brandTarget = "left cheek">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
-<<link "Both cheeks">>
-<<set $brandTarget = "cheeks">>
+<<link "Right">>
+<<set $brandTarget = "right cheek">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
+<<link "Both">>
+<<set $brandTarget = "cheeks">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Shoulders:
+<<link "Left">>
+<<set $brandTarget = "left shoulder">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right shoulder">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "shoulders">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Breasts:
+<<link "Right">>
+<<set $brandTarget = "right breast">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Left">>
+<<set $brandTarget = "left breast">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "breasts">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Arm, upper:
+<<link "Left">>
+<<set $brandTarget = "left upper arm">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right upper arm">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "upper arms">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Arm, lower:
+<<link "Left">>
+<<set $brandTarget = "left lower arm">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right lower arm">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "lower left arms">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Wrist:
+<<link "Left">>
+<<set $brandTarget = "left wrist">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right wrist">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "wrists">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Hand:
+<<link "Left">>
+<<set $brandTarget = "left hand">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right hand">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "hands">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Buttocks:
+<<link "Left">>
+<<set $brandTarget = "left buttock">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right buttock">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "buttocks">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Thigh: 
+<<link "Left">>
+<<set $brandTarget = "left thigh">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right thigh">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "thighs">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Calf: 
+<<link "Left">>
+<<set $brandTarget = "left calf">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right calf">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "calves">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Ankle: 
+<<link "Left">>
+<<set $brandTarget = "left ankle">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right ankle">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "ankles">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Feet:
+<<link "Left">>
+<<set $brandTarget = "left foot">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Right">>
+<<set $brandTarget = "right foot">>
+<<RAChangeBrandTarget>>
+<</link>>
+|
+<<link "Both">>
+<<set $brandTarget = "feet">>
+<<RAChangeBrandTarget>>
+<</link>>
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+
+Other:
 <<link "Neck">>
 <<set $brandTarget = "neck">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
-<<link "Right ear">>
-<<set $brandTarget = "right ear">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Left ear">>
-<<set $brandTarget = "left ear">>
-<<RAChangeBrandTarget>>
-<</link>>
-|
-<<link "Both ears">>
-<<set $brandTarget = "ears">>
+<<link "Chest">>
+<<set $brandTarget = "chest">>
 <<RAChangeBrandTarget>>
 <</link>>
 |
@@ -594,11 +618,18 @@ Your preferred location for brands is the ''$brandTarget.''
 <<set $brandTarget = "pubic mound">>
 <<RAChangeBrandTarget>>
 <</link>>
+|
+<<link "Back">>
+<<set $brandTarget = "back">>
+<<RAChangeBrandTarget>>
+<</link>>
 <br>
 
 <span id = "branddesign">
 Your brand design is ''$brandDesign.''
 </span>
+
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
 
 <<link "Your slaving emblem">>
 <<set $brandDesign = "your personal symbol">>

--- a/src/uncategorized/salon.tw
+++ b/src/uncategorized/salon.tw
@@ -139,12 +139,14 @@ $activeSlave.slaveName is seated in the auto salon. $pronounCap is awaiting your
 
 [[Nice makeup|Salon][$activeSlave.makeup = 1,$cash -= $modCost]]
 | [[Gorgeous makeup|Salon][$activeSlave.makeup = 2,$cash -= $modCost]]
-| [[Color-coordinate makeup with hair|Salon][$activeSlave.makeup = 3,$cash -= $modCost]]
-| [[Neon makeup|Salon][$activeSlave.makeup = 5,$cash -= $modCost]]
-| [[Color-coordinate neon makeup with hair|Salon][$activeSlave.makeup = 6,$cash -= $modCost]]
-| [[Metallic makeup|Salon][$activeSlave.makeup = 7,$cash -= $modCost]]
-| [[Color-coordinate metallic makeup with hair|Salon][$activeSlave.makeup = 8,$cash -= $modCost]]
 | [[Slutty makeup|Salon][$activeSlave.makeup = 4,$cash -= $modCost]]
+| [[Color-coordinate makeup with hair|Salon][$activeSlave.makeup = 3,$cash -= $modCost]]
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+[[Neon makeup|Salon][$activeSlave.makeup = 5,$cash -= $modCost]]
+| [[Color-coordinate neon makeup with hair|Salon][$activeSlave.makeup = 6,$cash -= $modCost]]
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+[[Metallic makeup|Salon][$activeSlave.makeup = 7,$cash -= $modCost]]
+| [[Color-coordinate metallic makeup with hair|Salon][$activeSlave.makeup = 8,$cash -= $modCost]]
 
 
 /* NAILS */
@@ -174,21 +176,21 @@ $activeSlave.slaveName is seated in the auto salon. $pronounCap is awaiting your
 	$possessiveCap nails are neatly clipped.
 <</if>>
 
-<br>&nbsp;&nbsp;&nbsp;&nbsp;
 
 <<if $activeSlave.amp != 1>>
-
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
 [[Clip nails|Salon][$activeSlave.nails = 0,$cash -= $modCost]]
 | [[Extend nails|Salon][$activeSlave.nails = 1,$cash -= $modCost]]
-| [[Color-coordinate nails with hair|Salon][$activeSlave.nails = 2,$cash -= $modCost]]
 | [[Sharp, claw-like nails|Salon][$activeSlave.nails = 3,$cash -= $modCost]]
 | [[Bright, glittery nails|Salon][$activeSlave.nails = 4,$cash -= $modCost]]
-| [[Vivid, neon nails|Salon][$activeSlave.nails = 6,$cash -= $modCost]]
-| [[Color-coordinate neon nails with hair|Salon][$activeSlave.nails = 7,$cash -= $modCost]]
-| [[Shiny, metallic nails|Salon][$activeSlave.nails = 8,$cash -= $modCost]]
-| [[Color-coordinate metallic nails with hair|Salon][$activeSlave.nails = 9,$cash -= $modCost]]
 | [[Streetwalker-style nails|Salon][$activeSlave.nails = 5,$cash -= $modCost]]
-
+| [[Color-coordinate nails with hair|Salon][$activeSlave.nails = 2,$cash -= $modCost]]
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+[[Vivid, neon nails|Salon][$activeSlave.nails = 6,$cash -= $modCost]]
+| [[Color-coordinate neon nails with hair|Salon][$activeSlave.nails = 7,$cash -= $modCost]]
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
+[[Shiny, metallic nails|Salon][$activeSlave.nails = 8,$cash -= $modCost]]
+| [[Color-coordinate metallic nails with hair|Salon][$activeSlave.nails = 9,$cash -= $modCost]]
 <</if>>
 
 

--- a/src/uncategorized/salon.tw
+++ b/src/uncategorized/salon.tw
@@ -136,17 +136,17 @@ $activeSlave.slaveName is seated in the auto salon. $pronounCap is awaiting your
 <</if>>
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
 
-
-[[Nice makeup|Salon][$activeSlave.makeup = 1,$cash -= $modCost]]
-| [[Gorgeous makeup|Salon][$activeSlave.makeup = 2,$cash -= $modCost]]
-| [[Slutty makeup|Salon][$activeSlave.makeup = 4,$cash -= $modCost]]
-| [[Color-coordinate makeup with hair|Salon][$activeSlave.makeup = 3,$cash -= $modCost]]
-<br>&nbsp;&nbsp;&nbsp;&nbsp;
-[[Neon makeup|Salon][$activeSlave.makeup = 5,$cash -= $modCost]]
-| [[Color-coordinate neon makeup with hair|Salon][$activeSlave.makeup = 6,$cash -= $modCost]]
-<br>&nbsp;&nbsp;&nbsp;&nbsp;
-[[Metallic makeup|Salon][$activeSlave.makeup = 7,$cash -= $modCost]]
-| [[Color-coordinate metallic makeup with hair|Salon][$activeSlave.makeup = 8,$cash -= $modCost]]
+Apply makeup:
+[[Nice|Salon][$activeSlave.makeup = 1,$cash -= $modCost]]
+| [[Gorgeous|Salon][$activeSlave.makeup = 2,$cash -= $modCost]]
+| [[Slutty|Salon][$activeSlave.makeup = 4,$cash -= $modCost]]
+| [[Color-coordinate with hair|Salon][$activeSlave.makeup = 3,$cash -= $modCost]]
+<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+[[Neon|Salon][$activeSlave.makeup = 5,$cash -= $modCost]]
+| [[Neon, color-coordinate with hair|Salon][$activeSlave.makeup = 6,$cash -= $modCost]]
+<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+[[Metallic|Salon][$activeSlave.makeup = 7,$cash -= $modCost]]
+| [[Metallic, color-coordinate with hair|Salon][$activeSlave.makeup = 8,$cash -= $modCost]]
 
 
 /* NAILS */
@@ -179,18 +179,19 @@ $activeSlave.slaveName is seated in the auto salon. $pronounCap is awaiting your
 
 <<if $activeSlave.amp != 1>>
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
-[[Clip nails|Salon][$activeSlave.nails = 0,$cash -= $modCost]]
-| [[Extend nails|Salon][$activeSlave.nails = 1,$cash -= $modCost]]
-| [[Sharp, claw-like nails|Salon][$activeSlave.nails = 3,$cash -= $modCost]]
-| [[Bright, glittery nails|Salon][$activeSlave.nails = 4,$cash -= $modCost]]
-| [[Streetwalker-style nails|Salon][$activeSlave.nails = 5,$cash -= $modCost]]
-| [[Color-coordinate nails with hair|Salon][$activeSlave.nails = 2,$cash -= $modCost]]
-<br>&nbsp;&nbsp;&nbsp;&nbsp;
-[[Vivid, neon nails|Salon][$activeSlave.nails = 6,$cash -= $modCost]]
-| [[Color-coordinate neon nails with hair|Salon][$activeSlave.nails = 7,$cash -= $modCost]]
-<br>&nbsp;&nbsp;&nbsp;&nbsp;
-[[Shiny, metallic nails|Salon][$activeSlave.nails = 8,$cash -= $modCost]]
-| [[Color-coordinate metallic nails with hair|Salon][$activeSlave.nails = 9,$cash -= $modCost]]
+Treat nails: 
+[[Clip|Salon][$activeSlave.nails = 0,$cash -= $modCost]]
+| [[Extend|Salon][$activeSlave.nails = 1,$cash -= $modCost]]
+| [[Sharp, claw-like|Salon][$activeSlave.nails = 3,$cash -= $modCost]]
+| [[Bright, glittery|Salon][$activeSlave.nails = 4,$cash -= $modCost]]
+| [[Streetwalker-style|Salon][$activeSlave.nails = 5,$cash -= $modCost]]
+| [[Color-coordinate with hair|Salon][$activeSlave.nails = 2,$cash -= $modCost]]
+<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+[[Neon|Salon][$activeSlave.nails = 6,$cash -= $modCost]]
+| [[Neon, color-coordinate with hair|Salon][$activeSlave.nails = 7,$cash -= $modCost]]
+<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+[[Metallic|Salon][$activeSlave.nails = 8,$cash -= $modCost]]
+| [[Metallic, color-coordinate with hair|Salon][$activeSlave.nails = 9,$cash -= $modCost]]
 <</if>>
 
 


### PR DESCRIPTION
Nail/makeup options list are now shorter (removed every instance of the word nails/makeup from individual options, and stated it once at the start.)

Also moved options with a modified twin to a new indented line.  (metallic/metallic color-matched to hair.)  That's a departure from previous FC style but I think it works here.