### PR TITLE
Restructuring of belly description widget.

### DIFF
--- a/src/utility/descriptionWidgets.tw
+++ b/src/utility/descriptionWidgets.tw
@@ -6943,710 +6943,770 @@ $pronounCap has
 <<if $activeSlave.preg > 30>>
 	$pronounCap is enormously pregnant,
 	<<if $activeSlave.height >= 185>>
-	but $possessive tall frame bears $possessive massive, drum-taut belly well.
+		but $possessive tall frame bears $possessive massive, drum-taut belly well.
 	<<elseif $activeSlave.height < 150>>
-	and $possessive massive, drum-taut belly dominates $possessive poor little frame.
+		and $possessive massive, drum-taut belly dominates $possessive poor little frame.
 	<<elseif $activeSlave.muscles > 30>>
-	and $possessive fit body bears $possessive massive, drum-taut belly well.
+		and $possessive fit body bears $possessive massive, drum-taut belly well.
 	<<else>>
-	and $possessive massive, drum-taut belly dominates $possessive frame.
+		and $possessive massive, drum-taut belly dominates $possessive frame.
 	<</if>>
 <<elseif $activeSlave.preg > 20>>
 	$pronounCap is heavily pregnant,
 	<<if $activeSlave.height >= 185>>
-	but $possessive tall frame bears $possessive swollen belly well.
+		but $possessive tall frame bears $possessive swollen belly well.
 	<<elseif $activeSlave.height < 150>>
-	and $possessive swollen belly dominates $possessive poor little frame.
+		and $possessive swollen belly dominates $possessive poor little frame.
 	<<elseif $activeSlave.muscles > 30>>
-	and $possessive fit body bears $possessive swollen belly well.
+		and $possessive fit body bears $possessive swollen belly well.
 	<<else>>
-	and $possessive swollen belly dominates $possessive frame.
+		and $possessive swollen belly dominates $possessive frame.
 	<</if>>
 <<elseif $activeSlave.preg > 8>>
 	$pronounCap is visibly pregnant,
 	<<if $activeSlave.weight > 30>>
-	but $pronoun's sufficiently overweight that it's not obvious.
+		but $pronoun's sufficiently overweight that it's not obvious.
 	<<elseif $activeSlave.height < 150>>
-	and $possessive swelling belly already looks huge on $possessive tiny frame.
+		and $possessive swelling belly already looks huge on $possessive tiny frame.
 	<<elseif $activeSlave.weight <= -30>>
-	$possessive thin form making $possessive swelling belly very obvious.
+		$possessive thin form making $possessive swelling belly very obvious.
 	<<else>>
-	the life growing within $possessive beginning to swell $possessive belly.
+		the life growing within $possessive beginning to swell $possessive belly.
 	<</if>>
 <<elseif ($activeSlave.assignment == "work in the dairy") && ($dairyFeedersSetting + $dairyStimulatorsSetting > 2)>>
 	$possessiveCap stomach is painfully distended from the nutrition and hydration being pumped down $possessive throat and up $possessive butt.
 <<elseif $activeSlave.weight > 95>>
 	<<if $activeSlave.muscles > 95>>
-	$possessiveCap massive abs are shrouded by a thick layer of fat.
+		$possessiveCap massive abs are shrouded by a thick layer of fat.
 	<<elseif $activeSlave.muscles > 30>>
-	$possessiveCap abs are hidden behind a big soft belly.
+		$possessiveCap abs are hidden behind a big soft belly.
 	<<else>>
-	$pronounCap carries a lot of $possessive weight on $possessive stomach; $pronoun's so fat that $possessive navel is buried in a fold of $possessive belly.
+		$pronounCap carries a lot of $possessive weight on $possessive stomach; $pronoun's so fat that $possessive navel is buried in a fold of $possessive belly.
 	<</if>>
 	<<if $activeSlave.age > 35>>
-	$possessiveCap fat belly is starting to show its age, and sags a little.
+		$possessiveCap fat belly is starting to show its age, and sags a little.
 	<</if>>
 <<elseif $activeSlave.weight > 30>>
 	<<if $activeSlave.muscles > 95>>
-	$possessiveCap abs are big enough that they're visible behind $possessive well-padded belly.
+		$possessiveCap abs are big enough that they're visible behind $possessive well-padded belly.
 	<<elseif $activeSlave.muscles > 5>>
-	$pronounCap's fit enough to carry $possessive extra weight well, leaving $possessive chubby belly appealingly soft.
+		$pronounCap's fit enough to carry $possessive extra weight well, leaving $possessive chubby belly appealingly soft.
 	<<else>>
-	$possessiveCap chubby belly is nice and soft, hiding the curve of $possessive waist a little.
+		$possessiveCap chubby belly is nice and soft, hiding the curve of $possessive waist a little.
 	<</if>>
 <<elseif $activeSlave.weight > 10>>
 	<<if $activeSlave.muscles > 30>>
-	$possessiveCap ripped abs are only slightly blurred by feminine belly fat.
+		$possessiveCap ripped abs are only slightly blurred by feminine belly fat.
 	<<elseif $activeSlave.muscles > 5>>
-	$pronounCap's fit yet soft, with $possessive toned abs complementing $possessive feminine belly.
+		$pronounCap's fit yet soft, with $possessive toned abs complementing $possessive feminine belly.
 	<<else>>
-	$possessiveCap belly is pleasantly soft.
+		$possessiveCap belly is pleasantly soft.
 	<</if>>
 <<elseif $activeSlave.weight >= -10>>
 	<<if $activeSlave.muscles > 30>>
-	$possessiveCap abs ripple as $pronoun moves, each one well-defined under the skin of $possessive midsection.
+		$possessiveCap abs ripple as $pronoun moves, each one well-defined under the skin of $possessive midsection.
 	<<elseif $activeSlave.muscles > 5>>
-	$pronounCap has a nicely toned midsection, promising good stamina.
+		$pronounCap has a nicely toned midsection, promising good stamina.
 	<<else>>
-	$pronounCap has a feminine belly with just a hint of softness.
+		$pronounCap has a feminine belly with just a hint of softness.
 	<</if>>
 <<elseif $activeSlave.weight >= -30>>
 	<<if $activeSlave.muscles > 30>>
-	$possessiveCap ridiculous abs ripple as $pronoun moves, every single striation and vein clearly visible under the skin of $possessive midsection.
+		$possessiveCap ridiculous abs ripple as $pronoun moves, every single striation and vein clearly visible under the skin of $possessive midsection.
 	<<elseif $activeSlave.muscles > 5>>
-	$possessiveCap thin midsection highlights $possessive abs, showing off a hint of a six-pack.
+		$possessiveCap thin midsection highlights $possessive abs, showing off a hint of a six-pack.
 	<<else>>
-	$pronounCap has a model's midsection, without any hint of belly or musculature.
+		$pronounCap has a model's midsection, without any hint of belly or musculature.
 	<</if>>
 <<else>>
 	<<if $activeSlave.muscles > 5>>
-	$possessiveCap abs are clearly visible, stretched over $possessive emaciated frame as they are.
+		$possessiveCap abs are clearly visible, stretched over $possessive emaciated frame as they are.
 	<<else>>
-	$possessiveCap emaciated belly is perfectly flat.
+		$possessiveCap emaciated belly is perfectly flat.
 	<</if>>
 <</if>>
 
 <<if ($showClothing == 1) && ($saleDescription == 0)>>
 <<if $surgeryDescription == 0>>
 
-<<if ($activeSlave.preg > 30 or $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
-
 <<if ($activeSlave.bellyAccessory == "an extreme corset")>>
-	$activeSlave.slaveName's huge pregnant belly is tightly compressed by $possessive corset; one or the other will eventually win out.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly is tightly compressed by $possessive corset; one or the other will eventually win out.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly is tightly compressed by $possessive corset; one or the other will eventually win out.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's huge gut is tightly compressed by $possessive corset, $possessive fat billows out of any gap it can find.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly is tightly compressed by $possessive corset causing $object distress.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby stomach is tightly compressed by $possessive corset, $possessive pudge bulges out of any gap it can find.
+	<</if>>
 <<elseif ($activeSlave.bellyAccessory == "a corset")>>
-	$activeSlave.slaveName's huge pregnant belly comfortably bulges out of $possessive corset.
-<</if>>
-<<switch $activeSlave.clothes>>
-<<case "a Fuckdoll suit">>
-	$activeSlave.slaveName's huge pregnant belly is allowed to bulge out of a huge hole in the suit.
-<<case "conservative clothing">>
-	<<if ($activeSlave.boobs > 20000)>>
-	$activeSlave.slaveName's immense breasts keep $possessive oversized sweater from covering $possessive huge pregnant belly, though they do a fine job of hiding it themselves.
-	<<elseif ($activeSlave.boobs > 10000)>>
-	$activeSlave.slaveName's huge pregnant belly is hidden by $possessive massive tits and oversized sweater.
-	<<elseif ($activeSlave.boobs > 8000)>>
-	$activeSlave.slaveName's oversized breasts keep $possessive sweater far from $possessive huge pregnant belly.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's sweater is pulled taut by $possessive huge pregnant belly, the bottom of which can be seen peeking out from underneath. $possessiveCap popped navel forms a small tent in the material.
-	<<else>>
-	$activeSlave.slaveName's blouse is pulled taut by $possessive huge pregnant belly, the bottom of which can be seen peeking out from underneath. $possessiveCap popped navel forms a small tent in $possessive shirt.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly comfortably bulges out of $possessive corset.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly comfortably bulges out of $possessive corset.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's huge gut hangs out the hole in $possessive corset designed to accommodate a pregnant belly.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly comfortably rounds out $possessive corset.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby stomach is compressed by $possessive corset, $possessive pudge bulges out above and below it.
 	<</if>>
-<<case "chains">>
-	$activeSlave.slaveName's huge pregnant belly is tightly wrapped with chains, causing it to bulge angrily.
-<<case "Western clothing">>
-	$activeSlave.slaveName's flannel shirt can't close over $possessive huge pregnant belly so $pronoun has left the bottom buttons open, leaving $possessive belly hanging out.
-<<case "body oil">>
-	$activeSlave.slaveName's huge belly is covered in a sheen of special oil meant to prevent stretch marks.
-<<case "a toga">>
-	$activeSlave.slaveName's huge pregnant belly parts $possessive toga.
-<<case "a huipil">>
-	$activeSlave.slaveName's huge pregnant belly lifts $possessive huipil.
-<<case "a slutty qipao">>
-	$possessiveCap qipao is slit up the side. However, it merely rests atop $possessive huge pregnant belly.
-<<case "uncomfortable straps">>
-	$activeSlave.slaveName's slave outfit's straining straps press into $possessive huge pregnant belly, causing flesh to spill out of the gaps. The straps connect to a steel ring encircling $possessive popped navel.
-<<case "shibari ropes">>
-	$activeSlave.slaveName's huge pregnant belly is tightly bound with ropes; flesh bulges angrily from between them.
-<<case "restrictive latex" "a latex catsuit">>
-	$activeSlave.slaveName's huge pregnant belly greatly distends $possessive latex suit. $pronounCap looks like an over inflated balloon ready to pop. Only $possessive popped navel sticking out the front of $possessive belly disrupts the smoothness.
-<<case "a military uniform">>
-	<<if ($activeSlave.boobs > 6000)>>
-	$activeSlave.slaveName's huge pregnant belly is obscured by $possessive massive tits.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's shirt strains to contain $possessive huge pregnant belly.
-	<<else>>
-	$activeSlave.slaveName's huge pregnant belly greatly stretches $possessive uniform's jacket.
-	<</if>>
-<<case "a nice nurse outfit">>
-	<<if ($activeSlave.boobs > 6000)>>
-	$activeSlave.slaveName's huge pregnant belly is obscured by $possessive massive tits.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's nurse outfit could be called conservative, if it could cover more than half of $possessive breasts; $possessive huge pregnant belly hangs out from under them, obscuring $possessive trousers.
-	<<else>>
-	$activeSlave.slaveName's nurse outfit is almost conservative, though $possessive huge pregnant belly hangs out from under $possessive top, obscuring $possessive trousers.
-	<</if>>
-<<case "a mini dress">>
-	$activeSlave.slaveName's mini dress barely clings to $possessive huge pregnant belly.
-<<case "attractive lingerie">>
-	$activeSlave.slaveName's huge pregnant belly completely hides $possessive lacy g-string.
-<<case "a succubus outfit">>
-	$activeSlave.slaveName's huge pregnant belly sticks out of $possessive corset, which is laced above and below it as best $pronoun can manage.
-<<case "a slutty maid outfit">>
-	$activeSlave.slaveName's maid dress fails to cover $possessive huge pregnant belly, but the outfit includes a thin white blouse that conceals only the upper part of $possessive stomach.
-<<case "a nice maid outfit">>
-	$activeSlave.slaveName's maid dress is almost conservative. It covers $possessive huge pregnant belly completely, though it can not hide $possessive popped navel, poking through the front.
-<<case "a fallen nuns habit">>
-	$activeSlave.slaveName's latex habit's corset is left hanging open fully revealing $possessive huge pregnant belly.
-<<case "a penitent nuns habit">>
-	$pronounCap looks absolutely blasphemous in a habit with such a huge pregnant belly. The coarse cloth aggravates $possessive sensitive stretched skin.
-<<case "a string bikini">>
-	$activeSlave.slaveName's huge pregnant belly parts $possessive string bikini to either side.
-<<case "clubslut netting">>
-	$activeSlave.slaveName's clubslut netting is stretched to the breaking point by $possessive huge pregnant belly.
-<<case "a cheerleader outfit">>
-	$activeSlave.slaveName's cheerleader top rides up $possessive huge pregnant belly, covering only the top of it while leaving the rest on display to show how slutty this cheerleader is.
-<<case "cutoffs and a t-shirt">>
-	<<if ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's huge pregnant belly is obscured by $possessive huge tits.
-	<<elseif ($activeSlave.boobs > 2000)>>
-	$activeSlave.slaveName's tits keep $possessive t-shirt far from $possessive huge pregnant belly.
-	<<else>>
-	$activeSlave.slaveName's t-shirt fails to cover $possessive huge pregnant belly at all.
-	<</if>>
-<<case "a slutty outfit">>
-	$activeSlave.slaveName's huge pregnant belly really shows what a slut $pronoun is.
-<<case "a slave gown">>
-	$activeSlave.slaveName's slave gown is carefully tailored, giving $object a sensual motherly look as it carefully caresses $possessive huge pregnant belly.
-<<case "slutty business attire">>
-	$activeSlave.slaveName's huge pregnant stomach hangs out the front of $possessive suit jacket and blouse, as there is no way $pronoun could close them.
-<<case "nice business attire">>
-	$activeSlave.slaveName's huge pregnant belly strains $possessive specially tailored blouse and jacket.
-<<case "harem gauze">>
-	$activeSlave.slaveName's harem girl outfit sensually accentuates $possessive huge pregnancy.
-<<case "a comfortable bodysuit">>
-	$activeSlave.slaveName's bodysuit tightly clings to $possessive huge pregnant belly, displaying $possessive popped navel and any movement $possessive babies make.
-<<case "a slutty nurse outfit">>
-	$activeSlave.slaveName's jacket fails to even come close to closing over $possessive huge pregnant belly, leaving $object with only the button below $possessive breasts done.
-<<case "a schoolgirl outfit">>
-	$activeSlave.slaveName's blouse rides up $possessive huge pregnant belly, leaving $possessive looking particularly slutty.
-<<case "a kimono">>
-	$activeSlave.slaveName's huge pregnant belly parts the front of $possessive kimono, leaving it gracefully covering its sides.
-<<case "a hijab and abaya">>
-	$activeSlave.slaveName's abaya is filled by $possessive huge pregnant belly.
-<<case "battledress">>
-	$activeSlave.slaveName's tank top barely even covers the top of $possessive huge pregnant belly, leaving $possessive looking like someone who had too much fun on shore leave.
-<<case "a halter top dress">>
-	$activeSlave.slaveName's beautiful halter top dress is filled by $possessive huge pregnant belly. $possessiveCap popped navel prominently pokes through its front.
-<<case "a ball gown">>
-	$activeSlave.slaveName's fabulous silken ball gown is tailored to not only fit $possessive huge pregnant belly, but draw attention to it.
-<<case "slutty jewelry">>
-	$activeSlave.slaveName's bangles include a long thin chain that rests above $possessive popped navel.
-<<case "a leotard">>
-	$activeSlave.slaveName's tight leotard shows off every kick and movement within $possessive huge pregnant belly. The material tightly clings to $possessive popped navel.
-<<case "a chattel habit">>
-	The strip of cloth running down $possessive front is parted to one side by $possessive huge pregnant belly.
-<<case "a bunny outfit">>
-	$activeSlave.slaveName's teddy is stretched to tearing by $possessive huge pregnant belly. $possessiveCap popped navel prominently pokes through the material.
-<<default>>
-<</switch>>
-
-<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
-
-<<if ($activeSlave.bellyAccessory == "an extreme corset")>>
-	$activeSlave.slaveName's pregnant belly is tightly compressed by $possessive corset; one or the other will eventually win out.
-<<elseif ($activeSlave.bellyAccessory == "a corset")>>
-	$activeSlave.slaveName's pregnant belly comfortably bulges out of $possessive corset.
-<</if>>
-<<switch $activeSlave.clothes>>
-<<case "a Fuckdoll suit">>
-	$activeSlave.slaveName's pregnant belly is allowed to bulge out of a hole in the suit.
-<<case "conservative clothing">>
-	<<if ($activeSlave.boobs > 20000)>>
-	$activeSlave.slaveName's immense breasts keep $possessive oversized sweater from covering $possessive pregnant belly, though they do a fine job of hiding it themselves.
-	<<elseif ($activeSlave.boobs > 10000)>>
-	$activeSlave.slaveName's pregnant belly is hidden by $possessive massive tits and oversized sweater.
-	<<elseif ($activeSlave.boobs > 8000)>>
-	$activeSlave.slaveName's oversized breasts keep $possessive sweater far from $possessive pregnant belly.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's sweater is pulled taut by $possessive pregnant belly. $possessiveCap popped navel forms a small tent in material.
-	<<else>>
-	$activeSlave.slaveName's blouse is pulled taut by $possessive pregnant belly. $possessiveCap popped navel forms a small tent in $possessive shirt.
-	<</if>>
-<<case "chains">>
-	$activeSlave.slaveName's pregnant belly is tightly wrapped with chains, causing it to bulge angrily.
-<<case "Western clothing">>
-	$activeSlave.slaveName's flannel shirt can't close over $possessive pregnant belly, so $pronoun has left the bottom buttons open leaving $possessive belly hanging out.
-<<case "body oil">>
-	$activeSlave.slaveName's belly is covered in a sheen of special oil meant to prevent stretch marks.
-<<case "a toga">>
-	$activeSlave.slaveName's pregnant belly parts $possessive toga.
-<<case "a huipil">>
-	$activeSlave.slaveName's pregnant belly lifts $possessive huipil.
-<<case "a slutty qipao">>
-	$possessiveCap qipao is slit up the side. However, it only covers the top of $possessive pregnant belly.
-<<case "uncomfortable straps">>
-	$activeSlave.slaveName's slave outfit's straining straps press into $possessive pregnant belly, causing flesh to spill out of the gaps. The straps connect to a steel ring encircling $possessive popped navel.
-<<case "shibari ropes">>
-	$activeSlave.slaveName's pregnant belly is tightly bound with rope; flesh bulges angrily from between them.
-<<case "restrictive latex" "a latex catsuit">>
-	$activeSlave.slaveName's pregnant belly greatly distends $possessive latex suit. $pronounCap looks like an over inflated balloon. Only $possessive popped navel sticking out the front of $possessive belly disrupts the smoothness.
-<<case "a military uniform">>
-	<<if ($activeSlave.boobs > 6000)>>
-	$activeSlave.slaveName's pregnant belly is obscured by $possessive massive tits.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's shirt strains to contain $possessive pregnant belly.
-	<<else>>
-	$activeSlave.slaveName's pregnant belly notably distends $possessive uniform's jacket.
-	<</if>>
-<<case "a nice nurse outfit">>
-	<<if ($activeSlave.boobs > 6000)>>
-	$activeSlave.slaveName's pregnant belly is obscured by $possessive massive tits.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's nurse outfit could be called conservative, if it could cover more than half of $possessive breasts; $possessive pregnant belly hangs out from under them, obscuring $possessive trousers.
-	<<else>>
-	$activeSlave.slaveName's nurse outfit is almost conservative, though $possessive pregnancy hangs out from under $possessive top, slightly obscuring $possessive trousers.
-	<</if>>
-<<case "a mini dress">>
-	$activeSlave.slaveName's mini dress tightly clings to $possessive pregnant belly.
-<<case "attractive lingerie">>
-	$activeSlave.slaveName's pregnant belly hides $possessive lacy g-string.
-<<case "a succubus outfit">>
-	$activeSlave.slaveName's pregnant belly sticks out of $possessive corset, which is laced above and below it.
-<<case "a slutty maid outfit">>
-	$activeSlave.slaveName's maid dress fails to cover $possessive pregnant belly, but the outfit includes a thin white blouse that conceals only the top half of $possessive stomach.
-<<case "a nice maid outfit">>
-	$activeSlave.slaveName's maid dress is almost conservative, it covers $possessive pregnant belly completely. Though it can not hide $possessive popped navel poking through the front.
-<<case "a fallen nuns habit">>
-	$activeSlave.slaveName's latex habit's corset is left hanging open fully revealing $possessive pregnant belly.
-<<case "a penitent nuns habit">>
-	$pronounCap looks absolutely blasphemous in a habit with a pregnant belly. The coarse cloth aggravates $possessive sensitive stretched skin.
-<<case "a string bikini">>
-	$activeSlave.slaveName's pregnant belly parts $possessive string bikini to either side.
-<<case "clubslut netting">>
-	$activeSlave.slaveName's clubslut netting is stretched out by $possessive pregnant belly.
-<<case "a cheerleader outfit">>
-	$activeSlave.slaveName's cheerleader top covers most of $possessive pregnant belly, the bottom of which peeks out showing how slutty this cheerleader is.
-<<case "cutoffs and a t-shirt">>
-	<<if ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's pregnant belly is obscured by $possessive huge tits.
-	<<elseif ($activeSlave.boobs > 2000)>>
-	$activeSlave.slaveName's tits keep $possessive t-shirt far from $possessive pregnant belly.
-	<<else>>
-	$activeSlave.slaveName's t-shirt covers only the top of $possessive pregnant belly.
-	<</if>>
-<<case "a slutty outfit">>
-	$activeSlave.slaveName's pregnant belly really shows how big of a slut $pronoun is.
-<<case "a slave gown">>
-	$activeSlave.slaveName's slave gown is carefully tailored, giving $possessive a sensual motherly look as it carefully caresses $possessive pregnant belly.
-<<case "slutty business attire">>
-	$activeSlave.slaveName's pregnant stomach strains the buttons of $possessive suit jacket and blouse.
-<<case "nice business attire">>
-	$activeSlave.slaveName's pregnant belly looks good in $possessive specially tailored blouse and jacket.
-<<case "harem gauze">>
-	$activeSlave.slaveName's harem girl outfit sensually accentuates $possessive pregnancy.
-<<case "a comfortable bodysuit">>
-	$activeSlave.slaveName's bodysuit tightly clings to $possessive pregnant belly, displaying $possessive popped navel and any movement $possessive babies make.
-<<case "a slutty nurse outfit">>
-	$activeSlave.slaveName's jacket barely closes over $possessive pregnant belly leaving its' buttons threatening to pop.
-<<case "a schoolgirl outfit">>
-	$activeSlave.slaveName's blouse rides up $possessive pregnant belly, leaving $possessive looking particularly slutty.
-<<case "a kimono">>
-	$activeSlave.slaveName's pregnant belly is demurely covered by $possessive kimono.
-<<case "a hijab and abaya">>
-	$activeSlave.slaveName's abaya is filled out by $possessive pregnant belly.
-<<case "battledress">>
-	$activeSlave.slaveName's tank top rides up $possessive pregnant belly leaving $possessive looking like someone who had too much fun on shore-leave.
-<<case "a halter top dress">>
-	$activeSlave.slaveName's beautiful halter top dress is filled by $possessive pregnant belly. $possessiveCap popped navel prominently pokes through the front of $possessive dress.
-<<case "a ball gown">>
-	$activeSlave.slaveName's fabulous silken ball gown is tailored to not only fit $possessive pregnant belly but draw attention to it.
-<<case "slutty jewelry">>
-	$activeSlave.slaveName's bangles include a long thin chain that rests above $possessive popped navel.
-<<case "a leotard">>
-	$activeSlave.slaveName's tight leotard shows off every kick and movement within $possessive pregnant belly. The material tightly clings to $possessive popped navel.
-<<case "a chattel habit">>
-	The strip of cloth running down $possessive front is parted to one side by $possessive pregnant belly.
-<<case "a bunny outfit">>
-	$activeSlave.slaveName's teddy is stretched out by $possessive pregnant belly. $possessiveCap popped navel prominently pokes through the material.
-<<default>>
-<</switch>>
-
-<<elseif $activeSlave.weight >= 95>>
-
-<<if ($activeSlave.bellyAccessory == "an extreme corset")>>
-	$activeSlave.slaveName's huge gut is tightly compressed by $possessive corset, $possessive fat billows out of any gap it can find.
-<<elseif ($activeSlave.bellyAccessory == "a corset")>>
-	$activeSlave.slaveName's huge gut hangs out the hole in $possessive corset designed to accommodate a pregnant belly.
 <<elseif ($activeSlave.bellyAccessory == "a small empathy belly")>>
-	$activeSlave.slaveName's small empathy belly is barely noticeable over $possessive huge gut.
+	<<if $activeSlave.weight > 95>>
+		$activeSlave.slaveName's small empathy belly is barely noticeable over $possessive huge gut.
+	<</if>>
 <</if>>
+
 <<switch $activeSlave.clothes>>
 <<case "a Fuckdoll suit">>
-	$activeSlave.slaveName's fat belly is cruelly squeezed by the suit.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly is allowed to bulge out of a huge hole in the suit.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly is allowed to bulge out of a hole in the suit.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's fat belly is cruelly squeezed by the suit.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing pregnancy will soon require $object to be switched into a suit with a hole to let her belly out.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby belly is tightly squeezed by the suit.
+	<</if>>
 <<case "conservative clothing">>
-	<<if ($activeSlave.boobs > 20000)>>
-	$activeSlave.slaveName's immense breasts keep $possessive oversized sweater from covering $possessive fat belly, though they do a fine job of hiding it themselves.
-	<<elseif ($activeSlave.boobs > 10000)>>
-	$activeSlave.slaveName's fat belly is hidden by $possessive massive tits and oversized sweater.
-	<<elseif ($activeSlave.boobs > 8000)>>
-	$activeSlave.slaveName's oversized breasts let $possessive fat belly hang free.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's sweater is pulled tight over $possessive fat belly. The bottom of which peeks out from under it.
-	<<else>>
-	$activeSlave.slaveName's blouse is pulled tight over $possessive fat belly. The bottom of which peeks out from under it.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		<<if ($activeSlave.boobs > 20000)>>
+			$activeSlave.slaveName's immense breasts keep $possessive oversized sweater from covering $possessive huge pregnant belly, though they do a fine job of hiding it themselves.
+		<<elseif ($activeSlave.boobs > 10000)>>
+			$activeSlave.slaveName's huge pregnant belly is hidden by $possessive massive tits and oversized sweater.
+		<<elseif ($activeSlave.boobs > 8000)>>
+			$activeSlave.slaveName's oversized breasts keep $possessive sweater far from $possessive huge pregnant belly.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's sweater is pulled taut by $possessive huge pregnant belly, the bottom of which can be seen peeking out from underneath. $possessiveCap popped navel forms a small tent in the material.
+		<<else>>
+			$activeSlave.slaveName's blouse is pulled taut by $possessive huge pregnant belly, the bottom of which can be seen peeking out from underneath. $possessiveCap popped navel forms a small tent in $possessive shirt.
+		<</if>>
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		<<if ($activeSlave.boobs > 20000)>>
+			$activeSlave.slaveName's immense breasts keep $possessive oversized sweater from covering $possessive pregnant belly, though they do a fine job of hiding it themselves.
+		<<elseif ($activeSlave.boobs > 10000)>>
+			$activeSlave.slaveName's pregnant belly is hidden by $possessive massive tits and oversized sweater.
+		<<elseif ($activeSlave.boobs > 8000)>>
+			$activeSlave.slaveName's oversized breasts keep $possessive sweater far from $possessive pregnant belly.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's sweater is pulled taut by $possessive pregnant belly. $possessiveCap popped navel forms a small tent in material.
+		<<else>>
+			$activeSlave.slaveName's blouse is pulled taut by $possessive pregnant belly. $possessiveCap popped navel forms a small tent in $possessive shirt.
+		<</if>>
+	<<elseif $activeSlave.weight > 95>>
+		<<if ($activeSlave.boobs > 20000)>>
+			$activeSlave.slaveName's immense breasts keep $possessive oversized sweater from covering $possessive fat belly, though they do a fine job of hiding it themselves.
+		<<elseif ($activeSlave.boobs > 10000)>>
+			$activeSlave.slaveName's fat belly is hidden by $possessive massive tits and oversized sweater.
+		<<elseif ($activeSlave.boobs > 8000)>>
+			$activeSlave.slaveName's oversized breasts let $possessive fat belly hang free.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's sweater is pulled tight over $possessive fat belly. The bottom of which peeks out from under it.
+		<<else>>
+			$activeSlave.slaveName's blouse is pulled tight over $possessive fat belly. The bottom of which peeks out from under it.
+		<</if>>
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		<<if ($activeSlave.boobs > 20000)>>
+			$activeSlave.slaveName's immense breasts keep $possessive oversized sweater from covering $possessive growing belly, though they do a fine job of hiding it themselves.
+		<<elseif ($activeSlave.boobs > 10000)>>
+			$activeSlave.slaveName's growing belly is hidden by $possessive massive tits and oversized sweater.
+		<<elseif ($activeSlave.boobs > 8000)>>
+			$activeSlave.slaveName's oversized breasts keep $possessive sweater far from $possessive growing belly.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's sweater bulges with $possessive growing belly.
+		<<else>>
+			$activeSlave.slaveName's blouse bulges with $possessive growing belly.
+		<</if>>
+	<<elseif $activeSlave.weight > 30>>
+		<<if ($activeSlave.boobs > 20000)>>
+			$activeSlave.slaveName's immense breasts keep $possessive oversized sweater from covering $possessive chubby belly, though they do a fine job of hiding it themselves.
+		<<elseif ($activeSlave.boobs > 10000)>>
+			$activeSlave.slaveName's chubby belly is hidden by $possessive massive tits and oversized sweater.
+		<<elseif ($activeSlave.boobs > 8000)>>
+			$activeSlave.slaveName's oversized breasts keep $possessive sweater far from $possessive chubby belly.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's sweater bulges with $possessive chubby belly.
+		<<else>>
+			$activeSlave.slaveName's blouse bulges with $possessive chubby belly.
+		<</if>>
 	<</if>>
 <<case "chains">>
-	$activeSlave.slaveName's chains sink deep into $possessive fat belly, several even disappearing beneath $possessive folds.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly is tightly wrapped with chains, causing it to bulge angrily.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly is tightly wrapped with chains, causing it to bulge angrily.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's chains sink deep into $possessive fat belly, several even disappearing beneath $possessive folds.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly is tightly wrapped with chains.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chains sink into $possessive chubby belly, making noticeable folds in $possessive sides.
+	<</if>>
 <<case "Western clothing">>
-	$activeSlave.slaveName's flannel shirt strains to stay shut over $possessive fat belly, fat bulges between $possessive buttons and quite a bit of $possessive lower belly hangs out beneath $possessive shirt.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's flannel shirt can't close over $possessive huge pregnant belly so $pronoun has left the bottom buttons open, leaving $possessive belly hanging out.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's flannel shirt can't close over $possessive pregnant belly, so $pronoun has left the bottom buttons open leaving $possessive belly hanging out.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's flannel shirt strains to stay shut over $possessive fat belly, fat bulges between $possessive buttons and quite a bit of $possessive lower belly hangs out beneath $possessive shirt.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's flannel shirt bulges with $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's flannel shirt bulges with $possessive chubby belly.
+	<</if>>
 <<case "body oil">>
-	$activeSlave.slaveName's fat belly is covered in a sheen of oil.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge belly is covered in a sheen of special oil meant to prevent stretch marks.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's belly is covered in a sheen of special oil meant to prevent stretch marks.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's fat belly is covered in a sheen of oil.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly is covered in a sheen of oil.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby belly is covered in a sheen of oil.
+	<</if>>
 <<case "a toga">>
-	$activeSlave.slaveName's toga can barely be pulled shut over $possessive fat belly.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly parts $possessive toga.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly parts $possessive toga.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's toga can barely be pulled shut over $possessive fat belly.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly gently bulges under $possessive toga.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's toga conceals $possessive chubby belly.
+	<</if>>
 <<case "a huipil">>
-	$activeSlave.slaveName's huipil gets lifted by $possessive fat belly, so it's useless for covering $possessive body.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly lifts $possessive huipil.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly lifts $possessive huipil.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's huipil gets lifted by $possessive fat belly, so it's useless for covering $possessive body.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly slightly bulges under $possessive huipil.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's huipil conceals $possessive chubby little belly.
+	<</if>>
 <<case "a slutty qipao">>
-	$possessiveCap qipao is slit up the side. However, it only covers the top of $possessive fat belly, allowing it to hang free.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$possessiveCap qipao is slit up the side. However, it merely rests atop $possessive huge pregnant belly.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$possessiveCap qipao is slit up the side. However, it only covers the top of $possessive pregnant belly.
+	<<elseif $activeSlave.weight > 95>>
+		$possessiveCap qipao is slit up the side. However, it only covers the top of $possessive fat belly, allowing it to hang free.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$possessiveCap qipao is slit up the side. The front is pushed out by $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$possessiveCap qipao is slit up the side. The front is pushed out by $possessive chubby belly.
+	<</if>>
 <<case "uncomfortable straps">>
-	$activeSlave.slaveName's slave outfit's straps sink deep into $possessive fat belly, several even disappearing beneath $possessive folds. The straps connect to a steel ring that parts the fold concealing $possessive navel, allowing it to be seen once again.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's slave outfit's straining straps press into $possessive huge pregnant belly, causing flesh to spill out of the gaps. The straps connect to a steel ring encircling $possessive popped navel.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's slave outfit's straining straps press into $possessive pregnant belly, causing flesh to spill out of the gaps. The straps connect to a steel ring encircling $possessive popped navel.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's slave outfit's straps sink deep into $possessive fat belly, several even disappearing beneath $possessive folds. The straps connect to a steel ring that parts the fold concealing $possessive navel, allowing it to be seen once again.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's slave outfit's straining straps press into $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's slave outfit's straps sink into $possessive chubby belly, making noticeable folds in $possessive sides. The straps connect to a steel ring pulled into the flesh around $possessive navel.
+	<</if>>
 <<case "shibari ropes">>
-	$activeSlave.slaveName's binding ropes sink deep into $possessive fat belly, several even disappearing beneath $possessive folds.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly is tightly bound with ropes; flesh bulges angrily from between them.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly is tightly bound with rope; flesh bulges angrily from between them.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's binding ropes sink deep into $possessive fat belly, several even disappearing beneath $possessive folds.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly is tightly bound with rope, flesh bulges from between them.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's binding ropes sink into $possessive chubby belly, making noticeable folds in $possessive sides.
+	<</if>>
 <<case "restrictive latex" "a latex catsuit">>
-	$activeSlave.slaveName's fat belly is compressed by $possessive latex suit, leaving it looking round and smooth.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly greatly distends $possessive latex suit. $pronounCap looks like an over inflated balloon ready to pop. Only $possessive popped navel sticking out the front of $possessive belly disrupts the smoothness.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly greatly distends $possessive latex suit. $pronounCap looks like an over inflated balloon. Only $possessive popped navel sticking out the front of $possessive belly disrupts the smoothness.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's fat belly is compressed by $possessive latex suit, leaving it looking round and smooth.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly greatly bulges under $possessive latex suit.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby belly in quite noticeable under $possessive latex suit, though any folds $pronoun might have are smoothed out by it.
+	<</if>>
 <<case "a military uniform">>
-	<<if ($activeSlave.boobs > 6000)>>
-	$activeSlave.slaveName's fat belly is obscured by $possessive massive tits.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's shirt struggles to cover $possessive fat belly. The bottom of which peeks out from under it.
-	<<else>>
-	$activeSlave.slaveName's fat belly is covered by $possessive uniform's jacket. The bottom of which just barely peeks out from under it.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		<<if ($activeSlave.boobs > 6000)>>
+			$activeSlave.slaveName's huge pregnant belly is obscured by $possessive massive tits.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's shirt strains to contain $possessive huge pregnant belly.
+		<<else>>
+			$activeSlave.slaveName's huge pregnant belly greatly stretches $possessive uniform's jacket.
+		<</if>>
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		<<if ($activeSlave.boobs > 6000)>>
+			$activeSlave.slaveName's pregnant belly is obscured by $possessive massive tits.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's shirt strains to contain $possessive pregnant belly.
+		<<else>>
+			$activeSlave.slaveName's pregnant belly notably distends $possessive uniform's jacket.
+		<</if>>
+	<<elseif $activeSlave.weight > 95>>
+		<<if ($activeSlave.boobs > 6000)>>
+			$activeSlave.slaveName's fat belly is obscured by $possessive massive tits.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's shirt struggles to cover $possessive fat belly. The bottom of which peeks out from under it.
+		<<else>>
+			$activeSlave.slaveName's fat belly is covered by $possessive uniform's jacket. The bottom of which just barely peeks out from under it.
+		<</if>>
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		<<if ($activeSlave.boobs > 6000)>>
+			$activeSlave.slaveName's growing belly is obscured by $possessive massive tits.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's undershirt covers $possessive growing belly.
+		<<else>>
+			$activeSlave.slaveName's uniform covers $possessive growing belly.
+		<</if>>
+	<<elseif $activeSlave.weight > 30>>
+		<<if ($activeSlave.boobs > 6000)>>
+			$activeSlave.slaveName's chubby belly is obscured by $possessive massive tits.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's undershirt covers $possessive chubby belly. The bottom of which just barely peeks out from under it.
+		<<else>>
+			$activeSlave.slaveName's uniform covers $possessive chubby belly. The bottom of which just barely peeks out from under it.
+		<</if>>
 	<</if>>
 <<case "a nice nurse outfit">>
-	<<if ($activeSlave.boobs > 6000)>>
-	$activeSlave.slaveName's fat belly is obscured by $possessive massive tits.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's nurse outfit could be called conservative, if it could cover more than half of $possessive breasts; $possessive fat belly freely hangs out from under them, obscuring $possessive trousers.
-	<<else>>
-	$activeSlave.slaveName's nurse outfit is almost conservative, though $possessive fat belly freely hangs from under $possessive top, obscuring $possessive trousers.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		<<if ($activeSlave.boobs > 6000)>>
+			$activeSlave.slaveName's huge pregnant belly is obscured by $possessive massive tits.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's nurse outfit could be called conservative, if it could cover more than half of $possessive breasts; $possessive huge pregnant belly hangs out from under them, obscuring $possessive trousers.
+		<<else>>
+			$activeSlave.slaveName's nurse outfit is almost conservative, though $possessive huge pregnant belly hangs out from under $possessive top, obscuring $possessive trousers.
+		<</if>>
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		<<if ($activeSlave.boobs > 6000)>>
+			$activeSlave.slaveName's pregnant belly is obscured by $possessive massive tits.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's nurse outfit could be called conservative, if it could cover more than half of $possessive breasts; $possessive pregnant belly hangs out from under them, obscuring $possessive trousers.
+		<<else>>
+			$activeSlave.slaveName's nurse outfit is almost conservative, though $possessive pregnancy hangs out from under $possessive top, slightly obscuring $possessive trousers.
+		<</if>>
+	<<elseif $activeSlave.weight > 95>>
+		<<if ($activeSlave.boobs > 6000)>>
+			$activeSlave.slaveName's fat belly is obscured by $possessive massive tits.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's nurse outfit could be called conservative, if it could cover more than half of $possessive breasts; $possessive fat belly freely hangs out from under them, obscuring $possessive trousers.
+		<<else>>
+			$activeSlave.slaveName's nurse outfit is almost conservative, though $possessive fat belly freely hangs from under $possessive top, obscuring $possessive trousers.
+		<</if>>
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		<<if ($activeSlave.boobs > 6000)>>
+			$activeSlave.slaveName's growing belly is obscured by $possessive massive tits.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's nurse outfit could be called conservative, if it could cover more than half of $possessive breasts; $possessive growing belly is completely exposed.
+		<<else>>
+			$activeSlave.slaveName's nurse outfit is almost conservative, it covers $possessive growing belly completely.
+		<</if>>
+	<<elseif $activeSlave.weight > 30>>
+		<<if ($activeSlave.boobs > 6000)>>
+			$activeSlave.slaveName's chubby belly is obscured by $possessive massive tits.
+		<<elseif ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's nurse outfit could be called conservative, if it could cover more than half of $possessive breasts; $possessive chubby belly is completely exposed and allowed to hang over the waist of $possessive pants.
+		<<else>>
+			$activeSlave.slaveName's nurse outfit is almost conservative, it covers $possessive chubby belly completely; though it does hide the top of $possessive pants.
+		<</if>>
 	<</if>>
 <<case "a mini dress">>
-	$activeSlave.slaveName's mini dress tightly clings to $possessive fat belly, clearly showing every fold and roll.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's mini dress barely clings to $possessive huge pregnant belly.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's mini dress tightly clings to $possessive pregnant belly.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's mini dress tightly clings to $possessive fat belly, clearly showing every fold and roll.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's mini dress tightly clings to $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's mini dress tightly clings to $possessive chubby belly, clearly showing every fold and roll.
+	<</if>>
 <<case "attractive lingerie">>
-	$activeSlave.slaveName's fat belly hides $possessive lacy g-string.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly completely hides $possessive lacy g-string.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly hides $possessive lacy g-string.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's fat belly hides $possessive lacy g-string.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly rests above $possessive lacy g-string.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby belly rests above $possessive lacy g-string, concealing the top of it.
+	<</if>>
 <<case "a succubus outfit">>
-	$activeSlave.slaveName's fat belly sticks out of $possessive corset, which is laced above and below it allowing it to hang free.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly sticks out of $possessive corset, which is laced above and below it as best $pronoun can manage.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly sticks out of $possessive corset, which is laced above and below it.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's fat belly sticks out of $possessive corset, which is laced above and below it allowing it to hang free.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's pregnant belly peeks out of $possessive corset, which is laced above and below it.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby belly peeks out of $possessive corset, which is laced above and below it to allow it to hang free.
+	<</if>>
 <<case "a slutty maid outfit">>
-	$activeSlave.slaveName's maid dress fails to cover $possessive fat belly, but the outfit includes a thin white blouse that, when stretched, only manages to wrangle the top of $possessive gut.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's maid dress fails to cover $possessive huge pregnant belly, but the outfit includes a thin white blouse that conceals only the upper part of $possessive stomach.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's maid dress fails to cover $possessive pregnant belly, but the outfit includes a thin white blouse that conceals only the top half of $possessive stomach.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's maid dress fails to cover $possessive fat belly, but the outfit includes a thin white blouse that, when stretched, only manages to wrangle the top of $possessive gut.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's maid dress is slightly distended by $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's maid dress is slightly distended by $possessive chubby belly.
+	<</if>>
 <<case "a nice maid outfit">>
-	$activeSlave.slaveName's maid dress is almost conservative, it covers $possessive fat belly completely, but does nothing to hide how big it is.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's maid dress is almost conservative. It covers $possessive huge pregnant belly completely, though it can not hide $possessive popped navel, poking through the front.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's maid dress is almost conservative, it covers $possessive pregnant belly completely. Though it can not hide $possessive popped navel poking through the front.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's maid dress is almost conservative, it covers $possessive fat belly completely, but does nothing to hide how big it is.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's maid dress is almost conservative, it covers $possessive growing belly completely.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's maid dress is almost conservative, it covers $possessive chubby belly completely.
+	<</if>>
 <<case "a fallen nuns habit">>
-	$activeSlave.slaveName's latex habit's corset is barely holding together over $possessive fat belly, causing flab to spill out from every opening.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's latex habit's corset is left hanging open fully revealing $possessive huge pregnant belly.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's latex habit's corset is left hanging open fully revealing $possessive pregnant belly.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's latex habit's corset is barely holding together over $possessive fat belly, causing flab to spill out from every opening.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's latex habit's corset struggles to hold $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's latex habit's corset compresses $possessive chubby belly forcing pudge to spill out from under it.
+	<</if>>
 <<case "a penitent nuns habit">>
-	$possessiveCap fat belly fills out $possessive habit. The coarse cloth has plenty of extra skin to aggravate.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$pronounCap looks absolutely blasphemous in a habit with such a huge pregnant belly. The coarse cloth aggravates $possessive sensitive stretched skin.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$pronounCap looks absolutely blasphemous in a habit with a pregnant belly. The coarse cloth aggravates $possessive sensitive stretched skin.
+	<<elseif $activeSlave.weight > 95>>
+		$possessiveCap fat belly fills out $possessive habit. The coarse cloth has plenty of extra skin to aggravate.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's habit gently bulges from $possessive growing belly. The coarse cloth aggravates $possessive sensitive skin.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's habit gently bulges from $possessive chubby belly. The coarse cloth takes advantage of the extra surface area.
+	<</if>>
 <<case "a string bikini">>
-	$activeSlave.slaveName's fat belly parts $possessive string bikini to either side.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly parts $possessive string bikini to either side.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly parts $possessive string bikini to either side.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's fat belly parts $possessive string bikini to either side.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly juts out between the strings of $possessive bikini.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby belly hangs between the strings of $possessive bikini.
+	<</if>>
 <<case "clubslut netting">>
-	$activeSlave.slaveName's clubslut netting is stretched out by $possessive fat belly, forcing flab to poke through the mesh.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's clubslut netting is stretched to the breaking point by $possessive huge pregnant belly.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's clubslut netting is stretched out by $possessive pregnant belly.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's clubslut netting is stretched out by $possessive fat belly, forcing flab to poke through the mesh.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's clubslut netting clings to $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's clubslut netting clings to $possessive chubby belly, gently forcing pudge through the mesh.
+	<</if>>
 <<case "a cheerleader outfit">>
-	$activeSlave.slaveName's cheerleader top covers most of $possessive fat belly. However, the bottom of it peeks out, obscuring $possessive skirt and a letting everyone know how badly this cheerleader needs to diet.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's cheerleader top rides up $possessive huge pregnant belly, covering only the top of it while leaving the rest on display to show how slutty this cheerleader is.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's cheerleader top covers most of $possessive pregnant belly, the bottom of which peeks out showing how slutty this cheerleader is.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's cheerleader top covers most of $possessive fat belly. However, the bottom of it peeks out, obscuring $possessive skirt and a letting everyone know how badly this cheerleader needs to diet.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's cheerleader top gently bulges from $possessive growing belly displaying how slutty this cheerleader is.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's cheerleader top frequently rides up $possessive chubby belly, letting it hang loose and hide the waist of $possessive skirt.
+	<</if>>
 <<case "cutoffs and a t-shirt">>
-	<<if ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's fat belly is obscured by $possessive huge tits.
-	<<elseif ($activeSlave.boobs > 2000)>>
-	$activeSlave.slaveName's tits keep $possessive t-shirt busy, allowing $possessive fat belly to hang free.
-	<<else>>
-	$activeSlave.slaveName's t-shirt covers only the top of $possessive fat belly, allowing it to hang mostly free and cover $possessive jeans.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		<<if ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's huge pregnant belly is obscured by $possessive huge tits.
+		<<elseif ($activeSlave.boobs > 2000)>>
+			$activeSlave.slaveName's tits keep $possessive t-shirt far from $possessive huge pregnant belly.
+		<<else>>
+			$activeSlave.slaveName's t-shirt fails to cover $possessive huge pregnant belly at all.
+		<</if>>
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		<<if ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's pregnant belly is obscured by $possessive huge tits.
+		<<elseif ($activeSlave.boobs > 2000)>>
+			$activeSlave.slaveName's tits keep $possessive t-shirt far from $possessive pregnant belly.
+		<<else>>
+			$activeSlave.slaveName's t-shirt covers only the top of $possessive pregnant belly.
+		<</if>>
+	<<elseif $activeSlave.weight > 95>>
+		<<if ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's fat belly is obscured by $possessive huge tits.
+		<<elseif ($activeSlave.boobs > 2000)>>
+			$activeSlave.slaveName's tits keep $possessive t-shirt busy, allowing $possessive fat belly to hang free.
+		<<else>>
+			$activeSlave.slaveName's t-shirt covers only the top of $possessive fat belly, allowing it to hang mostly free and cover $possessive jeans.
+		<</if>>
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		<<if ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's growing belly is obscured by $possessive huge tits.
+		<<elseif ($activeSlave.boobs > 2000)>>
+			$activeSlave.slaveName's tits keep $possessive t-shirt far from $possessive growing belly.
+		<<else>>
+			$activeSlave.slaveName's t-shirt bulges with $possessive growing belly. The bottom of which is beginning to peek from under $possessive T-shirt.
+		<</if>>
+	<<elseif $activeSlave.weight > 30>>
+		<<if ($activeSlave.boobs > 4000)>>
+			$activeSlave.slaveName's chubby belly is obscured by $possessive huge tits.
+		<<elseif ($activeSlave.boobs > 2000)>>
+			$activeSlave.slaveName's tits keep $possessive t-shirt busy, allowing $possessive chubby belly to openly jiggle.
+		<<else>>
+			$activeSlave.slaveName's t-shirt covers most of $possessive chubby belly. The bottom of which peeks out from under $possessive shirt as it hangs over the waist of $possessive jeans.
+		<</if>>
 	<</if>>
 <<case "a slutty outfit">>
-	$activeSlave.slaveName lets $possessive fat belly hang free, leaving $possessive looking particularly slutty.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly really shows what a slut $pronoun is.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly really shows how big of a slut $pronoun is.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName lets $possessive fat belly hang free, leaving $possessive looking particularly slutty.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly shows how big of a slut $pronoun is.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby belly is allowed to openly jiggle, making $object look particularly slutty.
+	<</if>>
 <<case "a slave gown">>
-	$activeSlave.slaveName's slave gown is carefully tailored, accentuating and hugging every curve of $possessive fat belly.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's slave gown is carefully tailored, giving $object a sensual motherly look as it carefully caresses $possessive huge pregnant belly.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's slave gown is carefully tailored, giving $possessive a sensual motherly look as it carefully caresses $possessive pregnant belly.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's slave gown is carefully tailored, accentuating and hugging every curve of $possessive fat belly.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's slave gown is carefully tailored, giving $object a sensual look as it carefully caresses $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's slave gown is carefully tailored, accentuating and hugging every curve of $possessive chubby belly.
+	<</if>>
 <<case "slutty business attire">>
-	$activeSlave.slaveName's fat belly strains the buttons of $possessive suit jacket and blouse. The bottom of which just barely peeks out from under them.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant stomach hangs out the front of $possessive suit jacket and blouse, as there is no way $pronoun could close them.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant stomach strains the buttons of $possessive suit jacket and blouse.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's fat belly strains the buttons of $possessive suit jacket and blouse. The bottom of which just barely peeks out from under them.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly bulges $possessive suit jacket and blouse. It peeks out from under their bottom slightly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby belly fills out $possessive suit jacket and blouse. It peeks out from under their bottom slightly.
+	<</if>>
 <<case "nice business attire">>
-	$activeSlave.slaveName's tailored blouse and jacket fit $possessive fat belly well, though they do nothing to hide how big $possessive gut is.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly strains $possessive specially tailored blouse and jacket.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly looks good in $possessive specially tailored blouse and jacket.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's tailored blouse and jacket fit $possessive fat belly well, though they do nothing to hide how big $possessive gut is.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly bulges under $possessive tailored blouse and jacket.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby belly fills out $possessive tailored blouse and jacket.
+	<</if>>
 <<case "harem gauze">>
-	$activeSlave.slaveName's harem girl outfit sensually accentuates $possessive fat belly.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's harem girl outfit sensually accentuates $possessive huge pregnancy.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's harem girl outfit sensually accentuates $possessive pregnancy.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's harem girl outfit sensually accentuates $possessive fat belly.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's harem girl outfit sensually accentuates $possessive growing pregnancy.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's harem girl outfit sensually accentuates $possessive chubby belly.
+	<</if>>
 <<case "a comfortable bodysuit">>
-	$activeSlave.slaveName's bodysuit tightly clings to $possessive fat belly, displaying every fold and roll in it.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's bodysuit tightly clings to $possessive huge pregnant belly, displaying $possessive popped navel<<if !["a huge empathy belly", "a large empathy belly"].includes $activeSlave.bellyAccessory>> and any movement $possessive babies make<</if>>.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's bodysuit tightly clings to $possessive pregnant belly, displaying $possessive popped navel<<if $activeSlave.bellyAccessory != "a medium empathy belly">> and any movement $possessive babies make<</if>>.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's bodysuit tightly clings to $possessive fat belly, displaying every fold and roll in it.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's bodysuit tightly clings to $possessive growing belly, displaying $possessive ripening body.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's bodysuit tightly clings to $possessive chubby belly, displaying every fold and roll in it.
+	<</if>>
 <<case "a slutty nurse outfit">>
-	$activeSlave.slaveName's jacket barely closes over $possessive fat belly forcing plenty of flab out from under its bottom and between the straining buttons.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's jacket fails to even come close to closing over $possessive huge pregnant belly, leaving $object with only the button below $possessive breasts done.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's jacket barely closes over $possessive pregnant belly leaving its' buttons threatening to pop.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's jacket barely closes over $possessive fat belly forcing plenty of flab out from under its bottom and between the straining buttons.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's jacket bulges with $possessive growing belly, which can be seen peeking out from underneath.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's jacket bulges with $possessive chubby belly, which can be seen peeking out from underneath as it hangs over $possessive waist of $possessive pants.
+	<</if>>
 <<case "a schoolgirl outfit">>
-	$activeSlave.slaveName's blouse rides up $possessive fat belly, leaving it hanging loose and covering $possessive skirt.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's blouse rides up $possessive huge pregnant belly, leaving $possessive looking particularly slutty.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's blouse rides up $possessive pregnant belly, leaving $possessive looking particularly slutty.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's blouse rides up $possessive fat belly, leaving it hanging loose and covering $possessive skirt.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's blouse bulges with $possessive growing belly. It peeks out from the bottom leaving $possessive looking particularly slutty.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's blouse bulges with $possessive chubby belly. It peeks out from the bottom as it hangs over the waist of $possessive skirt.
+	<</if>>
 <<case "a kimono">>
-	$activeSlave.slaveName's fat belly is demurely covered by $possessive kimono.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's huge pregnant belly parts the front of $possessive kimono, leaving it gracefully covering its sides.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's pregnant belly is demurely covered by $possessive kimono.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's fat belly is demurely covered by $possessive kimono.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's growing belly is demurely covered by $possessive kimono.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's chubby belly is demurely covered by $possessive kimono.
+	<</if>>
 <<case "a hijab and abaya">>
-	$activeSlave.slaveName's abaya is filled out by $possessive fat belly.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's abaya is filled by $possessive huge pregnant belly.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's abaya is filled out by $possessive pregnant belly.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's abaya is filled out by $possessive fat belly.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's abaya bulges with $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's abaya bulges from $possessive chubby belly.
+	<</if>>
 <<case "battledress">>
-	$activeSlave.slaveName's tank top rests atop $possessive fat belly, leaving everyone wondering how this recruit passed basic.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's tank top barely even covers the top of $possessive huge pregnant belly, leaving $possessive looking like someone who had too much fun on shore leave.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's tank top rides up $possessive pregnant belly leaving $possessive looking like someone who had too much fun on shore-leave.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's tank top rests atop $possessive fat belly, leaving everyone wondering how this recruit passed basic.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's tank top covers the top of $possessive growing belly leaving $possessive looking like someone who had too much fun on shore-leave.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's tank top covers the top of $possessive chubby belly leaving $possessive looking like someone who had has been lazy lately.
+	<</if>>
 <<case "a halter top dress">>
-	$activeSlave.slaveName's beautiful halter top dress is filled by $possessive fat belly. Every crease, fold and roll is clearly visible within it.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's beautiful halter top dress is filled by $possessive huge pregnant belly. $possessiveCap popped navel prominently pokes through its front.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's beautiful halter top dress is filled by $possessive pregnant belly. $possessiveCap popped navel prominently pokes through the front of $possessive dress.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's beautiful halter top dress is filled by $possessive fat belly. Every crease, fold and roll is clearly visible within it.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's beautiful halter top dress bulges with $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's beautiful halter top dress is filled by $possessive chubby belly. Every crease, fold and roll is clearly visible within it.
+	<</if>>
 <<case "a ball gown">>
-	$activeSlave.slaveName's fabulous silken ball gown is tailored to not only fit $possessive fat belly but draw attention to it.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's fabulous silken ball gown is tailored to not only fit $possessive huge pregnant belly, but draw attention to it.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's fabulous silken ball gown is tailored to not only fit $possessive pregnant belly but draw attention to it.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's fabulous silken ball gown is tailored to not only fit $possessive fat belly but draw attention to it.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's fabulous silken ball gown is tailored to draw attention to $possessive growing pregnancy.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's fabulous silken ball gown is tailored to draw attention to $possessive chubby belly.
+	<</if>>
 <<case "slutty jewelry">>
-	$activeSlave.slaveName's bangles include long, thin chains running along $possessive fat folds.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's bangles include a long thin chain that rests above $possessive popped navel.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's bangles include a long thin chain that rests above $possessive popped navel.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's bangles include long, thin chains running along $possessive fat folds.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's bangles include a long thin chain that rests across $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's bangles include a long thin chain that rests across $possessive chubby belly, just over $possessive forming rolls.
+	<</if>>
 <<case "a leotard">>
-	$activeSlave.slaveName's tight leotard tightly clings to $possessive fat belly, clearly displaying every fold and roll.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's tight leotard shows off <<if !["a huge empathy belly", "a large empathy belly"].includes $activeSlave.bellyAccessory>>every kick and movement within<<else>>the curvature of<</if>> $possessive huge pregnant belly. The material tightly clings to $possessive popped navel.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's tight leotard shows off every kick and movement within $possessive pregnant belly. The material tightly clings to $possessive popped navel.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's tight leotard tightly clings to $possessive fat belly, clearly displaying every fold and roll.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's tight leotard shows off $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's tight leotard clings to $possessive chubby belly, clearly displaying every fold and roll.
+	<</if>>
 <<case "a chattel habit">>
-	The strip of cloth running down $possessive front is gently sinks into $possessive fat belly.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		The strip of cloth running down $possessive front is parted to one side by $possessive huge pregnant belly.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		The strip of cloth running down $possessive front is parted to one side by $possessive pregnant belly.
+	<<elseif $activeSlave.weight > 95>>
+		The strip of cloth running down $possessive front is gently sinks into $possessive fat belly.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		The strip of cloth running down $possessive front is pushed out by $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		The strip of cloth running down $possessive front is pushed out by $possessive chubby belly.
+	<</if>>
 <<case "a bunny outfit">>
-	$activeSlave.slaveName's teddy is stretched out by $possessive fat belly. $possessiveCap flab juts out around its edges and it does nothing to hide $possessive folds and rolls.
-<<default>>
-<</switch>>
-	<<if $arcologies[0].FSSlimnessEnthusiast != "unset">>
-		 Your sleek, slim society finds $possessive bloated body unsightly.
+	<<if ($activeSlave.preg > 30 || $activeSlave.bellyAccessory == "a huge empathy belly" || $activeSlave.bellyAccessory == "a large empathy belly")>>
+		$activeSlave.slaveName's teddy is stretched to tearing by $possessive huge pregnant belly. $possessiveCap popped navel prominently pokes through the material.
+	<<elseif ($activeSlave.preg > 20 || $activeSlave.bellyAccessory == "a medium empathy belly")>>
+		$activeSlave.slaveName's teddy is stretched out by $possessive pregnant belly. $possessiveCap popped navel prominently pokes through the material.
+	<<elseif $activeSlave.weight > 95>>
+		$activeSlave.slaveName's teddy is stretched out by $possessive fat belly. $possessiveCap flab juts out around its edges and it does nothing to hide $possessive folds and rolls.
+	<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
+		$activeSlave.slaveName's teddy bulges with $possessive growing belly.
+	<<elseif $activeSlave.weight > 30>>
+		$activeSlave.slaveName's teddy is stretched by $possessive chubby belly. It does nothing to hide $possessive folds and rolls.
 	<</if>>
-
-<<elseif ($activeSlave.preg > 10 || $activeSlave.bellyAccessory == "a small empathy belly")>>
-
-<<if ($activeSlave.bellyAccessory == "an extreme corset")>>
-	$activeSlave.slaveName's growing belly is tightly compressed by $possessive corset causing $object distress.
-<<elseif ($activeSlave.bellyAccessory == "a corset")>>
-	$activeSlave.slaveName's growing belly comfortably rounds out $possessive corset.
-<</if>>
-<<switch $activeSlave.clothes>>
-<<case "a Fuckdoll suit">>
-	$activeSlave.slaveName's growing pregnancy will soon require $object to be switched into a suit with a hole to let her belly out.
-<<case "conservative clothing">>
-	<<if ($activeSlave.boobs > 20000)>>
-	$activeSlave.slaveName's immense breasts keep $possessive oversized sweater from covering $possessive growing belly, though they do a fine job of hiding it themselves.
-	<<elseif ($activeSlave.boobs > 10000)>>
-	$activeSlave.slaveName's growing belly is hidden by $possessive massive tits and oversized sweater.
-	<<elseif ($activeSlave.boobs > 8000)>>
-	$activeSlave.slaveName's oversized breasts keep $possessive sweater far from $possessive growing belly.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's sweater bulges with $possessive growing belly.
-	<<else>>
-	$activeSlave.slaveName's blouse bulges with $possessive growing belly.
-	<</if>>
-<<case "chains">>
-	$activeSlave.slaveName's growing belly is tightly wrapped with chains.
-<<case "Western clothing">>
-	$activeSlave.slaveName's flannel shirt bulges with $possessive growing belly.
-<<case "body oil">>
-	$activeSlave.slaveName's growing belly is covered in a sheen of oil.
-<<case "a toga">>
-	$activeSlave.slaveName's growing belly gently bulges under $possessive toga.
-<<case "a huipil">>
-	$activeSlave.slaveName's growing belly slightly bulges under $possessive huipil.
-<<case "a slutty qipao">>
-	$possessiveCap qipao is slit up the side. The front is pushed out by $possessive growing belly.
-<<case "uncomfortable straps">>
-	$activeSlave.slaveName's slave outfit's straining straps press into $possessive growing belly.
-<<case "shibari ropes">>
-	$activeSlave.slaveName's growing belly is tightly bound with rope, flesh bulges from between them.
-<<case "restrictive latex" "a latex catsuit">>
-	$activeSlave.slaveName's growing belly greatly bulges under $possessive latex suit.
-<<case "a military uniform">>
-	<<if ($activeSlave.boobs > 6000)>>
-	$activeSlave.slaveName's growing belly is obscured by $possessive massive tits.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's undershirt covers $possessive growing belly.
-	<<else>>
-	$activeSlave.slaveName's uniform covers $possessive growing belly.
-	<</if>>
-<<case "a nice nurse outfit">>
-	<<if ($activeSlave.boobs > 6000)>>
-	$activeSlave.slaveName's growing belly is obscured by $possessive massive tits.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's nurse outfit could be called conservative, if it could cover more than half of $possessive breasts; $possessive growing belly is completely exposed.
-	<<else>>
-	$activeSlave.slaveName's nurse outfit is almost conservative, it covers $possessive growing belly completely.
-	<</if>>
-<<case "a mini dress">>
-	$activeSlave.slaveName's mini dress tightly clings to $possessive growing belly.
-<<case "attractive lingerie">>
-	$activeSlave.slaveName's growing belly rests above $possessive lacy g-string.
-<<case "a succubus outfit">>
-	$activeSlave.slaveName's pregnant belly peeks out of $possessive corset, which is laced above and below it.
-<<case "a slutty maid outfit">>
-	$activeSlave.slaveName's maid dress is slightly distended by $possessive growing belly.
-<<case "a nice maid outfit">>
-	$activeSlave.slaveName's maid dress is almost conservative, it covers $possessive growing belly completely.
-<<case "a fallen nuns habit">>
-	$activeSlave.slaveName's latex habit's corset struggles to hold $possessive growing belly.
-<<case "a penitent nuns habit">>
-	$activeSlave.slaveName's habit gently bulges from $possessive growing belly. The coarse cloth aggravates $possessive sensitive skin.
-<<case "a string bikini">>
-	$activeSlave.slaveName's growing belly juts out between the strings of $possessive bikini.
-<<case "clubslut netting">>
-	$activeSlave.slaveName's clubslut netting clings to $possessive growing belly.
-<<case "a cheerleader outfit">>
-	$activeSlave.slaveName's cheerleader top gently bulges from $possessive growing belly displaying how slutty this cheerleader is.
-<<case "cutoffs and a t-shirt">>
-	<<if ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's growing belly is obscured by $possessive huge tits.
-	<<elseif ($activeSlave.boobs > 2000)>>
-	$activeSlave.slaveName's tits keep $possessive t-shirt far from $possessive growing belly.
-	<<else>>
-	$activeSlave.slaveName's t-shirt bulges with $possessive growing belly. The bottom of which is beginning to peek from under $possessive T-shirt.
-	<</if>>
-<<case "a slutty outfit">>
-	$activeSlave.slaveName's growing belly shows how big of a slut $pronoun is.
-<<case "a slave gown">>
-	$activeSlave.slaveName's slave gown is carefully tailored, giving $object a sensual look as it carefully caresses $possessive growing belly.
-<<case "slutty business attire">>
-	$activeSlave.slaveName's growing belly bulges $possessive suit jacket and blouse. It peeks out from under their bottom slightly.
-<<case "nice business attire">>
-	$activeSlave.slaveName's growing belly bulges under $possessive tailored blouse and jacket.
-<<case "harem gauze">>
-	$activeSlave.slaveName's harem girl outfit sensually accentuates $possessive growing pregnancy.
-<<case "a comfortable bodysuit">>
-	$activeSlave.slaveName's bodysuit tightly clings to $possessive growing belly, displaying $possessive ripening body.
-<<case "a slutty nurse outfit">>
-	$activeSlave.slaveName's jacket bulges with $possessive growing belly, which can be seen peeking out from underneath.
-<<case "a schoolgirl outfit">>
-	$activeSlave.slaveName's blouse bulges with $possessive growing belly. It peeks out from the bottom leaving $possessive looking particularly slutty.
-<<case "a kimono">>
-	$activeSlave.slaveName's growing belly is demurely covered by $possessive kimono.
-<<case "a hijab and abaya">>
-	$activeSlave.slaveName's abaya bulges with $possessive growing belly.
-<<case "battledress">>
-	$activeSlave.slaveName's tank top covers the top of $possessive growing belly leaving $possessive looking like someone who had too much fun on shore-leave.
-<<case "a halter top dress">>
-	$activeSlave.slaveName's beautiful halter top dress bulges with $possessive growing belly.
-<<case "a ball gown">>
-	$activeSlave.slaveName's fabulous silken ball gown is tailored to draw attention to $possessive growing pregnancy.
-<<case "slutty jewelry">>
-	$activeSlave.slaveName's bangles include a long thin chain that rests across $possessive growing belly.
-<<case "a leotard">>
-	$activeSlave.slaveName's tight leotard shows off $possessive growing belly.
-<<case "a chattel habit">>
-	The strip of cloth running down $possessive front is pushed out by $possessive growing belly.
-<<case "a bunny outfit">>
-	$activeSlave.slaveName's teddy bulges with $possessive growing belly.
 <<default>>
 <</switch>>
 
-<<elseif $activeSlave.weight >= 30>>
-
-<<if ($activeSlave.bellyAccessory == "an extreme corset")>>
-	$activeSlave.slaveName's chubby stomach is tightly compressed by $possessive corset, $possessive pudge bulges out of any gap it can find.
-<<elseif ($activeSlave.bellyAccessory == "a corset")>>
-	$activeSlave.slaveName's chubby stomach is compressed by $possessive corset, $possessive pudge bulges out above and below it.
-<</if>>
-<<switch $activeSlave.clothes>>
-<<case "a Fuckdoll suit">>
-	$activeSlave.slaveName's chubby belly is tightly squeezed by the suit.
-<<case "conservative clothing">>
-	<<if ($activeSlave.boobs > 20000)>>
-	$activeSlave.slaveName's immense breasts keep $possessive oversized sweater from covering $possessive chubby belly, though they do a fine job of hiding it themselves.
-	<<elseif ($activeSlave.boobs > 10000)>>
-	$activeSlave.slaveName's chubby belly is hidden by $possessive massive tits and oversized sweater.
-	<<elseif ($activeSlave.boobs > 8000)>>
-	$activeSlave.slaveName's oversized breasts keep $possessive sweater far from $possessive chubby belly.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's sweater bulges with $possessive chubby belly.
-	<<else>>
-	$activeSlave.slaveName's blouse bulges with $possessive chubby belly.
-	<</if>>
-<<case "chains">>
-	$activeSlave.slaveName's chains sink into $possessive chubby belly, making noticeable folds in $possessive sides.
-<<case "Western clothing">>
-	$activeSlave.slaveName's flannel shirt bulges with $possessive chubby belly.
-<<case "body oil">>
-	$activeSlave.slaveName's chubby belly is covered in a sheen of oil.
-<<case "a toga">>
-	$activeSlave.slaveName's toga conceals $possessive chubby belly.
-<<case "a huipil">>
-	$activeSlave.slaveName's huipil conceals $possessive chubby little belly.
-<<case "a slutty qipao">>
-	$possessiveCap qipao is slit up the side. The front is pushed out by $possessive chubby belly.
-<<case "uncomfortable straps">>
-	$activeSlave.slaveName's slave outfit's straps sink into $possessive chubby belly, making noticeable folds in $possessive sides. The straps connect to a steel ring pulled into the flesh around $possessive navel.
-<<case "shibari ropes">>
-	$activeSlave.slaveName's binding ropes sink into $possessive chubby belly, making noticeable folds in $possessive sides.
-<<case "restrictive latex" "a latex catsuit">>
-	$activeSlave.slaveName's chubby belly in quite noticeable under $possessive latex suit, though any folds $pronoun might have are smoothed out by it.
-<<case "a military uniform">>
-	<<if ($activeSlave.boobs > 6000)>>
-	$activeSlave.slaveName's chubby belly is obscured by $possessive massive tits.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's undershirt covers $possessive chubby belly. The bottom of which just barely peeks out from under it.
-	<<else>>
-	$activeSlave.slaveName's uniform covers $possessive chubby belly. The bottom of which just barely peeks out from under it.
-	<</if>>
-<<case "a nice nurse outfit">>
-	<<if ($activeSlave.boobs > 6000)>>
-	$activeSlave.slaveName's chubby belly is obscured by $possessive massive tits.
-	<<elseif ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's nurse outfit could be called conservative, if it could cover more than half of $possessive breasts; $possessive chubby belly is completely exposed and allowed to hang over the waist of $possessive pants.
-	<<else>>
-	$activeSlave.slaveName's nurse outfit is almost conservative, it covers $possessive chubby belly completely; though it does hide the top of $possessive pants.
-	<</if>>
-<<case "a mini dress">>
-	$activeSlave.slaveName's mini dress tightly clings to $possessive chubby belly, clearly showing every fold and roll.
-<<case "attractive lingerie">>
-	$activeSlave.slaveName's chubby belly rests above $possessive lacy g-string, concealing the top of it.
-<<case "a succubus outfit">>
-	$activeSlave.slaveName's chubby belly peeks out of $possessive corset, which is laced above and below it to allow it to hang free.
-<<case "a slutty maid outfit">>
-	$activeSlave.slaveName's maid dress is slightly distended by $possessive chubby belly.
-<<case "a nice maid outfit">>
-	$activeSlave.slaveName's maid dress is almost conservative, it covers $possessive chubby belly completely.
-<<case "a fallen nuns habit">>
-	$activeSlave.slaveName's latex habit's corset compresses $possessive chubby belly forcing pudge to spill out from under it.
-<<case "a penitent nuns habit">>
-	$activeSlave.slaveName's habit gently bulges from $possessive chubby belly. The coarse cloth takes advantage of the extra surface area.
-<<case "a string bikini">>
-	$activeSlave.slaveName's chubby belly hangs between the strings of $possessive bikini.
-<<case "clubslut netting">>
-	$activeSlave.slaveName's clubslut netting clings to $possessive chubby belly, gently forcing pudge through the mesh.
-<<case "a cheerleader outfit">>
-	$activeSlave.slaveName's cheerleader top frequently rides up $possessive chubby belly, letting it hang loose and hide the waist of $possessive skirt.
-<<case "cutoffs and a t-shirt">>
-	<<if ($activeSlave.boobs > 4000)>>
-	$activeSlave.slaveName's chubby belly is obscured by $possessive huge tits.
-	<<elseif ($activeSlave.boobs > 2000)>>
-	$activeSlave.slaveName's tits keep $possessive t-shirt busy, allowing $possessive chubby belly to openly jiggle.
-	<<else>>
-	$activeSlave.slaveName's t-shirt covers most of $possessive chubby belly. The bottom of which peeks out from under $possessive shirt as it hangs over the waist of $possessive jeans.
-	<</if>>
-<<case "a slutty outfit">>
-	$activeSlave.slaveName's chubby belly is allowed to openly jiggle, making $object look particularly slutty.
-<<case "a slave gown">>
-	$activeSlave.slaveName's slave gown is carefully tailored, accentuating and hugging every curve of $possessive chubby belly.
-<<case "slutty business attire">>
-	$activeSlave.slaveName's chubby belly fills out $possessive suit jacket and blouse. It peeks out from under their bottom slightly.
-<<case "nice business attire">>
-	$activeSlave.slaveName's chubby belly fills out $possessive tailored blouse and jacket.
-<<case "harem gauze">>
-	$activeSlave.slaveName's harem girl outfit sensually accentuates $possessive chubby belly.
-<<case "a comfortable bodysuit">>
-	$activeSlave.slaveName's bodysuit tightly clings to $possessive chubby belly, displaying every fold and roll in it.
-<<case "a slutty nurse outfit">>
-	$activeSlave.slaveName's jacket bulges with $possessive chubby belly, which can be seen peeking out from underneath as it hangs over $possessive waist of $possessive pants.
-<<case "a schoolgirl outfit">>
-	$activeSlave.slaveName's blouse bulges with $possessive chubby belly. It peeks out from the bottom as it hangs over the waist of $possessive skirt.
-<<case "a kimono">>
-	$activeSlave.slaveName's chubby belly is demurely covered by $possessive kimono.
-<<case "a hijab and abaya">>
-	$activeSlave.slaveName's abaya bulges from $possessive chubby belly.
-<<case "battledress">>
-	$activeSlave.slaveName's tank top covers the top of $possessive chubby belly leaving $possessive looking like someone who had has been lazy lately.
-<<case "a halter top dress">>
-	$activeSlave.slaveName's beautiful halter top dress is filled by $possessive chubby belly. Every crease, fold and roll is clearly visible within it.
-<<case "a ball gown">>
-	$activeSlave.slaveName's fabulous silken ball gown is tailored to draw attention to $possessive chubby belly.
-<<case "slutty jewelry")>>
-	$activeSlave.slaveName's bangles include a long thin chain that rests across $possessive chubby belly, just over $possessive forming rolls.
-<<case "a leotard">>
-	$activeSlave.slaveName's tight leotard clings to $possessive chubby belly, clearly displaying every fold and roll.
-<<case "a chattel habit">>
-	The strip of cloth running down $possessive front is pushed out by $possessive chubby belly.
-<<case "a bunny outfit">>
-	$activeSlave.slaveName's teddy is stretched by $possessive chubby belly. It does nothing to hide $possessive folds and rolls.
-<<default>>
-<</switch>>
 <<if $arcologies[0].FSSlimnessEnthusiast != "unset">>
-	 Your sleek, slim society finds $possessive flabby body unsightly.
+	<<if $activeSlave.weight > 95>>
+		Your sleek, slim society finds $possessive bloated body unsightly.
+	<<elseif $activeSlave.weight > 30>>
+		Your sleek, slim society finds $possessive flabby body unsightly.
+	<</if>>
 <</if>>
 
-<</if>>
 <<else>>
 	$activeSlave.slaveName's belly is bare and ready for surgery.
-<</if>>
-<</if>>
+<</if>> /* closes surgery description */
+<</if>> /* closes show clothing */
 
 <<if $activeSlave.cSec == 1>>
 	$pronounCap has an unsightly c-section scar under $possessive navel.


### PR DESCRIPTION
It now focuses on the clothing rather than the size of the slave's belly, much like the other desciption widgets focus on the clthing first.  Makes it much easier to add new outfits, since all the descriptions for it are now in the same place.  Also will allow for text consolidation.  Lastly, cleaned up slightly off .weight checks.

Not an absolutely necessary merge, but makes it easier to work with I think.  The old set up was easier to work when initially coding it, but doesn't provide any benefit to, if not complicates, new clothing addition.