### PR TITLE
Fix for virgin pregnancies in slaves pleasing you and fix for matchmaking-asDump error

### DIFF
--- a/src/uncategorized/matchmaking.tw
+++ b/src/uncategorized/matchmaking.tw
@@ -430,3 +430,5 @@ Being ordered into a relationship would be difficult for anyone, but they're so 
 <<set $activeSlave = $eventSlave>>
 
 <</if>>
+
+<<set $activeSlave = $eventSlave>>

--- a/src/uncategorized/saLongTermEffects.tw
+++ b/src/uncategorized/saLongTermEffects.tw
@@ -3190,7 +3190,7 @@
 		<</if>>
 
 	<<case "serve in the master suite" "please you">>
-		<<if ($PC.dick == 1) && (($slaves[$i].toyHole == "all her holes") || ($slaves[$i].toyHole == "pussy"))>>
+		<<if ($PC.dick == 1) && (($slaves[$i].toyHole == "all her holes" && $slaves[$i].vagina > 0) || ($slaves[$i].toyHole == "pussy"))>>
 			You frequently avail yourself to her fertile pussy. It's no surprise when @@.lime;she ends up pregnant with your child@@.
 			<<set $slaves[$i].preg = 1, $slaves[$i].pregSource = -1>>
 


### PR DESCRIPTION
"all her holes" only uses a slaves pussy if it has been broken in.  saLongTermEffects now reflects this.
Added in an <<set $activeSlave = $eventSlave>> to the end of mathmaking.  This shouldn't cause any unforseen trouble and satisfies asDump.  The other <<set $activeSlave = $eventSlave>> in the passage can likely be pruned too.