### PR TITLE
Asian faces return

### DIFF
--- a/src/uncategorized/bodyModRulesAssistantSettings.tw
+++ b/src/uncategorized/bodyModRulesAssistantSettings.tw
@@ -1080,7 +1080,7 @@ __Rule $r tattoos__
 <</link>>
 |
 <<link "Asian art">>
-<<set $currentRule.lipsTat = "no default setting">> /* No face option for Asian art */
+<<set $currentRule.lipsTat = "Asian art">>
 <<RAChangeFaceTattoos>>
 <<set $currentRule.shouldersTat = "Asian art">>
 <<RAChangeShoulderTattoos>>
@@ -1182,6 +1182,11 @@ Facial tattoos: ''
 |
 <<link "Bovine patterns">>
 <<set $currentRule.lipsTat = "bovine patterns">>
+<<RAChangeFaceTattoos>>
+<</link>>
+|
+<<link "Asian art">>
+<<set $currentRule.lipsTat = "Asian art">>
 <<RAChangeFaceTattoos>>
 <</link>>
 |

--- a/src/uncategorized/bodyModification.tw
+++ b/src/uncategorized/bodyModification.tw
@@ -103,7 +103,7 @@ Piercings:
 	 Her taint has a simple piercing between $possessive pussy and $possessive asshole.
 <</if>>
 <<if $activeSlave.corsetPiercing == 1>>
-	Her back has a 'corset' piercing, with a column of rings down either side of it woven together with ribbons.
+	Her back has a 'corset' piercing, with a column of rings down either side of it.
 <</if>>
 <</if>>
 
@@ -178,7 +178,7 @@ Piercings:
 
 <<if $activeSlave.corsetPiercing == 2>>
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	Her back has a 'corset' piercing, with a column of rings down either side of it woven together with chains.
+	Her back has a 'corset' piercing, with a column of heavy rings down either side of it.
 <</if>>
 
 
@@ -1184,12 +1184,12 @@ Choose a tattoo style:
 <</if>>
 
 <<if $activeSlave.lipsTat != "Asian art">>
-	<<set $activeSlave.lipsTat = "permanent makeup">>
+	<<set $activeSlave.lipsTat = "Asian art">>
 	<<set $cash -= $modCost>>
 	<<set $degradation += 1>>
 <</if>>
 
-<<if ($activeSlave.anusTat != "Asian art")>>
+<<if ($activeSlave.anusTat != "bleached")>>
 	<<set $activeSlave.anusTat = "bleached">>
 	<<set $cash -= $modCost>>
 	<<set $degradation += 1>>
@@ -1246,13 +1246,13 @@ Choose a tattoo style:
 	<<set $degradation += 1>>
 <</if>>
 
-<<if $activeSlave.lipsTat != "scenes">>
+<<if $activeSlave.lipsTat != "permanent makeup">>
 	<<set $activeSlave.lipsTat = "permanent makeup">>
 	<<set $cash -= $modCost>>
 	<<set $degradation += 1>>
 <</if>>
 
-<<if ($activeSlave.anusTat != "scenes")>>
+<<if ($activeSlave.anusTat != "bleached")>>
 	<<set $activeSlave.anusTat = "bleached">>
 	<<set $cash -= $modCost>>
 	<<set $degradation += 1>>

--- a/src/utility/descriptionWidgets.tw
+++ b/src/utility/descriptionWidgets.tw
@@ -3112,6 +3112,8 @@ $pronounCap's got a
 	$possessiveCap cock is tattooed with a vine that wraps around its shaft.
 <<case "advertisements">>
 	$possessiveCap cock reads 'Sissy Slut.'
+<<case "Asian art">>
+	$possessiveCap cock has an Asian dragon down each side.
 <<case "rude words">>
 	$possessiveCap cock reads 'Bitchstick.'
 <<case "degradation">>


### PR DESCRIPTION
Shoutout to @pregAnon and #827, I've reverted the removal.  Thanks for the info about descriptions!  Added a description for "Asian art" on dicks, since that's a legit option as you pointed out.

Thanks to descriptions reading, I have a better grasp of how many outfits corset piercings interact with, so I also reverted my more specific desciption.

Bug fix: I'm also correcting some checks within "whole body" tattoos, which sometimes checked for the general tattoo theme even if they needed to apply something else.  Example: There is no "scenes" setting for assholes, so it should check for the bleaching that it needs to apply when scenes is chosen.