### PR TITLE
Persistent Summary

### DIFF
--- a/src/gui/Encyclopedia/encyclopedia.tw
+++ b/src/gui/Encyclopedia/encyclopedia.tw
@@ -942,7 +942,7 @@ __I do not give credit without explicit permission to do so.__ If you have contr
 ''Rodziel'' contributed the cybernetics mod.
 ''prndev'' wrote the Free Range Dairy Assignment scene.
 ''freecitiesbandit'' wrote a number of random events.
-''DrNoOne'' wrote the bulk slave purchase code.
+''DrNoOne'' wrote the bulk slave purchase and persistent summary code.
 ''Mauve'' provided vector art for chastity belts and limp dicks.
 
 ''Many other anonymous contributors'' helped fix bugs via GitHub. They will be credited by name upon request.

--- a/src/npc/descriptions/fAnus.tw
+++ b/src/npc/descriptions/fAnus.tw
@@ -1,6 +1,7 @@
 :: FAnus [nobr]
 
 <<set $activeSlave.analCount++, $analTotal++>>
+<<set $activeSlave.currentSummary = 0>>
 
 You call her over so you can
 <<if ($activeSlave.anus > 3)>>

--- a/src/npc/descriptions/fBoobs.tw
+++ b/src/npc/descriptions/fBoobs.tw
@@ -1,7 +1,7 @@
-:: FBoobs
+:: FBoobs [nobr]
 
-<<nobr>>
 <<set $activeSlave.mammaryCount++, $mammaryTotal++>>
+<<set $activeSlave.currentSummary = 0>>
 
 You call her over so you can play with her
 <<if ($activeSlave.boobs >= 1000)>>
@@ -159,4 +159,3 @@ tits.
 	<</if>>
 <</for>>
 <</if>>
-<</nobr>>

--- a/src/npc/descriptions/fButt.tw
+++ b/src/npc/descriptions/fButt.tw
@@ -1,5 +1,7 @@
 :: FButt [nobr]
 
+<<set $activeSlave.currentSummary = 0>>
+
 You call her over so you can
 <<if ($activeSlave.vagina == -1)>>
 	use her sole fuckhole.

--- a/src/npc/descriptions/fLips.tw
+++ b/src/npc/descriptions/fLips.tw
@@ -2,6 +2,7 @@
 
 
 <<set $activeSlave.oralCount++, $oralTotal++>>
+<<set $activeSlave.currentSummary = 0>>
 
 You tell $activeSlave.slaveName to
 <<if ($PC.dick != 0)>>

--- a/src/npc/descriptions/fVagina.tw
+++ b/src/npc/descriptions/fVagina.tw
@@ -1,6 +1,7 @@
 :: FVagina [nobr]
 
 <<SlaveTitle $activeSlave>>
+<<set $activeSlave.currentSummary = 0>>
 
 You call her over so you can
 <<if ($activeSlave.vagina > 3)>>

--- a/src/npc/fAbuse.tw
+++ b/src/npc/fAbuse.tw
@@ -4,6 +4,7 @@
 	<<set $gameover = "idiot ball">><<goto "Gameover">>
 <</if>>
 
+<<set $activeSlave.currentSummary = 0>>
 <<set _asspain = 0>>
 
 <<if ($activeSlave.amp == 1)>>

--- a/src/uncategorized/longSlaveDescription.tw
+++ b/src/uncategorized/longSlaveDescription.tw
@@ -1,6 +1,9 @@
 :: Long Slave Description [nobr]
 
 <<SlavePronouns $activeSlave>>
+<<SlaveStatClamp $activeSlave>>
+/* Persistent Summary flag */
+<<set $activeSlave.currentSummary = 0>>
 
 /* 000-250-006 */
 <<if $seeImages == 1>>

--- a/src/uncategorized/main.tw
+++ b/src/uncategorized/main.tw
@@ -154,7 +154,7 @@ __''MAIN MENU''__&nbsp;&nbsp;&nbsp;&nbsp;//[[Summary Options]]//
 	<<else>>
 		| //<<link "Stop applying Rules Assistant at week end">><<set $rulesAssistantAuto = 0>><<goto "Main">><</link>>//
 	<</if>>
-	| //<<link "Re-apply Rules Assistant now (this will only check slaves in the Penthouse)">><<for _i = 0;_i < _SL;_i++>><<if $slaves[_i].assignmentVisible == 1 && $slaves[_i].useRulesAssistant == 1>><<CheckAutoRulesActivate $slaves[_i]>><<DefaultRules $slaves[_i]>><</if>><</for>><<goto "Main">><</link>>//
+	| //<<link "Re-apply Rules Assistant now (this will only check slaves in the Penthouse)">><<for _i = 0;_i < _SL;_i++>><<if $slaves[_i].assignmentVisible == 1 && $slaves[_i].useRulesAssistant == 1>><<$slaves[_i].currentSummary = 0>><<CheckAutoRulesActivate $slaves[_i]>><<DefaultRules $slaves[_i]>><</if>><</for>><<goto "Main">><</link>>//
 <</if>>
 //<<if $sortSlavesMain != 0>>
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;

--- a/src/uncategorized/nextWeek.tw
+++ b/src/uncategorized/nextWeek.tw
@@ -41,6 +41,7 @@
 		<<set $slaves[_i].rivalryTarget = 0>>
 	<</if>>
 	/% Fix some possible floating point rounding errors, and bring precision to one decimal place. %/
+	<<SlaveStatClamp $slaves[_i]>>
 	<<set $slaves[_i].energy = Math.clamp($slaves[_i].energy.toFixed(1), 0, 100)>>
 	<<if $slaves[_i].fetishStrength > 95>>
 		<<set $slaves[_i].fetishStrength = 100>>
@@ -72,6 +73,8 @@
 	<<elseif ($slaves[_i].assignment != "be confined in the cellblock") && ($slaves[_i].assignment != "be confined in the arcade") && (($slaves[_i].assignment != "work in the dairy") || ($dairyRestraintsSetting < 2))>>
 		<<set $averageTrust += $slaves[_i].trust*0.5, $averageDevotion += $slaves[_i].devotion*0.5, _slavesContributing += 0.5>>
 	<</if>>
+	/* Persistent Summary flag */
+	<<$slaves[_i].currentSummary = 0>>
 <</for>>
 <<set $averageTrust = $averageTrust/_slavesContributing>>
 <<set $averageDevotion = $averageDevotion/_slavesContributing>>

--- a/src/uncategorized/slaveSummary.tw
+++ b/src/uncategorized/slaveSummary.tw
@@ -3,11 +3,14 @@
 <<set _Pass = passage(), _SL = $slaves.length, $assignTo = _Pass>>
 <<for _ssi = 0; _ssi < _SL; _ssi++>>
 <<set _Slave = $slaves[_ssi]>>
+
 <<set _slaveName = _Slave.slaveName>>
 <<if _Slave.slaveSurname>><<set _slaveName += " " + _Slave.slaveSurname>><</if>>
+
 <<if _Slave.assignment == "be your agent" || _Slave.assignment == "live with your agent">>
 	<<continue>> /* slaves on these assignments should never be visible from facilities */
 <</if>>
+
 <<switch _Pass>>
 <<case "Main">>
 	<<if _Slave.assignmentVisible != 1>><<continue>><</if>>
@@ -28,2953 +31,509 @@
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_slaveName|Personal Attention Select][$personalAttention = $slaves["+_ssi+"].ID, $activeSlave = $slaves["+_ssi+"], $personalAttentionChanged = 1]]">>
 <<case "Agent Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.assignment != "be your agent") && (_Slave.devotion >= 20) && (_Slave.intelligence > 0) && (_Slave.intelligenceImplant > 0) && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Agent Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.assignment != "be your agent") && (_Slave.devotion >= 20) && (_Slave.intelligence > 0) && (_Slave.intelligenceImplant > 0) && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|Agent Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
 <<case "BG Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "guard you") && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Bodyguard Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "guard you") && canWalk(_Slave) && canSee(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|Bodyguard Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
 <<case "Recruiter Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "recruit girls") && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Recruiter Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "recruit girls") && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|Recruiter Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
 <<case "HG Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "be your Head Girl") && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|HG Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.assignment != "be your Head Girl") && canWalk(_Slave) && canSee(_Slave) && canTalk(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|HG Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
 <<case "Head Girl Suite">>
-<<if _Slave.fuckdoll > 0>><<continue>><</if>>
-<<if $Flag == 0>>
-	<<if (_Slave.assignment != "be your Head Girl") && (_Slave.indentureRestrictions <= 0)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<<else>>
-		<<continue>>
-	<</if>>
-<<else>>
-	<<if _Slave.assignment != "live with your Head Girl">>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<</if>>
-<<case "Subordinate Targeting">>
-<<if (_Slave.devotion >= -20) && (_Slave.fuckdoll == 0) && ($activeSlave.ID != _Slave.ID)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Subordinate Targeting][$activeSlave.subTarget = $slaves["+_ssi+"].ID]]">>
-<<else>>
-	<<continue>>
-<</if>>
-<<case "Spa">>
-<<if _Slave.fuckdoll > 0>><<continue>><</if>>
-<<if $Flag == 0>>
-	<<if _Slave.assignment == "rest in the spa">><<continue>><</if>>
-	<<if (_Slave.health < 20) || (_Slave.trust < 60) || (_Slave.devotion <= 60) || (_Slave.fetish == "mindbroken") || _Slave.sexualFlaw !== "none" || _Slave.behavioralFlaw !== "none">>
-	<<if _Slave.devotion >= -20 || _Slave.fetish == "mindbroken">>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<<else>>
-		<br>//_Slave.slaveName cannot be trusted in the spa//
-		<<continue>>
-	<</if>>
-	<<else>>
-		<br>//_Slave.slaveName cannot benefit from the spa//
-		<<continue>>
-	<</if>>
-<<elseif $Flag == 1>>
-	<<if _Slave.assignment != "rest in the spa">>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<<else>>
-	<<if _Slave.ID != $Attendant.ID>>
-		<<continue>>
-	<<else>>
-		<<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<</if>>
-<<case "Attendant Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Attendant Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
-<<case "Brothel">>
-<<if _Slave.fuckdoll > 0>><<continue>><</if>>
-<<if $Flag == 0>>
-	<<if _Slave.assignment == "work in the brothel">><<continue>><</if>>
-	<<if (_Slave.devotion > 50) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) ||  (_Slave.trust < -50) || (_Slave.trust > 50)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves[" + _ssi + "]]]">>
-	<<else>>
-		<br>//_Slave.slaveName must be either more fearful of you or devoted to you//
-		<<continue>>
-	<</if>>
-<<elseif $Flag == 1>>
-	<<if _Slave.assignment != "work in the brothel">>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<<else>>
-	<<if _Slave.ID != $Madam.ID>>
-		<<continue>>
-	<<else>>
-		<<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<</if>>
-<<case "Madam Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Madam Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
-<<case "Club">>
-<<if _Slave.fuckdoll > 0>><<continue>><</if>>
-<<if $Flag == 0>>
-	<<if _Slave.assignment == "serve in the club">><<continue>><</if>>
-	<<if (_Slave.devotion > 50) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50) || (_Slave.trust > 50)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<<else>>
-		<br>//_Slave.slaveName must be either more fearful of you or devoted to you//
-		<<continue>>
-	<</if>>
-<<elseif $Flag == 1>>
-	<<if _Slave.assignment != "serve in the club">>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<<else>>
-	<<if _Slave.ID != $DJ.ID>>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<</if>>
-<<case "DJ Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|DJ Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
-<<case "Clinic">>
-<<if _Slave.fuckdoll > 0>><<continue>><</if>>
-<<if $Flag == 0>>
-	<<if _Slave.assignment == "get treatment in the clinic">><<continue>><</if>>
-	<<if (_Slave.health < 20) || (($Nurse != 0) && (_Slave.chem > 0) && ($clinicUpgradeFilters == 1))>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<<else>>
-		<br>//_Slave.slaveName cannot benefit from the clinic//
-		<<continue>>
-	<</if>>
-<<elseif $Flag == 1>>
-	<<if _Slave.assignment != "get treatment in the clinic">>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<<else>>
-	<<if _Slave.ID != $Nurse.ID>>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<</if>>
-<<case "Nurse Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Nurse Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
-<<case "Schoolroom">>
-<<if _Slave.fuckdoll > 0 || _Slave.fetish == "mindbroken">><<continue>><</if>>
-<<if $Flag == 0>>
-	<<if _Slave.assignment == "learn in the schoolroom">><<continue>><</if>>
-	<<if (_Slave.devotion >= -20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50)>>
-		<<if (_Slave.intelligenceImplant < 1) || (_Slave.voice != 0 && _Slave.accent+$schoolroomUpgradeLanguage > 2) || (_Slave.oralSkill <= 10+$schoolroomUpgradeSkills*20) || (_Slave.whoreSkill <= 10+$schoolroomUpgradeSkills*20) || (_Slave.entertainSkill <= 10+$schoolroomUpgradeSkills*20) || (_Slave.analSkill < 10+$schoolroomUpgradeSkills*20) || ((_Slave.vagina >= 0) && (_Slave.vaginalSkill < 10+$schoolroomUpgradeSkills*20))>>
+	<<if _Slave.fuckdoll > 0>><<continue>><</if>>
+	<<if $Flag == 0>>
+		<<if (_Slave.assignment != "be your Head Girl") && (_Slave.indentureRestrictions <= 0)>>
 			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
 		<<else>>
-			<br>//_Slave.slaveName already has a basic education//
 			<<continue>>
 		<</if>>
 	<<else>>
-		<br>//_Slave.slaveName is too resistant to learn//
-		<<continue>>
+		<<if _Slave.assignment != "live with your Head Girl">>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
 	<</if>>
-<<elseif $Flag == 1>>
-	<<if _Slave.assignment != "learn in the schoolroom">>
-		<<continue>>
-	<<else>>
+<<case "Subordinate Targeting">>
+	<<if (_Slave.devotion >= -20) && (_Slave.fuckdoll == 0) && ($activeSlave.ID != _Slave.ID)>>
 		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<<else>>
-	<<if _Slave.ID != $Schoolteacher.ID>>
-		<<continue>>
+		<<print "[[_slaveName|Subordinate Targeting][$activeSlave.subTarget = $slaves["+_ssi+"].ID]]">>
 	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<<continue>>
 	<</if>>
-<</if>>
+<<case "Spa">>
+	<<if _Slave.fuckdoll > 0>><<continue>><</if>>
+	<<if $Flag == 0>>
+		<<if _Slave.assignment == "rest in the spa">><<continue>><</if>>
+		<<if (_Slave.health < 20) || (_Slave.trust < 60) || (_Slave.devotion <= 60) || (_Slave.fetish == "mindbroken") || _Slave.sexualFlaw !== "none" || _Slave.behavioralFlaw !== "none">>
+		<<if _Slave.devotion >= -20 || _Slave.fetish == "mindbroken">>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<<else>>
+			<br>//_Slave.slaveName cannot be trusted in the spa//
+			<<continue>>
+		<</if>>
+		<<else>>
+			<br>//_Slave.slaveName cannot benefit from the spa//
+			<<continue>>
+		<</if>>
+	<<elseif $Flag == 1>>
+		<<if _Slave.assignment != "rest in the spa">>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<<else>>
+		<<if _Slave.ID != $Attendant.ID>>
+			<<continue>>
+		<<else>>
+			<<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<</if>>
+<<case "Attendant Select">>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|Attendant Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
+<<case "Brothel">>
+	<<if _Slave.fuckdoll > 0>><<continue>><</if>>
+	<<if $Flag == 0>>
+		<<if _Slave.assignment == "work in the brothel">><<continue>><</if>>
+		<<if (_Slave.devotion > 50) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) ||  (_Slave.trust < -50) || (_Slave.trust > 50)>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves[" + _ssi + "]]]">>
+		<<else>>
+			<br>//_Slave.slaveName must be either more fearful of you or devoted to you//
+			<<continue>>
+		<</if>>
+	<<elseif $Flag == 1>>
+		<<if _Slave.assignment != "work in the brothel">>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<<else>>
+		<<if _Slave.ID != $Madam.ID>>
+			<<continue>>
+		<<else>>
+			<<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>><<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<</if>>
+<<case "Madam Select">>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave) && canSee(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|Madam Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
+<<case "Club">>
+	<<if _Slave.fuckdoll > 0>><<continue>><</if>>
+	<<if $Flag == 0>>
+		<<if _Slave.assignment == "serve in the club">><<continue>><</if>>
+		<<if (_Slave.devotion > 50) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50) || (_Slave.trust > 50)>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<<else>>
+			<br>//_Slave.slaveName must be either more fearful of you or devoted to you//
+			<<continue>>
+		<</if>>
+	<<elseif $Flag == 1>>
+		<<if _Slave.assignment != "serve in the club">>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<<else>>
+		<<if _Slave.ID != $DJ.ID>>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<</if>>
+<<case "DJ Select">>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|DJ Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
+<<case "Clinic">>
+	<<if _Slave.fuckdoll > 0>><<continue>><</if>>
+	<<if $Flag == 0>>
+		<<if _Slave.assignment == "get treatment in the clinic">><<continue>><</if>>
+		<<if (_Slave.health < 20) || (($Nurse != 0) && (_Slave.chem > 0) && ($clinicUpgradeFilters == 1))>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<<else>>
+			<br>//_Slave.slaveName cannot benefit from the clinic//
+			<<continue>>
+		<</if>>
+	<<elseif $Flag == 1>>
+		<<if _Slave.assignment != "get treatment in the clinic">>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<<else>>
+		<<if _Slave.ID != $Nurse.ID>>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<</if>>
+<<case "Nurse Select">>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) && canSee(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|Nurse Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
+<<case "Schoolroom">>
+	<<if _Slave.fuckdoll > 0 || _Slave.fetish == "mindbroken">><<continue>><</if>>
+	<<if $Flag == 0>>
+		<<if _Slave.assignment == "learn in the schoolroom">><<continue>><</if>>
+		<<if (_Slave.devotion >= -20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50)>>
+			<<if (_Slave.intelligenceImplant < 1) || (_Slave.voice != 0 && _Slave.accent+$schoolroomUpgradeLanguage > 2) || (_Slave.oralSkill <= 10+$schoolroomUpgradeSkills*20) || (_Slave.whoreSkill <= 10+$schoolroomUpgradeSkills*20) || (_Slave.entertainSkill <= 10+$schoolroomUpgradeSkills*20) || (_Slave.analSkill < 10+$schoolroomUpgradeSkills*20) || ((_Slave.vagina >= 0) && (_Slave.vaginalSkill < 10+$schoolroomUpgradeSkills*20))>>
+				<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+				<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+			<<else>>
+				<br>//_Slave.slaveName already has a basic education//
+				<<continue>>
+			<</if>>
+		<<else>>
+			<br>//_Slave.slaveName is too resistant to learn//
+			<<continue>>
+		<</if>>
+	<<elseif $Flag == 1>>
+		<<if _Slave.assignment != "learn in the schoolroom">>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<<else>>
+		<<if _Slave.ID != $Schoolteacher.ID>>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<</if>>
 <<case "Schoolteacher Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canTalk(_Slave) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Schoolteacher Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
-<<case "Dairy">>
-<<if _Slave.fuckdoll > 0>><<continue>><</if>>
-<<if $Flag == 0>>
-	<<if _Slave.assignment == "work in the dairy">><<continue>><</if>>
-	<<if (_Slave.indentureRestrictions > 0) && ($dairyRestraintsSetting > 1)>>
-		<br>//_Slave.slaveName's indenture forbids extractive Dairy service.//
-		<<continue>>
-	<<elseif (_Slave.indentureRestrictions > 1) && ($dairyRestraintsSetting > 0)>>
-		<br>//_Slave.slaveName's indenture allows only free range milking.//
-		<<continue>>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canTalk(_Slave) && canWalk(_Slave) && canSee(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|Schoolteacher Workaround][$i = "+_ssi+"]]">>
 	<<else>>
-		<<if ((_Slave.lactation > 0) || (_Slave.balls > 0)) || (($dairyFeedersUpgrade == 1) && ($dairyFeedersSetting > 0) && ($dairySlimMaintainUpgrade == 0))>>
-			<<if (_Slave.devotion > 20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) ||  (_Slave.trust < -50) || (_Slave.amp == 1) || ($dairyRestraintsUpgrade == 1)>>
-				<<if ($dairyStimulatorsSetting < 2) || (_Slave.anus > 2) || ($dairyPrepUpgrade == 1)>>
-					<<if ($dairyPregSetting < 2) || (_Slave.vagina > 2) || (_Slave.ovaries == 0) || ($dairyPrepUpgrade == 1)>>
-						<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-						<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<<continue>>
+	<</if>>
+<<case "Dairy">>
+	<<if _Slave.fuckdoll > 0>><<continue>><</if>>
+	<<if $Flag == 0>>
+		<<if _Slave.assignment == "work in the dairy">><<continue>><</if>>
+		<<if (_Slave.indentureRestrictions > 0) && ($dairyRestraintsSetting > 1)>>
+			<br>//_Slave.slaveName's indenture forbids extractive Dairy service.//
+			<<continue>>
+		<<elseif (_Slave.indentureRestrictions > 1) && ($dairyRestraintsSetting > 0)>>
+			<br>//_Slave.slaveName's indenture allows only free range milking.//
+			<<continue>>
+		<<else>>
+			<<if ((_Slave.lactation > 0) || (_Slave.balls > 0)) || (($dairyFeedersUpgrade == 1) && ($dairyFeedersSetting > 0) && ($dairySlimMaintainUpgrade == 0))>>
+				<<if (_Slave.devotion > 20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) ||  (_Slave.trust < -50) || (_Slave.amp == 1) || ($dairyRestraintsUpgrade == 1)>>
+					<<if ($dairyStimulatorsSetting < 2) || (_Slave.anus > 2) || ($dairyPrepUpgrade == 1)>>
+						<<if ($dairyPregSetting < 2) || (_Slave.vagina > 2) || (_Slave.ovaries == 0) || ($dairyPrepUpgrade == 1)>>
+							<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+							<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+							<<else>>
+								<br>//_Slave.slaveName's vagina cannot accommodate current machine settings//
+								<<continue>>
+							<</if>>
 						<<else>>
-							<br>//_Slave.slaveName's vagina cannot accommodate current machine settings//
+							<br>//_Slave.slaveName's anus cannot accommodate current machine settings//
 							<<continue>>
-						<</if>>
-					<<else>>
-						<br>//_Slave.slaveName's anus cannot accommodate current machine settings//
-						<<continue>>
+					<</if>>
+				<<else>>
+					<br>//_Slave.slaveName must be obedient in order to be milked here//
+					<<continue>>
+				<</if>>
+			<<elseif (($dairyFeedersUpgrade == 1) && ($dairyFeedersSetting > 0) && ($dairySlimMaintainUpgrade == 1) && ($dairySlimMaintain == 1))>>
+				<br>//_Slave.slaveName is not lactating<<if $seeDicks > 0>> or producing semen<</if>>, and <<print $dairyName>>'s current settings forbid the automatic implantation of lactation inducing drugs, so she can not be a cow//
+				<<continue>>
+			<<else>>
+				<br>//_Slave.slaveName is not lactating<<if $seeDicks > 0>> or producing semen<</if>> and cannot be a cow//
+				<<continue>>
+			<</if>>
+		<</if>>
+	<<elseif $Flag == 1>>
+		<<if _Slave.assignment != "work in the dairy">>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<<else>>
+		<<if _Slave.ID != $Milkmaid.ID>>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<</if>>
+<<case "Milkmaid Select">>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 20) && canWalk(_Slave) && canSee(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|Milkmaid Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
+<<case "Servants' Quarters">>
+	<<if _Slave.fuckdoll > 0>><<continue>><</if>>
+	<<if $Flag == 0>>
+		<<if _Slave.assignment == "work as a servant">><<continue>><</if>>
+		<<if (_Slave.devotion >= -20) || ((_Slave.devotion >= -50) && (_Slave.trust <= 20)) || (_Slave.trust < -20)>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<<else>>
+			<br>//_Slave.slaveName must be either more fearful of you or devoted to you//
+			<<continue>>
+		<</if>>
+	<<elseif $Flag == 1>>
+		<<if _Slave.assignment != "work as a servant">>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<<else>>
+		<<if _Slave.ID != $Stewardess.ID>>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<</if>>
+<<case "Stewardess Select">>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave) && canSee(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|Stewardess Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
+<<case "Master Suite">>
+	<<if $Flag == 0>>
+		<<if _Slave.assignment == "serve in the master suite">><<continue>><</if>>
+		<<if (_Slave.devotion > 20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50)>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves[" + _ssi + "]]]">>
+		<<else>>
+			<br>//_Slave.slaveName is not sufficiently broken for the master suite//
+			<<continue>>
+		<</if>>
+	<<elseif $Flag == 1>>
+		<<if _Slave.assignment != "serve in the master suite">>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<<else>>
+		<<if _Slave.ID != $Concubine.ID>>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<</if>>
+<<case "Concubine Select">>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) && canSee(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|Concubine Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
+<<case "Cellblock">>
+	<<if $Flag == 0>>
+		<<if _Slave.assignment == "be confined in the cellblock">><<continue>><</if>>
+		<<if (_Slave.devotion < -20 && _Slave.trust >= -20) || (_Slave.devotion < -50 && _Slave.trust >= -50)>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<<else>>
+			<<continue>>
+		<</if>>
+	<<elseif $Flag == 1>>
+		<<if _Slave.assignment != "be confined in the cellblock">>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<<else>>
+		<<if _Slave.ID != $Wardeness.ID>>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<</if>>
+<<case "Wardeness Select">>
+	<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) & canSee(_Slave)>>
+		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+		<<print "[[_slaveName|Wardeness Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		<<continue>>
+	<</if>>
+<<case "Arcade">>
+	<<if $Flag == 0>>
+		<<if _Slave.assignment == "be confined in the arcade">><<continue>><</if>>
+		<<if $arcade <= $arcadeSlaves && $arcadeUpgradeFuckdolls != 1>><<continue>><</if>>
+		<<if (_Slave.indentureRestrictions <= 0)>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<<else>>
+			<br>//_Slave.slaveName's indenture forbids arcade service.//
+			<<continue>>
+		<</if>>
+	<<else>>
+		<<if _Slave.assignment != "be confined in the arcade">>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+		<</if>>
+	<</if>>
+<<case "Pit">>
+	<<if _Slave.fuckdoll > 0>><<continue>><</if>>
+	<<if $Flag == 0>>
+		<<if (_Slave.indentureRestrictions > 0) && ($pitLethal == 1)>>
+			<br>//_Slave.slaveName's indenture forbids lethal fights.//
+			<<continue>>
+		<<elseif (_Slave.indentureRestrictions > 1)>>
+			<br>//_Slave.slaveName's indenture forbids fighting.//
+			<<continue>>
+		<<elseif (_Slave.heels != 1) || ((_Slave.shoes != "none") || (_Slave.shoes != "flats"))>>
+			<<if (_Slave.assignment != "work in the dairy") || ($dairyRestraintsSetting < 2) || canWalk(_Slave)>>
+				<<if ($fighterIDs.includes(_Slave.ID))>>
+					<<continue>>
+				<<else>>
+					<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+					<<print "[[_slaveName|Assign][$i = "+_ssi+"]]">>
 				<</if>>
 			<<else>>
-				<br>//_Slave.slaveName must be obedient in order to be milked here//
 				<<continue>>
-			<</if>>
-		<<elseif (($dairyFeedersUpgrade == 1) && ($dairyFeedersSetting > 0) && ($dairySlimMaintainUpgrade == 1) && ($dairySlimMaintain == 1))>>
-			<br>//_Slave.slaveName is not lactating<<if $seeDicks > 0>> or producing semen<</if>>, and <<print $dairyName>>'s current settings forbid the automatic implantation of lactation inducing drugs, so she can not be a cow//
-			<<continue>>
-		<<else>>
-			<br>//_Slave.slaveName is not lactating<<if $seeDicks > 0>> or producing semen<</if>> and cannot be a cow//
-			<<continue>>
-		<</if>>
-	<</if>>
-<<elseif $Flag == 1>>
-	<<if _Slave.assignment != "work in the dairy">>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<<else>>
-	<<if _Slave.ID != $Milkmaid.ID>>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<</if>>
-<<case "Milkmaid Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 20) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Milkmaid Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
-<<case "Servants' Quarters">>
-<<if _Slave.fuckdoll > 0>><<continue>><</if>>
-<<if $Flag == 0>>
-	<<if _Slave.assignment == "work as a servant">><<continue>><</if>>
-	<<if (_Slave.devotion >= -20) || ((_Slave.devotion >= -50) && (_Slave.trust <= 20)) || (_Slave.trust < -20)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<<else>>
-		<br>//_Slave.slaveName must be either more fearful of you or devoted to you//
-		<<continue>>
-	<</if>>
-<<elseif $Flag == 1>>
-	<<if _Slave.assignment != "work as a servant">>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<<else>>
-	<<if _Slave.ID != $Stewardess.ID>>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<</if>>
-<<case "Stewardess Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && (_Slave.intelligence > -2) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Stewardess Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
-<<case "Master Suite">>
-<<if $Flag == 0>>
-	<<if _Slave.assignment == "serve in the master suite">><<continue>><</if>>
-	<<if (_Slave.devotion > 20) || ((_Slave.devotion >= -50) && (_Slave.trust < -20)) || (_Slave.trust < -50)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves[" + _ssi + "]]]">>
-	<<else>>
-		<br>//_Slave.slaveName is not sufficiently broken for the master suite//
-		<<continue>>
-	<</if>>
-<<elseif $Flag == 1>>
-	<<if _Slave.assignment != "serve in the master suite">>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<<else>>
-	<<if _Slave.ID != $Concubine.ID>>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<</if>>
-<<case "Concubine Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) && canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Concubine Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
-<<case "Cellblock">>
-<<if $Flag == 0>>
-	<<if _Slave.assignment == "be confined in the cellblock">><<continue>><</if>>
-	<<if (_Slave.devotion < -20 && _Slave.trust >= -20) || (_Slave.devotion < -50 && _Slave.trust >= -50)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<<else>>
-		<<continue>>
-	<</if>>
-<<elseif $Flag == 1>>
-	<<if _Slave.assignment != "be confined in the cellblock">>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<<else>>
-	<<if _Slave.ID != $Wardeness.ID>>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<</if>>
-<<case "Wardeness Select">>
-<<if (_Slave.fuckdoll == 0) && (_Slave.devotion > 50) && canWalk(_Slave) & canSee(_Slave)>>
-	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-	<<print "[[_slaveName|Wardeness Workaround][$i = "+_ssi+"]]">>
-<<else>>
-	<<continue>>
-<</if>>
-<<case "Arcade">>
-<<if $Flag == 0>>
-	<<if _Slave.assignment == "be confined in the arcade">><<continue>><</if>>
-	<<if $arcade <= $arcadeSlaves && $arcadeUpgradeFuckdolls != 1>><<continue>><</if>>
-	<<if (_Slave.indentureRestrictions <= 0)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<<else>>
-		<br>//_Slave.slaveName's indenture forbids arcade service.//
-		<<continue>>
-	<</if>>
-<<else>>
-	<<if _Slave.assignment != "be confined in the arcade">>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
-	<</if>>
-<</if>>
-<<case "Pit">>
-<<if _Slave.fuckdoll > 0>><<continue>><</if>>
-<<if $Flag == 0>>
-	<<if (_Slave.indentureRestrictions > 0) && ($pitLethal == 1)>>
-		<br>//_Slave.slaveName's indenture forbids lethal fights.//
-		<<continue>>
-	<<elseif (_Slave.indentureRestrictions > 1)>>
-		<br>//_Slave.slaveName's indenture forbids fighting.//
-		<<continue>>
-	<<elseif (_Slave.heels != 1) || ((_Slave.shoes != "none") || (_Slave.shoes != "flats"))>>
-		<<if (_Slave.assignment != "work in the dairy") || ($dairyRestraintsSetting < 2) || canWalk(_Slave)>>
-			<<if ($fighterIDs.includes(_Slave.ID))>>
-				<<continue>>
-			<<else>>
-				<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-				<<print "[[_slaveName|Assign][$i = "+_ssi+"]]">>
 			<</if>>
 		<<else>>
 			<<continue>>
 		<</if>>
 	<<else>>
-		<<continue>>
+		<<if $fighterIDs.includes(_Slave.ID)>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Retrieve][$i = "+_ssi+"]]">>
+		<<else>>
+			<<continue>>
+		<</if>>
 	<</if>>
-<<else>>
-	<<if $fighterIDs.includes(_Slave.ID)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Retrieve][$i = "+_ssi+"]]">>
-	<<else>>
-		<<continue>>
-	<</if>>
-<</if>>
 <<case "Coursing Association">>
-<<if _Slave.fuckdoll > 0>><<continue>><</if>>
-<<if $Flag == 0>>
-	<<if canWalk(_Slave) && ($Lurcher.ID != _Slave.ID)>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Assign][$i = "+_ssi+"]]">>
+	<<if _Slave.fuckdoll > 0>><<continue>><</if>>
+	<<if $Flag == 0>>
+		<<if canWalk(_Slave) && ($Lurcher.ID != _Slave.ID)>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Assign][$i = "+_ssi+"]]">>
+		<<else>>
+			<<continue>>
+		<</if>>
 	<<else>>
-		<<continue>>
+		<<if $Lurcher.ID != _Slave.ID>>
+			<<continue>>
+		<<else>>
+			<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
+			<<print "[[_slaveName|Retrieve][$i = "+_ssi+"]]">>
+		<</if>>
 	<</if>>
-<<else>>
-	<<if $Lurcher.ID != _Slave.ID>>
-		<<continue>>
-	<<else>>
-		<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
-		<<print "[[_slaveName|Retrieve][$i = "+_ssi+"]]">>
-	<</if>>
-<</if>>
 <<case "New Game Plus">>
-<<if $Flag == 0>>
-	<<if _Slave.assignment != "be imported">>
-		<br>__''@@.pink;_Slave.slaveName@@''__
+	<<if $Flag == 0>>
+		<<if _Slave.assignment != "be imported">>
+			<br>__''@@.pink;_Slave.slaveName@@''__
+		<<else>>
+			<<continue>>
+		<</if>>
 	<<else>>
-		<<continue>>
+		<<if _Slave.assignment != "be imported">>
+			<<continue>>
+		<<else>>
+			<br>__''@@.pink;_Slave.slaveName@@''__
+		<</if>>
 	<</if>>
-<<else>>
-	<<if _Slave.assignment != "be imported">>
-		<<continue>>
-	<<else>>
-		<br>__''@@.pink;_Slave.slaveName@@''__
-	<</if>>
-<</if>>
 <<case "Rules Slave Select">>
-<<if $Flag == 0>>
-	<<if !ruleSlaveSelected(_Slave, $currentRule)>>
-		<br>__''
-		<<print "[[_slaveName|Rules Slave Select Workaround][$activeSlave = $slaves["+_ssi+"]]]">>''__
+	<<if $Flag == 0>>
+		<<if !ruleSlaveSelected(_Slave, $currentRule)>>
+			<br>__''
+			<<print "[[_slaveName|Rules Slave Select Workaround][$activeSlave = $slaves["+_ssi+"]]]">>''__
+		<<else>>
+			<<continue>>
+		<</if>>
 	<<else>>
-		<<continue>>
+		<<if ruleSlaveSelected(_Slave, $currentRule)>>
+			<br>__''
+			<<print "[[_slaveName|Rules Slave Deselect Workaround][$activeSlave = $slaves["+_ssi+"]]]">>''__
+		<<else>>
+			<<continue>>
+		<</if>>
 	<</if>>
-<<else>>
-	<<if ruleSlaveSelected(_Slave, $currentRule)>>
-		<br>__''
-		<<print "[[_slaveName|Rules Slave Deselect Workaround][$activeSlave = $slaves["+_ssi+"]]]">>''__
-	<<else>>
-		<<continue>>
-	<</if>>
-<</if>>
 <<case "Rules Slave Exclude">>
-<<if $Flag == 0>>
-	<<if !ruleSlaveExcluded(_Slave, $currentRule)>>
-		<br>__''
-		<<print "[[_slaveName|Rules Slave Exclude Workaround][$activeSlave = $slaves["+_ssi+"]]]">>''__
+	<<if $Flag == 0>>
+		<<if !ruleSlaveExcluded(_Slave, $currentRule)>>
+			<br>__''
+			<<print "[[_slaveName|Rules Slave Exclude Workaround][$activeSlave = $slaves["+_ssi+"]]]">>''__
+		<<else>>
+			<<continue>>
+		<</if>>
 	<<else>>
-		<<continue>>
+		<<if ruleSlaveExcluded(_Slave, $currentRule)>>
+			<br>__''
+			<<print "[[_slaveName|Rules Slave NoExclude Workaround][$activeSlave = $slaves["+_ssi+"]]]">>''__
+		<<else>>
+			<<continue>>
+		<</if>>
 	<</if>>
-<<else>>
-	<<if ruleSlaveExcluded(_Slave, $currentRule)>>
-		<br>__''
-		<<print "[[_slaveName|Rules Slave NoExclude Workaround][$activeSlave = $slaves["+_ssi+"]]]">>''__
-	<<else>>
-		<<continue>>
-	<</if>>
-<</if>>
 <<case "Matchmaking">>
 	<<if (_Slave.devotion < 100) || (_Slave.relationship != $activeSlave.relationship) || (_Slave.ID == $activeSlave.ID)>><<continue>><</if>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
 	<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
 <</switch>>
 
-<<set _Slave.energy = Math.clamp(_Slave.energy, 0, 100)>>
-
-<<if _Slave.devotion > 100>>
-	<<if _Slave.trust < -95>>
-		<<set _Slave.trust = -100>>
-	<<elseif (_Slave.trust < 100) && (_Slave.trust >= -20)>>
-		<<set _Slave.trust += Math.trunc(_Slave.devotion-100)>>
-	<<else>>
-		<<set $rep += 10*(_Slave.devotion-100)>>
-	<</if>>
-	<<set _Slave.devotion = 100>>
-<<elseif _Slave.devotion < -95>>
-	<<set _Slave.devotion = -100>>
-<</if>>
-<<if _Slave.trust > 100>>
-	<<if _Slave.devotion < -95>>
-		<<set _Slave.devotion = -100>>
-	<<elseif _Slave.devotion < 100>>
-		<<set _Slave.devotion += Math.trunc(_Slave.trust-100)>>
-	<<else>>
-		<<set $rep += 10*(_Slave.trust-100)>>
-	<</if>>
-	<<set _Slave.trust = 100>>
-<<elseif _Slave.trust < -95>>
-	<<set _Slave.trust = -100>>
-<</if>>
-<<if _Slave.trust < -100>><<set _Slave.trust = -100>><</if>>
-<<if _Slave.devotion < -100>><<set _Slave.devotion = -100>><</if>>
-
-<<set _Slave.trust = Math.trunc(_Slave.trust), _Slave.devotion = Math.trunc(_Slave.devotion), _Slave.health = Math.trunc(_Slave.health)>>
-
+/* SlaveStatClamp should get moved in the long run */
+<<SlaveStatClamp _Slave>>
+<<SlaveSummary _Slave>>
 <<set $slaves[_ssi] = _Slave>>
 
-will
-<<if (_Slave.assignment == "rest") && (_Slave.health >= -20)>>
-	''__@@.lawngreen;rest.@@__''
-<<elseif (_Slave.assignment == "stay confined") && ((_Slave.devotion > 20) || ((_Slave.trust < -20) && (_Slave.devotion >= -20)) || ((_Slave.trust < -50) && (_Slave.devotion >= -50)))>>
-	''__@@.lawngreen;stay confined.@@__''<<if _Slave.sentence > 0>> (_Slave.sentence weeks)<</if>>
-<<else>>
-	<<if _Slave.choosesOwnAssignment == 1>>choose her own job<<else>>_Slave.assignment<<if _Slave.sentence > 0>> (_Slave.sentence weeks)<</if>><</if>>.
-<</if>>
-
-<<if ($displayAssignments == 1) && (_Pass == "Main") && (_Slave.ID != $HeadGirl.ID) && (_Slave.ID != $Recruiter.ID) && (_Slave.ID != $Bodyguard.ID)>>
-	<span style="float:right;">
-	//Improve:// 
-	<<if _Slave.assignment != "rest">>
-		<<print "[[Rest|Rest Workaround][$i = "+_ssi+"]]">>
-	<<else>>
-		Rest
-	<</if>>
-	
-	<<if _Slave.fuckdoll == 0>>
-		<<if (_Slave.assignment != "stay confined")>>
-			| <<print "[[Confinement|Confinement Workaround][$i = "+_ssi+"]]">>
-		<<else>>
-			| Confinement
-		<</if>>
-	<</if>>
-	
-	<<if _Slave.fuckdoll == 0>>
-		<<if (_Slave.assignment != "take classes")>>
-			<<if (_Slave.intelligenceImplant != 1) && ((_Slave.devotion >= -20) || ((_Slave.trust < -20) && (_Slave.devotion >= -50)) || (_Slave.trust < -50)) && (_Slave.fetish != "mindbroken")>>
-				| <<print "[[Classes|Classes Workaround][$i = "+_ssi+"]]">>
-			<</if>>
-		<<else>>
-			| Classes
-		<</if>>
-	<</if>>
-	
-	&nbsp;&nbsp;&nbsp;&nbsp;
-	//Work:// 
-	
-	<<if _Slave.assignment != "please you">>
-		<<print "[[Fucktoy|Fucktoy Workaround][$i = "+_ssi+"]]">>
-	<<else>>
-		Fucktoy
-	<</if>>
-	
-	<<if _Slave.fuckdoll == 0>>
-		<<if (_Slave.assignment != "whore")>>
-			| <<print "[[Whore|Whore Workaround][$i = "+_ssi+"]]">>
-		<<else>>
-			| Whore
-		<</if>>
-	<</if>>
-				
-	<<if _Slave.fuckdoll == 0>>
-		<<if (_Slave.assignment != "serve the public")>>
-			| <<print "[[Public Servant|Public Servant Workaround][$i = "+_ssi+"]]">>
-		<<else>>
-			| Public Servant
-		<</if>>
-	<</if>>
-	
-	<<if _Slave.fuckdoll == 0>>
-		<<if (_Slave.assignment != "be a servant")>>
-			<<if ((_Slave.devotion >= -20) || ((_Slave.trust < -20) && (_Slave.devotion >= -50)) || (_Slave.trust < -50)) && canWalk(_Slave) && canSee(_Slave)>>
-				| <<print "[[House Servant|Servant Workaround][$i = "+_ssi+"]]">>
-			<</if>>
-		<<else>>
-			| House Servant
-		<</if>>
-	<</if>>
-		
-	<<if _Slave.fuckdoll == 0>>
-		<<if (_Slave.lactation > 0) || (_Slave.balls > 0)>>
-			<<if (_Slave.assignment != "get milked")>>
-				| <<print "[[Milked|Milking Workaround][$i = "+_ssi+"]]">>
-			<<else>>
-				| Milked
-			<</if>>
-		<</if>>
-	<</if>>	
-
-	<<if _Slave.indentureRestrictions <= 0>>
-		<<if _Slave.assignment != "work a glory hole">>
-			| <<print "[[Gloryhole|Hole Workaround][$i = "+_ssi+"]]">>
-		<<else>>
-			| Hole
-		<</if>>
-	<</if>>
-	</span>
-<</if>>
-
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $abbreviateDevotion == 1>>
-	<<if _Slave.fetish == "mindbroken">>@@.red;MB@@
-	<<elseif _Slave.devotion < -95>>@@.darkviolet;VHate<<if $summaryStats>>[_Slave.devotion]<</if>>@@
-	<<elseif _Slave.devotion < -50>>@@.darkviolet;Hate<<if $summaryStats>>[_Slave.devotion]<</if>>@@
-	<<elseif _Slave.devotion < -20>>@@.mediumorchid;Res<<if $summaryStats>>[_Slave.devotion]<</if>>@@
-	<<elseif _Slave.devotion <= 20>>@@.yellow;Ambiv<<if $summaryStats>>[_Slave.devotion]<</if>>@@
-	<<elseif _Slave.devotion <= 50>>@@.hotpink;Accept<<if $summaryStats>>[_Slave.devotion]<</if>>@@
-	<<elseif _Slave.devotion <= 95>>@@.deeppink;Devo<<if $summaryStats>>[_Slave.devotion]<</if>>@@
-	<<else>>@@.magenta;Wor<<if $summaryStats>>[_Slave.devotion]<</if>>@@
-	<</if>>
-	<<if _Slave.fetish == "mindbroken">>
-	<<elseif _Slave.trust < -95>>@@.darkgoldenrod;ETerr<<if $summaryStats>>[_Slave.trust]<</if>>
-	<<elseif _Slave.trust < -50>>@@.goldenrod;Terr<<if $summaryStats>>[_Slave.trust]<</if>>
-	<<elseif _Slave.trust < -20>>@@.gold;Fright<<if $summaryStats>>[_Slave.trust]<</if>>
-	<<elseif _Slave.trust <= 20>>@@.yellow;Fear<<if $summaryStats>>[_Slave.trust]<</if>>
-	<<elseif _Slave.trust <= 50>>@@.mediumaquamarine;Caref<<if $summaryStats>>[_Slave.trust]<</if>>
-	<<elseif _Slave.trust < 95>>@@.mediumseagreen;Trust<<if $summaryStats>>[_Slave.trust]<</if>>
-	<<else>>@@.seagreen;VTrust <<if $summaryStats>>[_Slave.trust]<</if>>
-	<</if>>
-<<elseif $abbreviateDevotion == 2>>
-	<<if _Slave.fetish == "mindbroken">>@@.red;Mindbroken.@@
-	<<elseif _Slave.devotion < -95>>@@.darkviolet;Very hateful<<if $summaryStats>> [_Slave.devotion]<</if>>.@@
-	<<elseif _Slave.devotion < -50>>@@.darkviolet;Hateful<<if $summaryStats>> [_Slave.devotion]<</if>>.@@
-	<<elseif _Slave.devotion < -20>>@@.mediumorchid;Resistant<<if $summaryStats>> [_Slave.devotion]<</if>>.@@
-	<<elseif _Slave.devotion <= 20>>@@.yellow;Ambivalent<<if $summaryStats>> [_Slave.devotion]<</if>>.@@
-	<<elseif _Slave.devotion <= 50>>@@.hotpink;Accepting<<if $summaryStats>> [_Slave.devotion]<</if>>.@@
-	<<elseif _Slave.devotion <= 95>>@@.deeppink;Devoted<<if $summaryStats>> [_Slave.devotion]<</if>>.@@
-	<<else>>@@.magenta;Worshipful<<if $summaryStats>> [_Slave.devotion]<</if>>.@@
-	<</if>>
-	<<if _Slave.fetish == "mindbroken">>
-	<<elseif _Slave.trust < -95>>@@.darkgoldenrod;Extremely terrified<<if $summaryStats>> [_Slave.trust]<</if>>.@@
-	<<elseif _Slave.trust < -50>>@@.goldenrod;Terrified<<if $summaryStats>> [_Slave.trust]<</if>>.@@
-	<<elseif _Slave.trust < -20>>@@.gold;Frightened<<if $summaryStats>> [_Slave.trust]<</if>>.@@
-	<<elseif _Slave.trust <= 20>>@@.yellow;Fearful<<if $summaryStats>> [_Slave.trust]<</if>>.@@
-	<<elseif _Slave.trust <= 50>>@@.mediumaquamarine;Careful<<if $summaryStats>> [_Slave.trust]<</if>>.@@
-	<<elseif _Slave.trust < 95>>@@.mediumseagreen;Trusting<<if $summaryStats>> [_Slave.trust]<</if>>.@@
-	<<else>>@@.seagreen;Profoundly trusting<<if $summaryStats>> [_Slave.trust]<</if>>.@@
-	<</if>>
-<</if>>
-
-<<if _Slave.fuckdoll == 0>>
-<<if $abbreviateRules == 1>>
-<<switch _Slave.livingRules>>
-<<case "luxurious">>
-	''LS:Lux''
-<<case "normal">>
-	''LS:Nor''
-<<default>>
-	''LS:Spa''
-<</switch>>
-<<if canTalk(_Slave)>>
-<<switch _Slave.speechRules>>
-<<case "permissive">>
-	''SpR:P''
-<<case "accent elimination">>
-	''SpR:NoAcc''
-<<default>>
-	''SpR:R''
-<</switch>>
-<</if>>
-<<switch _Slave.relationshipRules>>
-<<case "permissive">>
-	''ReR:P''
-<<case "just friends">>
-	''ReR:Fr''
-<<default>>
-	''ReR:R''
-<</switch>>
-<<switch _Slave.standardPunishment>>
-<<case "confinement">>
-	''Pun:Conf''
-<<case "whipping">>
-	''Pun:Whip''
-<<case "chastity">>
-	''Pun:Chas''
-<<default>>
-	''Pun:Situ''
-<</switch>>
-<<switch _Slave.standardReward>>
-<<case "relaxation">>
-	''Rew:Relx''
-<<case "drugs">>
-	''Rew:Drug''
-<<case "orgasm">>
-	''Rew:Orga''
-<<default>>
-	''Rew:Situ''
-<</switch>>
-<<switch _Slave.releaseRules>>
-<<case "permissive">>
-	''MaR:P''
-<<case "sapphic">>
-	''MaR:S''
-<<default>>
-	''MaR:R''
-<</switch>>
-<<elseif $abbreviateRules == 2>>
-Living standard: _Slave.livingRules.
-<<if canTalk(_Slave)>>Speech rules: _Slave.speechRules.<</if>>
-Relationship rules: _Slave.relationshipRules.
-Typical punishment: _Slave.standardPunishment.
-Typical reward: _Slave.standardReward.
-Release rules: _Slave.releaseRules.
-<</if>>
-<</if>>
-
-<<if _Slave.tired != 0>>Tired.<</if>>
-
-<<if $abbreviateDiet == 1>>
-	<<if _Slave.weight < -95>>
-		''@@.red;W---<<if $summaryStats>>[_Slave.weight]<</if>>@@''
-	<<elseif _Slave.weight < -30>>
-		<<if _Slave.hips < -1>>
-			''W--<<if $summaryStats>>[_Slave.weight]<</if>>''
-		<<else>>
-			''@@.red;W--<<if $summaryStats>>[_Slave.weight]<</if>>@@''
-		<</if>>
-	<<elseif _Slave.weight < -10>>
-		''W-<<if $summaryStats>>[_Slave.weight]<</if>>''
-	<<elseif _Slave.weight <= 10 >>
-		''W<<if $summaryStats>>[_Slave.weight]<</if>>''
-	<<elseif _Slave.weight <= 30>>
-		''W+<<if $summaryStats>>[_Slave.weight]<</if>>''
-	<<elseif _Slave.weight <= 95>>
-		<<if _Slave.hips > 1>>
-			''W++<<if $summaryStats>>[_Slave.weight]<</if>>''
-		<<else>>
-			''@@.red;W++<<if $summaryStats>>[_Slave.weight]<</if>>@@''
-		<</if>>
-	<<else>>
-		''@@.red;W+++<<if $summaryStats>>[_Slave.weight]<</if>>@@''
-	<</if>>
-<<elseif $abbreviateDiet == 2>>
-	<<if _Slave.weight < -95>>
-		@@.red;Emaciated<<if $summaryStats>> [_Slave.weight]<</if>>.@@
-	<<elseif _Slave.weight < -30>>
-		<<if _Slave.hips < -1>>
-			Model-thin<<if $summaryStats>> [_Slave.weight]<</if>>.
-		<<else>>
-			@@.red;Very thin<<if $summaryStats>> [_Slave.weight]<</if>>.@@
-		<</if>>
-	<<elseif _Slave.weight < -10>>
-		Thin<<if $summaryStats>> [_Slave.weight]<</if>>.
-	<<elseif _Slave.weight <= 10 >>
-		Trim<<if $summaryStats>> [_Slave.weight]<</if>>.
-	<<elseif _Slave.weight <= 30>>
-		Plush<<if $summaryStats>> [_Slave.weight]<</if>>.
-	<<elseif _Slave.weight <= 95>>
-		<<if _Slave.hips > 1>>
-			Nicely chubby<<if $summaryStats>> [_Slave.weight]<</if>>.
-		<<else>>
-			@@.red;Overweight<<if $summaryStats>> [_Slave.weight]<</if>>.@@
-		<</if>>
-	<<else>>
-		@@.red;Fat<<if $summaryStats>> [_Slave.weight]<</if>>.@@
-	<</if>>
-<</if>>
-
-<<if $abbreviateDiet == 1>>
-	<<switch _Slave.diet>>
-	<<case "restricted">>
-		''Di:W-''
-	<<case "fattening">>
-		''Di:W+''
-	<<case "muscle building">>
-		''Di:M+''
-	<<case "slimming">>
-		''Di:M-''
-	<</switch>>
-	<<if _Slave.dietCum == 2>>
-		''Cum++''
-	<<elseif ((_Slave.dietCum == 1) && (_Slave.dietMilk == 0))>>
-		''Cum+''
-	<<elseif ((_Slave.dietCum == 1) && (_Slave.dietMilk == 1))>>
-		''Cum+ Milk+''
-	<<elseif ((_Slave.dietCum == 0) && (_Slave.dietMilk == 1))>>
-		''Milk+''
-	<<elseif (_Slave.dietMilk == 2)>>
-		''Milk++''
-	<</if>>
-<<elseif $abbreviateDiet == 2>>
-	<<switch _Slave.diet>>
-	<<case "restricted">>
-		Dieting.
-	<<case "fattening">>
-		Gaining weight.
-	<<case "muscle building">>
-		Pumping iron.
-	<<case "slimming">>
-		Slimming down.
-	<</switch>>
-	<<if _Slave.dietCum == 2>>
-		Diet Base: @@.cyan;Cum Based.@@
-	<<elseif ((_Slave.dietCum == 1) && (_Slave.dietMilk == 0))>>
-		Diet Base: Cum Added.
-	<<elseif ((_Slave.dietCum == 1) && (_Slave.dietMilk == 1))>>
-		Diet Base: Milk & Cum Added.
-	<<elseif ((_Slave.dietCum == 0) && (_Slave.dietMilk == 1))>>
-		Diet Base: Milk Added.
-	<<elseif (_Slave.dietMilk == 2)>>
-		Diet Base: @@.cyan;Milk Based.@@
-	<</if>>
-<</if>>
-
-<<if $abbreviateHealth == 1>>
-	<<if _Slave.health < -20>>
-		''@@.red;H<<if $summaryStats>>[_Slave.health]<</if>>@@''
-	<<elseif _Slave.health <= 20>>
-		''@@.yellow;H<<if $summaryStats>>[_Slave.health]<</if>>@@''
-	<<elseif _Slave.health > 20>>
-		''@@.green;H<<if $summaryStats>>[_Slave.health]<</if>>@@''
-	<</if>>
-<<elseif $abbreviateHealth == 2>>
-	<<if _Slave.health < -90>>
-		@@.red;On the edge of death<<if $summaryStats>> [_Slave.health]<</if>>.@@
-	<<elseif _Slave.health < -50>>
-		@@.red;Extremely unhealthy<<if $summaryStats>> [_Slave.health]<</if>>.@@
-	<<elseif _Slave.health < -20>>
-		@@.red;Unhealthy<<if $summaryStats>> [_Slave.health]<</if>>.@@
-	<<elseif _Slave.health <= 20>>
-		@@.yellow;Healthy<<if $summaryStats>> [_Slave.health]<</if>>.@@
-	<<elseif _Slave.health <= 50>>
-		@@.green;Very healthy<<if $summaryStats>> [_Slave.health]<</if>>.@@
-	<<elseif _Slave.health <= 90>>
-		@@.green;Extremely healthy<<if $summaryStats>> [_Slave.health]<</if>>.@@
-	<<else>>
-		@@.green;Unnaturally healthy<<if $summaryStats>> [_Slave.health]<</if>>.@@
-	<</if>>
-<</if>>
-
-<<if $abbreviateDrugs == 1>>
-	<<switch _Slave.drugs>>
-	<<case "breast injections">>
-		''Dr:Boobs+''
-	<<case "butt injections">>
-		''Dr:Butt+''
-	<<case "lip injections">>
-		''Dr:Lip+''
-	<<case "fertility drugs">>
-		''Dr:Fert+''
-	<<case "penis enhancement">>
-		''Dr:Dick+''
-	<<case "testicle enhancement">>
-		''Dr:Balls+''
-	<<case "psychosuppressants">>
-		''Dr:Psych''
-	<<case "steroids">>
-		''Dr:Ster''
-	<<case "hormone enhancers">>
-		''Dr:Horm+''
-	<</switch>>
-	<<if _Slave.curatives == 2>>
-		''Cura''
-	<<elseif _Slave.curatives == 1>>
-		''Prev''
-	<</if>>
-	<<if _Slave.addict != 0>>
-		<<switch _Slave.aphrodisiacs>>
-		<<case 0>>
-		@@.cyan;Add@@
-		<<case 1>>
-			@@.cyan;Aph@@
-		<<case 2>>
-			@@.cyan;Aph++@@
-		<</switch>>
-	<<else>>
-		<<switch _Slave.aphrodisiacs>>
-		<<case 1>>
-			Aph
-		<<case 2>>
-			Aph++
-		<</switch>>
-	<</if>>
-	<<if _Slave.hormones > 1>>
-		''Ho:F+''
-	<<elseif _Slave.hormones > 0>>
-		''Ho:F''
-	<<elseif _Slave.hormones < -1>>
-		''Ho:M+''
-	<<elseif _Slave.hormones < 0>>
-		''Ho:M''
-	<</if>>
-	<<if ((_Slave.preg == -2) || (_Slave.ovaries == 0)) && (_Slave.vagina != -1)>>
-		''Barr''
-	<<elseif _Slave.preg == -1>>
-		''CC''
-	<<elseif _Slave.preg == 0>>
-		''Fert+''
-	<<elseif (_Slave.preg < 4) && (_Slave.preg > 0)>>
-		''Preg?''
-	<<elseif _Slave.preg >= 4>>
-		''_Slave.preg wks preg''
-	<</if>>
-<<elseif $abbreviateDrugs == 2>>
-	<<if (_Slave.drugs != "no drugs") && (_Slave.drugs != "none")>>
-		On _Slave.drugs.
-	<</if>>
-	<<if _Slave.curatives == 2>>
-		On curatives.
-	<<elseif _Slave.curatives == 1>>
-		On preventatives.
-	<</if>>
-	<<if _Slave.aphrodisiacs != 0>>
-		On <<if _Slave.aphrodisiacs > 1>>extreme <</if>>aphrodisiacs.
-	<</if>>
-	<<if _Slave.addict != 0>>
-		@@.cyan;Addict.@@
-	<</if>>
-	<<if _Slave.hormones > 1>>
-		''Heavy female hormones.''
-	<<elseif _Slave.hormones > 0>>
-		''Female hormones.''
-	<<elseif _Slave.hormones < -1>>
-		''Heavy male hormones.''
-	<<elseif _Slave.hormones < 0>>
-		''Male hormones.''
-	<</if>>
-	<<if ((_Slave.preg == -2) || (_Slave.ovaries == 0)) && (_Slave.vagina != -1)>>
-		Barren.
-	<<elseif _Slave.preg == -1>>
-		On contraceptives.
-	<<elseif _Slave.preg == 0>>
-		Fertile.
-	<<elseif (_Slave.preg < 4) && (_Slave.preg > 0)>>
-		May be pregnant.
-	<<elseif _Slave.preg >= 4>>
-		<<if _Slave.pregType < 2>>
-		_Slave.preg weeks pregnant.
-		<<else>>
-		_Slave.preg weeks pregnant with
-		<<if _Slave.pregType > 4>>
-		quintuplets.
-		<<elseif _Slave.pregType == 4>>
-		quadruplets.
-		<<elseif _Slave.pregType == 3>>
-		triplets.
-		<<else>>
-		twins.
-		<</if>>
-		<</if>>
-	<</if>>
-<</if>>
-
-<<if $abbreviateNationality+$abbreviateGenitalia+$abbreviatePhysicals+$abbreviateSkills+$abbreviateMental != 0>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<</if>>
-
-<<SlaveTitle _Slave>>
-<<set $seed = $desc.substring(0,1)>>
-<<set $seed = $seed.toUpperCase()>>
-<<set $desc = $seed + $desc.substring(1)>>
-''@@.coral;$desc<<if $abbreviatePhysicals == 2>>.<</if>>@@''
-
-<<if $seeRace == 1>>
-@@.tan;
-<<if $abbreviateRace == 1>>
-<<switch _Slave.race>>
-<<case "white">>
-	C
-<<case "asian">>
-	A
-<<case "indo-aryan">>
-	I
-<<case "latina">>
-	L
-<<case "middle eastern">>
-	ME
-<<case "black">>
-	B
-<<case "pacific islander">>
-	PI
-<<case "malay">>
-	M
-<<case "amerindian">>
-	AI
-<<case "semitic">>
-	S
-<<case "southern european">>
-	SE
-<<case "mixed race">>
-	MR
-<<default>>
-	<<print _Slave.race.charAt(0).toUpperCase() + _Slave.race.charAt(1) + _Slave.race.charAt(2)>>
-<</switch>>
-<<elseif $abbreviateRace == 2>>
-<<switch _Slave.race>>
-<<case "white">>
-	Caucasian.
-<<case "asian">>
-	Asian.
-<<case "indo-aryan">>
-	Indo-aryan.
-<<case "latina">>
-	Latina.
-<<case "middle eastern">>
-	Middle Eastern.
-<<case "black">>
-	Black.
-<<case "pacific islander">>
-	Pacific Islander.
-<<case "malay">>
-	Malay.
-<<case "amerindian">>
-	Amerindian.
-<<case "semitic">>
-	Semitic.
-<<case "southern european">>
-	Southern European.
-<<case "mixed race">>
-	Mixed race.
-<<default>>
-	<<print _Slave.race.charAt(0).toUpperCase() + _Slave.race.slice(1)>>.
-<</switch>>
-<</if>>
-@@
-<</if>>
-
-<<if $abbreviateNationality == 1>>
-@@.tan;
-<<switch _Slave.nationality>>
-<<case "American">>
-	US
-<<case "Canadian">>
-	Can
-<<case "Puerto Rican">>
-	PR
-<<case "Cuban">>
-	Cub
-<<case "Haitian">>
-	Hai
-<<case "Jamaican">>
-	Jam
-<<case "Mexican">>
-	Mex
-<<case "Peruvian">>
-	Per
-<<case "Venezuelan">>
-	Ven
-<<case "Bolivian">>
-	Bol
-<<case "Guatemalan">>
-	Gtm
-<<case "Brazilian">>
-	Bra
-<<case "Argentinian">>
-	Arg
-<<case "Chilean">>
-	Chl
-<<case "Colombian">>
-	Col
-<<case "Egyptian">>
-	Egy
-<<case "Turkish">>
-	Tur
-<<case "Iranian">>
-	Irn
-<<case "Armenian">>
-	Arm
-<<case "Israeli">>
-	Isr
-<<case "Saudi">>
-	Sau
-<<case "Moroccan">>
-	Mor
-<<case "Nigerian">>
-	Ng
-<<case "Kenyan">>
-	Ken
-<<case "Zimbabwean">>
-	Zwe
-<<case "Ugandan">>
-	Uga
-<<case "Tanzanian">>
-	Tza
-<<case "Ghanan">>
-	Gha
-<<case "Congolese">>
-	Cog
-<<case "Ethiopian">>
-	Eth
-<<case "South African">>
-	RSA
-<<case "Chinese">>
-	Chi
-<<case "Korean">>
-	Kor
-<<case "Japanese">>
-	Jpn
-<<case "Thai">>
-	Tha
-<<case "Vietnamese">>
-	Vnm
-<<case "Indonesian">>
-	Idn
-<<case "Filipina">>
-	Phl
-<<case "Burmese">>
-	Bur
-<<case "Nepalese">>
-	Npl
-<<case "Uzbek">>
-	Uzb
-<<case "Afghan">>
-	Afg
-<<case "Algerian">>
-	Alg
-<<case "Libyan">>
-	Lby
-<<case "Tunisian">>
-	Tun
-<<case "Lebanese">>
-	Lbn
-<<case "Jordanian">>
-	Jor
-<<case "Emirati">>
-	AE
-<<case "Omani">>
-	Omn
-<<case "Malian">>
-	Mal
-<<case "Sudanese">>
-	Sud
-<<case "Yemeni">>
-	Yem
-<<case "Iraqi">>
-	Irq
-<<case "Indian">>
-	Ind
-<<case "Malaysian">>
-	Mys
-<<case "Kazakh">>
-	Kaz
-<<case "Pakistani">>
-	Pak
-<<case "Bangladeshi">>
-	Bgd
-<<case "Russian">>
-	Rus
-<<case "Ukrainian">>
-	Ukr
-<<case "Irish">>
-	Irl
-<<case "Icelandic">>
-	Isl
-<<case "Finnish">>
-	Fin
-<<case "Swiss">>
-	Swi
-<<case "Danish">>
-	Dan
-<<case "Norwegian">>
-	Nor
-<<case "Austrian">>
-	Aut
-<<case "Slovak">>
-	Svk
-<<case "Dutch">>
-	Nld
-<<case "Belgian">>
-	Bel
-<<case "Czech">>
-	Cze
-<<case "Serbian">>
-	Srb
-<<case "Portuguese">>
-	Por
-<<case "Hungarian">>
-	Hun
-<<case "Estonian">>
-	Est
-<<case "Polish">>
-	Pol
-<<case "Lithuanian">>
-	Lit
-<<case "Romanian">>
-	Rom
-<<case "German">>
-	Ger
-<<case "Swedish">>
-	Swe
-<<case "French">>
-	Fra
-<<case "Italian">>
-	Ita
-<<case "Greek">>
-	Gre
-<<case "Spanish">>
-	Spa
-<<case "British">>
-	GB
-<<case "Australian">>
-	Aus
-<<case "a New Zealander">>
-	NZ
-<<case "Ancient Egyptian Revivalist">>
-	Egy Rev
-<<case "Ancient Chinese Revivalist">>
-	Chi Rev
-<<case "Edo Revivalist">>
-	Edo Rev
-<<case "Roman Revivalist">>
-	Rom Rev
-<<case "Aztec Revivalist">>
-	Azt Rev
-<<case "Arabian Revivalist">>
-	Ara Rev
-<<case "slave" "none" "">>
-	None
-<<default>>
-	<<print _Slave.nationality.charAt(0) + _Slave.nationality.charAt(1) + _Slave.nationality.charAt(2)>>
-<</switch>>
-@@
-<<elseif $abbreviateNationality == 2>>
-@@.tan;
-<<switch _Slave.nationality>>
-<<case "slave" "none" "">>
-	Stateless.
-<<default>>
-	_Slave.nationality.
-<</switch>>
-@@
-<</if>>
-
-<<if $abbreviatePhysicals == 1>>
-@@.pink;
-	<<switch _Slave.skin>>
-	<<case "light brown">>
-		L. Br
-	<<case "extremely pale">>
-		Ex. Pa
-	<<case "tanned">>
-		Tan
-	<<case "dark" "fair" "pale">>
-		<<print _Slave.skin.charAt(0).toUpperCase() + _Slave.skin.slice(1)>>
-	<<default>>
-		<<print _Slave.skin.charAt(0).toUpperCase() + _Slave.skin.charAt(1) + _Slave.skin.charAt(2)>>
-	<</switch>>
-<<else>>
-<<print _Slave.skin.charAt(0).toUpperCase() + _Slave.skin.slice(1)>> skin.
-@@
-<</if>>
-<<if $abbreviateGenitalia == 1>>
-<<if _Slave.dick > 0>>
-@@.pink;
-<<if _Slave.balls == 0>>
-	Geld
-<</if>>
-<<if (_Slave.dick > 8) && (_Slave.balls > 5)>>
-	Junk+++
-<<elseif (_Slave.dick > 5) && (_Slave.balls > 5)>>
-	Junk++
-<<elseif (_Slave.dick > 4) && (_Slave.balls > 4)>>
-	Junk+
-<<elseif (_Slave.dick > 3) && (_Slave.balls > 3)>>
-	Junk
-<<elseif _Slave.dick > 8>>
-	Dick+++
-<<elseif _Slave.dick > 5>>
-	Dick++
-<<elseif _Slave.dick > 4>>
-	Dick+
-<<elseif _Slave.dick > 3>>
-	Dick
-<<elseif _Slave.balls > 5>>
-	Balls++
-<<elseif _Slave.balls > 4>>
-	Balls+
-<<elseif _Slave.balls > 3>>
-	Balls
-<</if>>
-@@
-<</if>>
-<<if _Slave.vagina == 0>>
-	@@.lime;VV@@
-<<elseif (_Slave.preg > 0) && canWalk(_Slave) && (_Slave.clothes == "no clothing") && (_Slave.shoes == "none")>>
-	@@.pink;NBP@@
-<</if>>
-<<if _Slave.anus == 0>>
-	@@.lime;AV@@
-<</if>>
-@@.pink;
-<<if (_Slave.vagina > 3) && (_Slave.anus > 3)>>
-	V++A++
-<<elseif (_Slave.vagina > 2) && (_Slave.anus > 2)>>
-	V+A+
-<<elseif _Slave.vagina > 3>>
-	V++
-<<elseif _Slave.vagina > 2>>
-	V+
-<<elseif _Slave.anus > 3>>
-	A++
-<<elseif _Slave.anus > 2>>
-	A+
-<</if>>
-@@
-<<elseif $abbreviateGenitalia == 2>>
-<<if _Slave.dick > 0>>
-@@.pink;
-<<if _Slave.balls == 0>>
-	Gelded.
-<</if>>
-<<if (_Slave.dick > 8) && (_Slave.balls > 5)>>
-	Hyper dick & balls.
-<<elseif (_Slave.dick > 5) && (_Slave.balls > 5)>>
-	Monster dick & balls.
-<<elseif (_Slave.dick > 4) && (_Slave.balls > 4)>>
-	Huge dick & balls.
-<<elseif (_Slave.dick > 3) && (_Slave.balls > 3)>>
-	Big dick & balls.
-<<elseif _Slave.dick > 8>>
-	Hyper dong.
-<<elseif _Slave.dick > 5>>
-	Monster dong.
-<<elseif _Slave.dick > 4>>
-	Huge dick.
-<<elseif _Slave.dick > 3>>
-	Big dick.
-<<elseif _Slave.balls > 5>>
-	Monstrous balls.
-<<elseif _Slave.balls > 4>>
-	Huge balls.
-<<elseif _Slave.balls > 3>>
-	Big balls.
-<</if>>
-@@
-<</if>>
-<<if _Slave.vagina == 0>>
-	@@.lime;Virgin.@@
-<<elseif (_Slave.preg > 0) && canWalk(_Slave) && (_Slave.clothes == "no clothing") && (_Slave.shoes == "none")>>
-	@@.pink;Naked, barefoot, and pregnant.@@
-<</if>>
-<<if _Slave.anus == 0>>
-	@@.lime;Anal virgin.@@
-<</if>>
-@@.pink;
-<<if (_Slave.vagina > 3) && (_Slave.anus > 3)>>
-	Blown out holes.
-<<elseif (_Slave.vagina > 2) && (_Slave.anus > 2)>>
-	High mileage.
-<<elseif _Slave.vagina > 3>>
-	Cavernous pussy.
-<<elseif _Slave.vagina > 2>>
-	Loose pussy.
-<<elseif _Slave.anus > 3>>
-	Permagaped anus.
-<<elseif _Slave.anus > 2>>
-	Gaping anus.
-<</if>>
-@@
-<</if>>
-
-<<if $abbreviatePhysicals == 1>>
-@@.pink;
-<<if $showAgeDetail == 1>>
-	_Slave.age
-<<elseif _Slave.age >= 40>>
-	40s
-<<elseif _Slave.age >= 35>>
-	Lt30s
-<<elseif _Slave.age >= 30>>
-	Ea30s
-<<elseif _Slave.age >= 25>>
-	Lt20s
-<<elseif _Slave.age >= 20>>
-	Ea20s
-<<elseif _Slave.age >= 18>>
-	_Slave.age
-<</if>>
-<<if _Slave.ageImplant == 1>>
-	Age-
-<</if>>
-<<if _Slave.face < -95>>
-	@@.red;Face---<<if $summaryStats>>[_Slave.face]<</if>>@@
-<<elseif _Slave.face < -40>>
-	@@.red;Face--<<if $summaryStats>>[_Slave.face]<</if>>@@
-<<elseif _Slave.face < -10>>
-	@@.red;Face-<<if $summaryStats>>[_Slave.face]<</if>>@@
-<<elseif _Slave.face <= 10>>
-	Face<<if $summaryStats>>[_Slave.face]<</if>>
-<<elseif _Slave.face <= 40>>
-	@@.pink;Face+<<if $summaryStats>>[_Slave.face]<</if>>@@
-<<elseif _Slave.face <= 95>>
-	@@.pink;Face++<<if $summaryStats>>[_Slave.face]<</if>>@@
-<<else>>
-	@@.pink;Face+++<<if $summaryStats>>[_Slave.face]<</if>>@@
-<</if>>
-<<if _Slave.eyes == -2>>
-	@@.red;Blind@@
-<<elseif _Slave.eyes == -1 && (_Slave.eyewear != "corrective glasses") && (_Slave.eyewear != "corrective contacts")>>
-	@@.yellow;Sight-@@
-<</if>>
-
-<<if _Slave.markings != "none">>
-	Markings
-<</if>>
-
-<<if _Slave.lips > 95>>
-	Facepussy
-<<elseif _Slave.lips > 70>>
-	Lips+++<<if $summaryStats>>[_Slave.lips]<</if>>
-<<elseif _Slave.lips > 40>>
-	Lips++<<if $summaryStats>>[_Slave.lips]<</if>>
-<<elseif _Slave.lips > 20>>
-	Lips+<<if $summaryStats>>[_Slave.lips]<</if>>
-<<elseif _Slave.lips > 10>>
-	Lips<<if $summaryStats>>[_Slave.lips]<</if>>
-<<else>>
-	@@.red;Lips-@@<<if $summaryStats>>[_Slave.lips]<</if>>
-<</if>>
-<<if _Slave.teeth == "crooked">>
-	@@.yellow;Cr Teeth@@
-<<elseif _Slave.teeth == "cosmetic braces">>
-	Cos Braces
-<<elseif _Slave.teeth == "straightening braces">>
-	Braces
-<<elseif _Slave.teeth == "removable">>
-	Rem Teeth
-<<elseif _Slave.teeth == "pointy">>
-	Fangs
-<</if>>
-<<if _Slave.muscles > 95>>
-	Musc++<<if $summaryStats>>[_Slave.muscles]<</if>>
-<<elseif _Slave.muscles > 30>>
-	Musc+<<if $summaryStats>>[_Slave.muscles]<</if>>
-<<elseif _Slave.muscles > 5>>
-	Toned<<if $summaryStats>>[_Slave.muscles]<</if>>
-<<else>>
-	Musc-<<if $summaryStats>>[_Slave.muscles]<</if>>
-<</if>>
-<<if _Slave.amp != 0>>
-  <<if _Slave.amp == -1>>
-	P-Limbs
-  <<elseif _Slave.amp == -2>>
-	Sex P-Limbs
-  <<elseif _Slave.amp == -3>>
-	Beauty P-Limbs
-  <<elseif _Slave.amp == -4>>
-	Combat P-Limbs
-  <<elseif _Slave.amp == -5>>
-	Cyber P-Limbs
-  <<else>>
-	Amp
-  <</if>>
-<</if>>
-<<if !canWalk(_Slave)>>
-	Immob
-<</if>>
-<<if _Slave.heels == 1>>
-	Heel
-<</if>>
-@@
-<<if _Slave.voice == 0>>
-	@@.pink;Mute@@
-<<else>>
-	<<if _Slave.accent == 3>>
-		@@.red;Acc--@@
-	<<elseif _Slave.accent == 2>>
-		Acc-
-	<<elseif _Slave.accent == 1>>
-		@@.pink;Acc@@
-	<</if>>
-<</if>>
-@@.pink;
-<<if (_Slave.boobs > 10000) && (_Slave.butt > 9)>>
-	T&A+++
-<<elseif (_Slave.boobs > 4000) && (_Slave.butt > 8)>>
-	T&A++
-<<elseif (_Slave.boobs > 2000) && (_Slave.butt > 6)>>
-	T&A+
-<<elseif (_Slave.boobs > 800) && (_Slave.butt > 4)>>
-	T&A
-<<elseif (_Slave.boobs < 500) && (_Slave.butt < 3) && (_Slave.weight <= 10) && (_Slave.muscles <= 30)>>
-	Girlish
-<<elseif _Slave.boobs > 10000>>
-	Boobs+++
-<<elseif _Slave.boobs > 4000>>
-	Boobs++
-<<elseif _Slave.boobs > 2000>>
-	Boobs+
-<<elseif _Slave.boobs > 800>>
-	Boobs
-<<elseif _Slave.butt > 9>>
-	Ass+++
-<<elseif _Slave.butt > 8>>
-	Ass++
-<<elseif _Slave.butt > 6>>
-	Ass+
-<<elseif _Slave.butt > 4>>
-	Ass
-<</if>>
-@@
-@@.red;
-<<if _Slave.hips < -1>>
-<<if _Slave.butt > 2 && $arcologies[0].FSTransformationFetishist < 20>>
-	Disp
-<</if>>
-<<elseif _Slave.hips < 0>>
-<<if _Slave.butt > 4 && $arcologies[0].FSTransformationFetishist < 20>>
-	Disp
-<</if>>
-<<elseif _Slave.hips > 1>>
-<<if _Slave.butt <= 3>>
-	Disp
-<</if>>
-<<elseif _Slave.hips > 0>>
-<<if _Slave.butt > 8>>
-<<if $arcologies[0].FSTransformationFetishist < 20>>
-	Disp
-<</if>>
-<<elseif _Slave.butt <= 2>>
-	Disp
-<</if>>
-<<else>>
-<<if _Slave.butt > 6>>
-<<if $arcologies[0].FSTransformationFetishist < 20>>
-	Disp
-<</if>>
-<<elseif _Slave.butt <= 1>>
-	Disp
-<</if>>
-<</if>>
-@@
-<<if _Slave.waist > 95>>@@.red;Wst---<<if $summaryStats>>[_Slave.waist]<</if>>@@
-<<elseif _Slave.waist > 40>>@@.red;Wst--<<if $summaryStats>>[_Slave.waist]<</if>>@@
-<<elseif _Slave.waist > 10>>@@.red;Wst-<<if $summaryStats>>[_Slave.waist]<</if>>@@
-<<elseif _Slave.waist >= -10>>Wst<<if $summaryStats>>[_Slave.waist]<</if>>
-<<elseif _Slave.waist >= -40>>@@.pink;Wst+<<if $summaryStats>>[_Slave.waist]<</if>>@@
-<<elseif _Slave.waist >= -95>>@@.pink;Wst++<<if $summaryStats>>[_Slave.waist]<</if>>@@
-<<else>>@@.pink;Wst+++<<if $summaryStats>>[_Slave.waist]<</if>>@@
-<</if>>
-@@.pink;
-<<if (_Slave.boobsImplant == 0) && (_Slave.buttImplant == 0) && (_Slave.waist >= -95) && (_Slave.lipsImplant == 0) && (_Slave.faceImplant < 2)>>
-	Natr
-<<else>>
-	Impl
-<</if>>
-<<if _Slave.lactation == 1>>
-	Lact
-<<elseif _Slave.lactation == 2>>
-	Lact++
-<</if>>
-<<modScore _Slave>>
-<<if _Slave.corsetPiercing == 0 && $piercingScore < 3 && $tatScore < 2>>
-<<elseif $modScore > 15 || ($piercingScore > 8 && $tatScore > 5)>>
-	Mods++
-<<elseif $modScore > 7>>
-	Mods+
-<<else>>
-	Mods
-<</if>>
-<<if _Slave.brand != 0>>
-	Br
-<</if>>
-@@
-<<elseif $abbreviatePhysicals == 2>>
-@@.pink;
-<<if $showAgeDetail == 1>>
-	Age _Slave.age.
-<<elseif _Slave.age >= 40>>
-	Forties.
-<<elseif _Slave.age >= 35>>
-	Late thirties.
-<<elseif _Slave.age >= 30>>
-	Early thirties.
-<<elseif _Slave.age >= 25>>
-	Late twenties.
-<<elseif _Slave.age >= 20>>
-	Early twenties.
-<<elseif _Slave.age >= 19>>
-	Nineteen.
-<<else>>
-	Eighteen.
-<</if>>
-<<if _Slave.ageImplant == 1>>
-	Looks younger.
-<</if>>
-<<if _Slave.face < -95>>
-	@@.red;Very ugly<<if $summaryStats>> [_Slave.face]<</if>>@@
-<<elseif _Slave.face < -40>>
-	@@.red;Ugly<<if $summaryStats>> [_Slave.face]<</if>>@@
-<<elseif _Slave.face < -10>>
-	@@.red;Unattractive<<if $summaryStats>> [_Slave.face]<</if>>@@
-<<elseif _Slave.face <= 10>>
-	Average<<if $summaryStats>> [_Slave.face]<</if>>
-<<elseif _Slave.face <= 40>>
-	@@.pink;Attractive<<if $summaryStats>> [_Slave.face]<</if>>@@
-<<elseif _Slave.face <= 95>>
-	@@.pink;Beautiful<<if $summaryStats>> [_Slave.face]<</if>>@@
-<<else>>
-	@@.pink;Very beautiful<<if $summaryStats>> [_Slave.face]<</if>>@@
-<</if>>
-_Slave.faceShape face.
-<<if _Slave.eyes <= -2>>
-	@@.red;Blind.@@
-<<elseif _Slave.eyes <= -1>>
-	@@.yellow;Nearsighted.@@
-<</if>>
-<<if _Slave.lips > 95>>
-	Facepussy<<if $summaryStats>> [_Slave.lips]<</if>>.
-<<elseif _Slave.lips > 70>>
-	Huge lips<<if $summaryStats>> [_Slave.lips]<</if>>.
-<<elseif _Slave.lips > 40>>
-	Big lips<<if $summaryStats>> [_Slave.lips]<</if>>.
-<<elseif _Slave.lips > 20>>
-	Pretty lips<<if $summaryStats>> [_Slave.lips]<</if>>.
-<<elseif _Slave.lips > 10>>
-	Normal lips<<if $summaryStats>> [_Slave.lips]<</if>>.
-<<else>>
-	@@.red;Thin lips<<if $summaryStats>> [_Slave.lips]<</if>>.@@
-<</if>>
-<<if _Slave.teeth == "crooked">>
-	@@.yellow;Crooked teeth.@@
-<<elseif _Slave.teeth == "cosmetic braces">>
-	Cosmetic braces.
-<<elseif _Slave.teeth == "straightening braces">>
-	Braces.
-<<elseif _Slave.teeth == "removable">>
-	Removable teeth.
-<<elseif _Slave.teeth == "pointy">>
-	Sharp fangs.
-<</if>>
-<<if _Slave.muscles > 95>>
-	Hugely muscular<<if $summaryStats>> [_Slave.muscles]<</if>>.
-<<elseif _Slave.muscles > 30>>
-	Muscular<<if $summaryStats>> [_Slave.muscles]<</if>>.
-<<elseif _Slave.muscles > 5>>
-	Toned<<if $summaryStats>> [_Slave.muscles]<</if>>.
-<<else>>
-	Soft<<if $summaryStats>> [_Slave.muscles]<</if>>.
-<</if>>
-<<if _Slave.amp != 0>>
-	<<if _Slave.amp == -1>>
-	Prosthetic limbs.
-	<<elseif _Slave.amp == -2>>
-	Sexy prosthetic limbs.
-	<<elseif _Slave.amp == -3>>
-	Beautiful prosthetic limbs.
-	<<elseif _Slave.amp == -4>>
-	Deadly prosthetic limbs.
-	<<elseif _Slave.amp == -5>>
-	Cyber prosthetic limbs.
-	<<else>>
-	Amputee.
-	<</if>>
-<</if>>
-<<if !canWalk(_Slave)>>
-	Immobile.
-<</if>>
-<<if _Slave.heels == 1>>
-	Heeled.
-<</if>>
-@@
-<<if _Slave.voice == 0>>
-	@@.pink;Mute.@@
-<<else>>
-	<<if _Slave.accent == 3>>
-		@@.red;Bad accent.@@
-	<<elseif _Slave.accent == 2>>
-		Accent.
-	<<elseif _Slave.accent == 1>>
-		@@.pink;Cute accent.@@
-	<</if>>
-<</if>>
-@@.pink;
-<<if (_Slave.boobs > 10000) && (_Slave.butt > 9)>>
-	Hyper T&A.
-<<elseif (_Slave.boobs > 4000) && (_Slave.butt > 8)>>
-	Enormous T&A.
-<<elseif (_Slave.boobs > 2000) && (_Slave.butt > 6)>>
-	Huge T&A.
-<<elseif (_Slave.boobs > 800) && (_Slave.butt > 4)>>
-	Big T&A.
-<<elseif (_Slave.boobs < 500) && (_Slave.butt < 3) && (_Slave.weight <= 10) && (_Slave.muscles <= 30)>>
-	Girlish figure.
-<<elseif _Slave.boobs > 10000>>
-	Immobilizing tits.
-<<elseif _Slave.boobs > 4000>>
-	Monstrous tits.
-<<elseif _Slave.boobs > 2000>>
-	Huge tits.
-<<elseif _Slave.boobs > 800>>
-	Big tits.
-<<elseif _Slave.butt > 9>>
-	Hyper ass.
-<<elseif _Slave.butt > 8>>
-	Titanic ass.
-<<elseif _Slave.butt > 6>>
-	Huge ass.
-<<elseif _Slave.butt > 4>>
-	Big ass.
-<</if>>
-@@
-@@.red;
-<<if _Slave.hips < -1>>
-<<if _Slave.butt > 2 && $arcologies[0].FSTransformationFetishist < 20>>
-	Disproportionately big butt.
-<</if>>
-<<elseif _Slave.hips < 0>>
-<<if _Slave.butt > 4 && $arcologies[0].FSTransformationFetishist < 20>>
-	Disproportionately big butt.
-<</if>>
-<<elseif _Slave.hips > 1>>
-<<if _Slave.butt <= 3>>
-	Disproportionately small butt.
-<</if>>
-<<elseif _Slave.hips > 0>>
-<<if _Slave.butt > 8>>
-<<if $arcologies[0].FSTransformationFetishist < 20>>
-	Disproportionately big butt.
-<</if>>
-<<elseif _Slave.butt <= 2>>
-	Disproportionately small butt.
-<</if>>
-<<else>>
-<<if _Slave.butt > 6>>
-<<if $arcologies[0].FSTransformationFetishist < 20>>
-	Disproportionately big butt.
-<</if>>
-<<elseif _Slave.butt <= 1>>
-	Disproportionately small butt.
-<</if>>
-<</if>>
-@@
-<<if _Slave.waist > 95>>
-@@.red;Masculine waist<<if $summaryStats>> [_Slave.waist]<</if>>.@@
-<<elseif _Slave.waist > 40>>@@.red;Ugly waist<<if $summaryStats>> [_Slave.waist]<</if>>.@@
-<<elseif _Slave.waist > 10>>@@.red;Unattractive waist<<if $summaryStats>> [_Slave.waist]<</if>>.@@
-<<elseif _Slave.waist >= -10>>Average waist<<if $summaryStats>> [_Slave.waist]<</if>>.
-<<elseif _Slave.waist >= -40>>@@.pink;Feminine waist<<if $summaryStats>> [_Slave.waist]<</if>>.@@
-<<elseif _Slave.waist >= -95>>@@.pink;Hourglass waist<<if $summaryStats>> [_Slave.waist]<</if>>.@@
-<<else>>@@.pink;Absurdly narrow waist<<if $summaryStats>> [_Slave.waist]<</if>>.@@
-<</if>>
-@@.pink;
-<<if (_Slave.boobsImplant != 0) || (_Slave.buttImplant != 0) || (_Slave.lipsImplant != 0)>>
-	Implants.
-<<elseif (_Slave.faceImplant >= 2) || (_Slave.waist < -95)>>
-	Surgery enhanced.
-<<else>>
-	All natural.
-<</if>>
-<<if _Slave.lactation == 1>>
-	Lactating naturally.
-<<elseif _Slave.lactation == 2>>
-	Heavy lactation.
-<</if>>
-<<modScore _Slave>>
-<<if _Slave.corsetPiercing == 0 && $piercingScore < 3 && $tatScore < 2>>
-<<elseif $modScore > 15 || ($piercingScore > 8 && $tatScore > 5)>>
-	Extensive body mods.
-<<elseif $modScore > 7>>
-	Noticeable body mods.
-<<else>>
-	Light body mods.
-<</if>>
-<<if _Slave.brand != 0>>
-	Branded.
-<</if>>
-@@
-<</if>>
-
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-
-<<if $abbreviateSkills == 1>>
-<<if _Slave.fetish == "mindbroken">>
-<<elseif _Slave.intelligenceImplant == 1>>
-<<switch _Slave.intelligence>>
-<<case 3>>
-	@@.deepskyblue;I+++(e)@@
-<<case 2>>
-	@@.deepskyblue;I++(e)@@
-<<case 1>>
-	@@.deepskyblue;I+(e)@@
-<<case -1>>
-	@@.orangered;I-(e)@@
-<<case -2>>
-	@@.orangered;I--(e)@@
-<<case -3>>
-	@@.orangered;I---(e)@@
-<<default>>
-	I(e)
-<</switch>>
-<<else>>
-<<switch _Slave.intelligence>>
-<<case 3>>
-	@@.deepskyblue;I+++@@
-<<case 2>>
-	@@.deepskyblue;I++@@
-<<case 1>>
-	@@.deepskyblue;I+@@
-<<case -1>>
-	@@.orangered;I-@@
-<<case -2>>
-	@@.orangered;I--@@
-<<case -3>>
-	@@.orangered;I---@@
-<<default>>
-	I
-<</switch>>
-<</if>>
-
-<<set _SSkills = _Slave.analSkill+_Slave.oralSkill>>
-@@.aquamarine;
-<<if ((_SSkills+_Slave.whoreSkill+_Slave.entertainSkill) >= 400) && ((_Slave.vagina < 0) || (_Slave.vaginalSkill >= 100))>>
-	MSS
-<<else>>
-	<<set _SSkills += _Slave.vaginalSkill>>
-	<<set _SSkills = Math.trunc(_SSkills)>>
-	<<if _SSkills > 180>>S++
-		<<elseif (_SSkills > 120) && (_Slave.vagina < 0)>>Sh++
-		<<elseif _SSkills > 90>>S+
-		<<elseif _SSkills > 30>>S
-		<<else>>S-
-	<</if>>
-	<<if $summaryStats>>[_SSkills]<</if>>
-	<<if _Slave.whoreSkill >= 100>>W+++
-		<<elseif _Slave.whoreSkill > 60>>W++
-		<<elseif _Slave.whoreSkill > 30>>W+
-		<<elseif _Slave.whoreSkill > 10>>W
-	<</if>>
-	<<if _Slave.whoreSkill > 10>>
-		<<if $summaryStats>>[_Slave.whoreSkill]<</if>>
-	<</if>>
-	<<if _Slave.entertainSkill >= 100>>E+++
-		<<elseif _Slave.entertainSkill > 60>>E++
-		<<elseif _Slave.entertainSkill > 30>>E+
-		<<elseif _Slave.entertainSkill > 10>>E
-	<</if>>
-	<<if _Slave.entertainSkill > 10>>
-		<<if $summaryStats>>[_Slave.entertainSkill]<</if>>
-	<</if>>
-<</if>>
-<<if _Slave.combatSkill > 0>>
-	C
-<</if>>
-@@
-<<if _Slave.prestige > 0>>
-@@.green;
-<<if _Slave.prestige > 2>>
-	Prest++
-<<elseif _Slave.prestige == 2>>
-	Prest+
-<<elseif _Slave.prestige == 1>>
-	Prest
-<</if>>
-@@
-<</if>>
-<<elseif $abbreviateSkills == 2>>
-<<if _Slave.fetish == "mindbroken">>
-<<elseif _Slave.intelligenceImplant == 1>>
-<<switch _Slave.intelligence>>
-<<case 3>>
-	@@.deepskyblue;Brilliant, educated.@@
-<<case 2>>
-	@@.deepskyblue;Very smart, educated.@@
-<<case 1>>
-	@@.deepskyblue;Smart, educated.@@
-<<case -1>>
-	@@.orangered;Slow, educated.@@
-<<case -2>>
-	@@.orangered;Very slow, educated.@@
-<<case -3>>
-	@@.orangered;Moronic, educated.@@
-<<default>>
-	Average intelligence, educated.
-<</switch>>
-<<else>>
-<<switch _Slave.intelligence>>
-<<case 3>>
-	@@.deepskyblue;Brilliant.@@
-<<case 2>>
-	@@.deepskyblue;Very smart.@@
-<<case 1>>
-	@@.deepskyblue;Smart.@@
-<<case -1>>
-	@@.orangered;Slow.@@
-<<case -2>>
-	@@.orangered;Very slow.@@
-<<case -3>>
-	@@.orangered;Moronic.@@
-<<default>>
-	Average intelligence.
-<</switch>>
-<</if>>
-<<set _SSkills = (_Slave.analSkill+_Slave.oralSkill)>>
-@@.aquamarine;
-<<if ((_SSkills+_Slave.whoreSkill+_Slave.entertainSkill) >= 400) && ((_Slave.vagina < 0) || (_Slave.vaginalSkill >= 100))>>
-	Masterful Sex Slave.
-<<else>>
-	<<set _SSkills += _Slave.vaginalSkill>>
-	<<if _SSkills > 180>>
-		Sex master<<if $summaryStats>><<set _SSkills = Math.trunc(_SSkills)>> [_SSkills]<</if>>.
-	<<elseif (_SSkills > 120) && (_Slave.vagina < 0)>>
-		Masterful shemale<<if $summaryStats>><<set _SSkills = Math.trunc(_SSkills)>> [_SSkills]<</if>>.
-	<<elseif _SSkills > 90>>
-		Sexual expert<<if $summaryStats>><<set _SSkills = Math.trunc(_SSkills)>> [_SSkills]<</if>>.
-	<<elseif _SSkills > 30>>
-		Sexually skilled<<if $summaryStats>><<set _SSkills = Math.trunc(_SSkills)>> [_SSkills]<</if>>.
-	<<else>>
-		Sexually unskilled<<if $summaryStats>><<set _SSkills = Math.trunc(_SSkills)>> [_SSkills]<</if>>.
-	<</if>>
-	<<if _Slave.whoreSkill >= 100>>
-		Masterful whore<<if $summaryStats>> [_Slave.whoreSkill]<</if>>.
-	<<elseif _Slave.whoreSkill >= 60>>
-		Expert whore<<if $summaryStats>> [_Slave.whoreSkill]<</if>>.
-	<<elseif _Slave.whoreSkill >= 30>>
-		Skilled whore<<if $summaryStats>> [_Slave.whoreSkill]<</if>>.
-	<<elseif _Slave.whoreSkill >= 10>>
-		Basic whore<<if $summaryStats>> [_Slave.whoreSkill]<</if>>.
-	<</if>>
-	<<if _Slave.entertainSkill >= 100>>
-		Masterful entertainer<<if $summaryStats>> [_Slave.entertainSkill]<</if>>.
-	<<elseif _Slave.entertainSkill >= 60>>
-		Expert entertainer<<if $summaryStats>> [_Slave.entertainSkill]<</if>>.
-	<<elseif _Slave.entertainSkill >= 30>>
-		Skilled entertainer<<if $summaryStats>> [_Slave.entertainSkill]<</if>>.
-	<<elseif _Slave.entertainSkill >= 10>>
-		Basic entertainer<<if $summaryStats>> [_Slave.entertainSkill]<</if>>.
-	<</if>>
-<</if>>
-<<if _Slave.combatSkill > 0>>
-	Trained fighter.
-<</if>>
-@@
-<<if _Slave.prestige > 0>>
-@@.green;
-<<if _Slave.prestige > 2>>
-	Extremely prestigious.
-<<elseif _Slave.prestige == 2>>
-	Very prestigious.
-<<elseif _Slave.prestige == 1>>
-	Prestigious.
-<</if>>
-@@
-<</if>>
-<</if>>
-
-<<if $abbreviateMental == 1>>
-	<<if _Slave.fetish != "mindbroken">>
-	<<if _Slave.fetishKnown == 1>>
-	@@.lightcoral;
-	<<switch _Slave.fetish>>
-	<<case "submissive">>
-	<<if _Slave.fetishStrength > 95>>
-		Sub++
-	<<elseif _Slave.fetishStrength > 60>>
-		Sub+
-	<<else>>
-		Sub
-	<</if>>
-	<<case "cumslut">>
-	<<if _Slave.fetishStrength > 95>>
-		Oral++
-	<<elseif _Slave.fetishStrength > 60>>
-		Oral+
-	<<else>>
-		Oral
-	<</if>>
-	<<case "humiliation">>
-	<<if _Slave.fetishStrength > 95>>
-		Humil++
-	<<elseif _Slave.fetishStrength > 60>>
-		Humil+
-	<<else>>
-		Humil
-	<</if>>
-	<<case "buttslut">>
-	<<if _Slave.fetishStrength > 95>>
-		Anal++
-	<<elseif _Slave.fetishStrength > 60>>
-		Anal+
-	<<else>>
-		Anal
-	<</if>>
-	<<case "boobs">>
-	<<if _Slave.fetishStrength > 95>>
-		Boobs++
-	<<elseif _Slave.fetishStrength > 60>>
-		Boobs+
-	<<else>>
-		Boobs
-	<</if>>
-	<<case "sadist">>
-	<<if _Slave.fetishStrength > 95>>
-		Sadist++
-	<<elseif _Slave.fetishStrength > 60>>
-		Sadist+
-	<<else>>
-		Sadist
-	<</if>>
-	<<case "masochist">>
-	<<if _Slave.fetishStrength > 95>>
-		Pain++
-	<<elseif _Slave.fetishStrength > 60>>
-		Pain+
-	<<else>>
-		Pain
-	<</if>>
-	<<case "dom">>
-	<<if _Slave.fetishStrength > 95>>
-		Dom++
-	<<elseif _Slave.fetishStrength > 60>>
-		Dom+
-	<<else>>
-		Dom
-	<</if>>
-	<<case "pregnancy">>
-	<<if _Slave.fetishStrength > 95>>
-		Preg++
-	<<elseif _Slave.fetishStrength > 60>>
-		Preg+
-	<<else>>
-		Preg
-	<</if>>
-	<<default>>
-		Vanilla
-	<</switch>>
-	<<if $summaryStats>>[_Slave.fetishStrength]<</if>>
-	@@
-	<</if>>
-	<<if _Slave.attrKnown == 1>>
-	<<if _Slave.attrXY <= 5>>
-		@@.red;XY---<<if $summaryStats>>[_Slave.attrXY]<</if>>@@
-	<<elseif _Slave.attrXY <= 15>>
-		@@.red;XY--<<if $summaryStats>>[_Slave.attrXY]<</if>>@@
-	<<elseif _Slave.attrXY <= 35>>
-		@@.red;XY-<<if $summaryStats>>[_Slave.attrXY]<</if>>@@
-	<<elseif _Slave.attrXY <= 65>>
-		XY<<if $summaryStats>>[_Slave.attrXY]<</if>>
-	<<elseif _Slave.attrXY <= 85>>
-		@@.green;XY+<<if $summaryStats>>[_Slave.attrXY]<</if>>@@
-	<<elseif _Slave.attrXY <= 95>>
-		@@.green;XY++<<if $summaryStats>>[_Slave.attrXY]<</if>>@@
-	<<elseif _Slave.attrXX > 95>>
-		<<if _Slave.energy <= 95>>
-			@@.green;Omni!@@
-		<<else>>
-			@@.green;Omni+Nympho!!@@
-		<</if>>
-	<<else>>
-		@@.green;XY+++<<if $summaryStats>>[_Slave.attrXY]<</if>>@@
-	<</if>>
-	<<if _Slave.attrXX <= 5>>
-		@@.red;XX---<<if $summaryStats>>[_Slave.attrXX]<</if>>@@
-	<<elseif _Slave.attrXX <= 15>>
-		@@.red;XX--<<if $summaryStats>>[_Slave.attrXX]<</if>>@@
-	<<elseif _Slave.attrXX <= 35>>
-		@@.red;XX-<<if $summaryStats>>[_Slave.attrXX]<</if>>@@
-	<<elseif _Slave.attrXX <= 65>>
-		XX<<if $summaryStats>>[_Slave.attrXX]<</if>>
-	<<elseif _Slave.attrXX <= 85>>
-		@@.green;XX+<<if $summaryStats>>[_Slave.attrXX]<</if>>@@
-	<<elseif _Slave.attrXX <= 95>>
-		@@.green;XX++<<if $summaryStats>>[_Slave.attrXX]<</if>>@@
-	<<elseif _Slave.attrXY <= 95>>
-		@@.green;XX+++<<if $summaryStats>>[_Slave.attrXX]<</if>>@@
-	<</if>>
-	<<if _Slave.energy > 95>>
-		<<if (_Slave.attrXY <= 95) || (_Slave.attrXX <= 95)>>
-			@@.green;Nympho!@@
-		<</if>>
-	<<elseif _Slave.energy > 80>>
-		@@.green;SD++<<if $summaryStats>>[_Slave.energy]<</if>>@@
-	<<elseif _Slave.energy > 60>>
-		@@.green;SD+<<if $summaryStats>>[_Slave.energy]<</if>>@@
-	<<elseif _Slave.energy > 40>>
-		@@.yellow;SD<<if $summaryStats>>[_Slave.energy]<</if>>@@
-	<<elseif _Slave.energy > 20>>
-		@@.red;SD-<<if $summaryStats>>[_Slave.energy]<</if>>@@
-	<<else>>
-		@@.red;SD--<<if $summaryStats>>[_Slave.energy]<</if>>@@
-		<</if>>
-	<</if>>
-	<</if>>
-	<<if _Slave.clitPiercing == 3>>
-	<<if _Slave.fetishKnown == 1>>
-	<<if _Slave.clitSetting == "off">>
-		SP-
-	<<elseif ((_Slave.fetish != "submissive") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "submissive")>>
-		SP:sub
-	<<elseif ((_Slave.fetish != "cumslut") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "oral")>>
-		SP:oral
-	<<elseif ((_Slave.fetish != "humiliation") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "humiliation")>>
-		SP:humil
-	<<elseif ((_Slave.fetish != "buttslut") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "anal")>>
-		SP:anal
-	<<elseif ((_Slave.fetish != "boobs") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "boobs")>>
-		SP:boobs
-	<<elseif ((_Slave.fetish != "sadist") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "sadist")>>
-		SP:sade
-	<<elseif ((_Slave.fetish != "masochist") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "masochist")>>
-		SP:pain
-	<<elseif ((_Slave.fetish != "dom") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "dom")>>
-		SP:dom
-	<<elseif ((_Slave.fetish != "pregnancy") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "pregnancy")>>
-		SP:preg
-	<<elseif ((_Slave.fetish != "none") && (_Slave.clitSetting == "vanilla"))>>
-		SP:vanilla
-	<<elseif (_Slave.energy <= 95) && (_Slave.clitSetting == "all")>>
-		SP:all
-	<<elseif (_Slave.energy > 5) && (_Slave.clitSetting == "none")>>
-		SP:none
-	<</if>>
-	<<else>>
-	<<switch _Slave.clitSetting>>
-	<<case "off">>
-		SP-
-	<<case "submissive">>
-		SP:sub
-	<<case "lesbian">>
-		SP:les
-	<<case "oral">>
-		SP:oral
-	<<case "humiliation">>
-		SP:humil
-	<<case "anal">>
-		SP:anal
-	<<case "boobs">>
-		SP:boobs
-	<<case "sadist">>
-		SP:sade
-	<<case "masochist">>
-		SP:pain
-	<<case "dom">>
-		SP:dom
-	<<case "pregnancy">>
-		SP:pregnancy
-	<<case "vanilla">>
-		SP:vanilla
-	<<case "all">>
-		SP:all
-	<<case "none">>
-		SP:none
-	<</switch>>
-	<</if>>
-	<<if _Slave.attrKnown == 1>>
-		<<if _Slave.clitSetting == "women">>
-			<<if _Slave.attrXX < 95>>SP:women<</if>>
-		<<elseif _Slave.clitSetting == "men">>
-			<<if _Slave.attrXY < 95>>SP:men<</if>>
-		<<elseif _Slave.clitSetting == "anti-women">>
-			<<if _Slave.attrXX > 0>>SP:anti-women<</if>>
-		<<elseif _Slave.clitSetting == "anti-men">>
-			<<if _Slave.attrXY > 0>>SP:anti-men<</if>>
-		<</if>>
-	<<else>>
-		<<if _Slave.clitSetting == "women">>
-			SP:women
-		<<elseif _Slave.clitSetting == "men">>
-			SP:men
-		<<elseif _Slave.clitSetting == "anti-women">>
-			SP:anti-women
-		<<elseif _Slave.clitSetting == "anti-men">>
-			SP:anti-men
-		<</if>>
-	<</if>>
-	<</if>>
-	@@.red;
-	<<switch _Slave.behavioralFlaw>>
-	<<case "arrogant">>
-		Arrog
-	<<case "bitchy">>
-		Bitchy
-	<<case "odd">>
-		Odd
-	<<case "hates men">>
-		Men-
-	<<case "hates women">>
-		Women-
-	<<case "gluttonous">>
-		Glut
-	<<case "anorexic">>
-		Ano
-	<<case "devout">>
-		Dev
-	<<case "liberated">>
-		Lib
-	<<default>>
-		<<set _Slave.behavioralFlaw = "none">>
-	<</switch>>
-	@@
-	<<switch _Slave.sexualFlaw>>
-	<<case "hates oral">>
-		@@.red;Oral-@@
-	<<case "hates anal">>
-		@@.red;Anal-@@
-	<<case "hates penetration">>
-		@@.red;Fuck-@@
-	<<case "shamefast">>
-		@@.red;Shame@@
-	<<case "idealistic">>
-		@@.red;Ideal@@
-	<<case "repressed">>
-		@@.red;Repre@@
-	<<case "apathetic">>
-		@@.red;Apath@@
-	<<case "crude">>
-		@@.red;Crude@@
-	<<case "judgemental">>
-		@@.red;Judge@@
-	<<case "cum addict">>
-		@@.yellow;CumAdd@@
-	<<case "anal addict">>
-		@@.yellow;AnalAdd@@
-	<<case "attention whore">>
-		@@.yellow;Attention@@
-	<<case "breast growth">>
-		@@.yellow;BoobObsess@@
-	<<case "abusive">>
-		@@.yellow;Abusive@@
-	<<case "malicious">>
-		@@.yellow;Malice@@
-	<<case "self hating">>
-		@@.yellow;SelfHatr@@
-	<<case "neglectful">>
-		@@.yellow;SelfNeglect@@
-	<<case "breeder">>
-		@@.yellow;BreedObsess@@
-	<<default>>
-		<<set _Slave.sexualFlaw = "none">>
-	<</switch>>
-	@@.green;
-	<<switch _Slave.behavioralQuirk>>
-	<<case "confident">>
-		Confid
-	<<case "cutting">>
-		Cutting
-	<<case "funny">>
-		Funny
-	<<case "fitness">>
-		Fit
-	<<case "adores women">>
-		Women+
-	<<case "adores men">>
-		Men+
-	<<case "insecure">>
-		Insec
-	<<case "sinful">>
-		Sinf
-	<<case "advocate">>
-		Advoc
-	<<default>>
-		<<set _Slave.behavioralQuirk = "none">>
-	<</switch>>
-	<<switch _Slave.sexualQuirk>>
-	<<case "gagfuck queen">>
-		Gagfuck
-	<<case "painal queen">>
-		Painal
-	<<case "strugglefuck queen">>
-		Struggle
-	<<case "tease">>
-		Tease
-	<<case "romantic">>
-		Romantic
-	<<case "perverted">>
-		Perverted
-	<<case "caring">>
-		Caring
-	<<case "unflinching">>
-		Unflinch
-	<<case "size queen">>
-		SizeQ
-	<<default>>
-		<<set _Slave.sexualQuirk = "none">>
-	<</switch>>
-	@@
-<<elseif $abbreviateMental == 2>>
-	<<if _Slave.fetish != "mindbroken">>
-	<<if _Slave.fetishKnown == 1>>
-		@@.lightcoral;
-		<<switch _Slave.fetish>>
-		<<case "submissive">>
-			<<if _Slave.fetishStrength > 95>>
-				Complete submissive<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<elseif _Slave.fetishStrength > 60>>
-				Submissive<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<else>>
-				Submissive tendencies<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<</if>>
-		<<case "cumslut">>
-			<<if _Slave.fetishStrength > 95>>
-				Cumslut<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<elseif _Slave.fetishStrength > 60>>
-				Oral fixation<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<else>>
-				Prefers oral<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<</if>>
-		<<case "humiliation">>
-			<<if _Slave.fetishStrength > 95>>
-				Humiliation slut<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<elseif _Slave.fetishStrength > 60>>
-				Exhibitionist<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<else>>
-				Interest in humiliation<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<</if>>
-		<<case "buttslut">>
-			<<if _Slave.fetishStrength > 95>>
-				Buttslut<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<elseif _Slave.fetishStrength > 60>>
-				Anal fixation<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<else>>
-				Prefers anal<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<</if>>
-		<<case "boobs">>
-			<<if _Slave.fetishStrength > 95>>
-				Boobslut<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<elseif _Slave.fetishStrength > 60>>
-				Breast fixation<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<else>>
-				Loves boobs<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<</if>>
-		<<case "sadist">>
-			<<if _Slave.fetishStrength > 95>>
-				Complete sadist<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<elseif _Slave.fetishStrength > 60>>
-				Sadist<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<else>>
-				Sadistic tendencies<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<</if>>
-		<<case "masochist">>
-			<<if _Slave.fetishStrength > 95>>
-				Complete masochist<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<elseif _Slave.fetishStrength > 60>>
-				Masochist<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<else>>
-				Masochistic tendencies<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<</if>>
-		<<case "dom">>
-			<<if _Slave.fetishStrength > 95>>
-				Complete dom<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<elseif _Slave.fetishStrength > 60>>
-				Dominant<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<else>>
-				Dominant tendencies<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<</if>>
-		<<case "pregnancy">>
-			<<if _Slave.fetishStrength > 95>>
-				Pregnancy fetish<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<elseif _Slave.fetishStrength > 60>>
-				Pregnancy kink<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<<else>>
-				Interest in impregnation<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-			<</if>>
-		<<default>>
-			Sexually vanilla<<if $summaryStats>> [_Slave.fetishStrength]<</if>>.
-		<</switch>>
-		@@
-	<</if>>
-	<</if>>
-	<<if _Slave.attrKnown == 1>>
-		<<if _Slave.attrXY <= 5>>
-			@@.red;Disgusted by men<<if $summaryStats>> [_Slave.attrXY]<</if>>,@@
-		<<elseif _Slave.attrXY <= 15>>
-			@@.red;Turned off by men<<if $summaryStats>> [_Slave.attrXY]<</if>>,@@
-		<<elseif _Slave.attrXY <= 35>>
-			@@.red;Not attracted to men<<if $summaryStats>> [_Slave.attrXY]<</if>>,@@
-		<<elseif _Slave.attrXY <= 65>>
-			Indifferent to men<<if $summaryStats>> [_Slave.attrXY]<</if>>,
-		<<elseif _Slave.attrXY <= 85>>
-			@@.green;Attracted to men<<if $summaryStats>> [_Slave.attrXY]<</if>>,@@
-		<<elseif _Slave.attrXY <= 95>>
-			@@.green;Aroused by men<<if $summaryStats>> [_Slave.attrXY]<</if>>,@@
-		<<elseif _Slave.attrXX > 95>>
-			<<if _Slave.energy <= 95>>
-				@@.green;Omnisexual!@@
-			<<else>>
-				@@.green;Omnisexual nymphomaniac!@@
-			<</if>>
-		<<else>>
-			@@.green;Passionate about men<<if $summaryStats>> [_Slave.attrXY]<</if>>,@@
-		<</if>>
-		<<if _Slave.attrXX <= 5>>
-			@@.red;disgusted by women<<if $summaryStats>> [_Slave.attrXX]<</if>>.@@
-		<<elseif _Slave.attrXX <= 15>>
-			@@.red;turned off by women<<if $summaryStats>> [_Slave.attrXX]<</if>>.@@
-		<<elseif _Slave.attrXX <= 35>>
-			@@.red;not attracted to women<<if $summaryStats>> [_Slave.attrXX]<</if>>.@@
-		<<elseif _Slave.attrXX <= 65>>
-			indifferent to women<<if $summaryStats>> [_Slave.attrXX]<</if>>. 
-		<<elseif _Slave.attrXX <= 85>>
-			@@.green;attracted to women<<if $summaryStats>> [_Slave.attrXX]<</if>>.@@
-		<<elseif _Slave.attrXX <= 95>>
-			@@.green;aroused by women<<if $summaryStats>> [_Slave.attrXX]<</if>>.@@
-		<<elseif _Slave.attrXY <= 95>>
-			@@.green;passionate about women<<if $summaryStats>> [_Slave.attrXX]<</if>>.@@
-		<</if>>
-		<<if _Slave.energy > 95>>
-			<<if (_Slave.attrXY <= 95) || (_Slave.attrXX <= 95)>>
-				@@.green;Nymphomaniac!@@
-			<</if>>
-		<<elseif _Slave.energy > 80>>
-			@@.green;Powerful sex drive<<if $summaryStats>> [_Slave.energy]<</if>>.@@
-		<<elseif _Slave.energy > 60>>
-			@@.green;Good sex drive<<if $summaryStats>> [_Slave.energy]<</if>>.@@
-		<<elseif _Slave.energy > 40>>
-			@@.yellow;Average sex drive<<if $summaryStats>> [_Slave.energy]<</if>>.@@
-		<<elseif _Slave.energy > 20>>
-			@@.red;Poor sex drive<<if $summaryStats>> [_Slave.energy]<</if>>.@@
-		<<else>>
-			@@.red;No sex drive<<if $summaryStats>> [_Slave.energy]<</if>>.@@
-		<</if>>
-	<</if>>
-	<<if _Slave.clitPiercing == 3>>
-		<<if _Slave.fetishKnown == 1>>
-			<<if _Slave.clitSetting == "off">>
-				SP off.
-			<<elseif ((_Slave.fetish != "submissive") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "submissive")>>
-				SP: submissive.
-			<<elseif ((_Slave.fetish != "cumslut") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "oral")>>
-				SP: oral.
-			<<elseif ((_Slave.fetish != "humiliation") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "humiliation")>>
-				SP: humiliation.
-			<<elseif ((_Slave.fetish != "buttslut") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "anal")>>
-				SP: anal.
-			<<elseif ((_Slave.fetish != "boobs") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "boobs")>>
-				SP: breasts.
-			<<elseif ((_Slave.fetish != "sadist") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "sadist")>>
-				SP: sadism.
-			<<elseif ((_Slave.fetish != "masochist") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "masochist")>>
-				SP: masochism.
-			<<elseif ((_Slave.fetish != "dom") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "dom")>>
-				SP: dominance.
-			<<elseif ((_Slave.fetish != "pregnancy") || (_Slave.fetishStrength <= 95)) && (_Slave.clitSetting == "pregnancy")>>
-				SP: pregnancy.
-			<<elseif (_Slave.fetish != "none") && (_Slave.clitSetting == "vanilla")>>
-				SP: vanilla.
-			<<elseif (_Slave.energy <= 95) && (_Slave.clitSetting == "all")>>
-				SP: all.
-			<<elseif (_Slave.energy > 5) && (_Slave.clitSetting == "none")>>
-				SP: none.
-			<</if>>
-		<<else>>
-			<<switch _Slave.clitSetting>>
-			<<case "off">>
-				SP off.
-			<<case "submissive">>
-				SP: submissive.
-			<<case "oral">>
-				SP: oral.
-			<<case "humiliation">>
-				SP: humiliation.
-			<<case "anal">>
-				SP: anal.
-			<<case "boobs">>
-				SP: breasts.
-			<<case "sadist">>
-				SP: sadism.
-			<<case "masochist">>
-				SP: masochism.
-			<<case "dom">>
-				SP: dominance.
-			<<case "pregnancy">>
-				SP: pregnancy.
-			<<case "vanilla">>
-				SP: vanilla.
-			<<case "all">>
-				SP: all.
-			<<case "none">>
-				SP: none.
-			<</switch>>
-		<</if>>
-		<<if _Slave.attrKnown == 1>>
-			<<if (_Slave.attrXX < 100) && (_Slave.clitSetting == "women")>>
-				SP: women.
-			<<elseif (_Slave.attrXY < 100) && (_Slave.clitSetting == "men")>>
-				SP: men.
-			<</if>>
-		<<else>>
-			<<if _Slave.clitSetting == "women">>
-				SP: women.
-			<<elseif _Slave.clitSetting == "men">>
-				SP: men.
-			<</if>>
-		<</if>>
-	<</if>>
-	@@.red;
-	<<switch _Slave.behavioralFlaw>>
-	<<case "arrogant">>
-		Arrogant.
-	<<case "bitchy">>
-		Bitchy.
-	<<case "odd">>
-		Odd.
-	<<case "hates men">>
-		Hates men.
-	<<case "hates women">>
-		Hates women.
-	<<case "gluttonous">>
-		Stress eater.
-	<<case "anorexic">>
-		Anorexic.
-	<<case "devout">>
-		Devoutly religious.
-	<<case "liberated">>
-		Mentally liberated.
-	<<default>>
-		<<set _Slave.behavioralFlaw = "none">>
-	<</switch>>
-	@@
-	<<switch _Slave.sexualFlaw>>
-	<<case "hates oral">>
-		@@.red;Hates oral.@@
-	<<case "hates anal">>
-		@@.red;Hates anal.@@
-	<<case "hates penetration">>
-		@@.red;Hates penetration.@@
-	<<case "shamefast">>
-		@@.red;Shamefast.@@
-	<<case "idealistic">>
-		@@.red;Sexually idealistic.@@
-	<<case "repressed">>
-		@@.red;Sexually repressed.@@
-	<<case "apathetic">>
-		@@.red;Sexually apathetic.@@
-	<<case "crude">>
-		@@.red;Sexually crude.@@
-	<<case "judgemental">>
-		@@.red;Sexually judgemental.@@
-	<<case "cum addict">>
-		@@.yellow;Cum addict.@@
-	<<case "anal addict">>
-		@@.yellow;Anal addict.@@
-	<<case "attention whore">>
-		@@.yellow;Attention whore.@@
-	<<case "breast growth">>
-		@@.yellow;Breast obsession.@@
-	<<case "abusive">>
-		@@.yellow;Sexually abusive.@@
-	<<case "malicious">>
-		@@.yellow;Sexually malicious.@@
-	<<case "self hating">>
-		@@.yellow;Self hatred.@@
-	<<case "neglectful">>
-		@@.yellow;Self neglectful.@@
-	<<case "breeder">>
-		@@.yellow;Breeding obsession.@@
-	<<default>>
-		<<set _Slave.sexualFlaw = "none">>
-	<</switch>>
-	@@.green;
-	<<switch _Slave.behavioralQuirk>>
-	<<case "confident">>
-		Confident.
-	<<case "cutting">>
-		Cutting.
-	<<case "funny">>
-		Funny.
-	<<case "fitness">>
-		Fitness.
-	<<case "adores women">>
-		Adores women.
-	<<case "adores men">>
-		Adores men.
-	<<case "insecure">>
-		Insecure.
-	<<case "sinful">>
-		Sinful.
-	<<case "advocate">>
-		Advocate.
-	<<default>>
-		<<set _Slave.behavioralQuirk = "none">>
-	<</switch>>
-	<<switch _Slave.sexualQuirk>>
-	<<case "gagfuck queen">>
-		Gagfuck queen.
-	<<case "painal queen">>
-		Painal queen.
-	<<case "strugglefuck queen">>
-		Strugglefuck queen.
-	<<case "tease">>
-		Tease.
-	<<case "romantic">>
-		Romantic.
-	<<case "perverted">>
-		Perverted.
-	<<case "caring">>
-		Caring.
-	<<case "unflinching">>
-		Unflinching.
-	<<case "size queen">>
-		Size queen.
-	<<default>>
-		<<set _Slave.sexualQuirk = "none">>
-	<</switch>>
-	@@
-<</if>>
-
-<<if _Slave.customLabel != "">>''@@.yellow;_Slave.customLabel@@''<</if>>
-
-<<if (_Slave.relationship != 0) || (_Slave.relation != 0) || ($abbreviateClothes == 2) || ($abbreviateRulesets == 2)>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<</if>>
-
-<<if $abbreviateMental == 1>>
-@@.lightgreen;
-<<if _Slave.relation != 0>>
-<<for _ssj = 0; _ssj < _SL; _ssj++>>
-<<if _Slave.relationTarget == $slaves[_ssj].ID>>
-	$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s _Slave.relation
-	<<if _Slave.relationship <= 0>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-	<<break>>
-<</if>>
-<</for>>
-<</if>>
-<<if _Slave.relationship > 0>>
-<<for _ssj = 0; _ssj < _SL; _ssj++>>
-<<if _Slave.relationshipTarget == $slaves[_ssj].ID>>
-<<switch _Slave.relationship>>
-<<case 1>>
-	<<if _Slave.relationshipTarget != _Slave.relationTarget>>$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s<<else>>&<</if>> friend
-<<case 2>>
-	<<if _Slave.relationshipTarget != _Slave.relationTarget>>$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s<<else>>&<</if>> BFF
-<<case 3>>
-	<<if _Slave.relationshipTarget != _Slave.relationTarget>>$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s<<else>>&<</if>> FWB
-<<case 4>>
-	<<if _Slave.relationshipTarget != _Slave.relationTarget>>$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s<<else>>&<</if>> lover
-<<case 5>>
-	<<if _Slave.relationshipTarget != _Slave.relationTarget>>$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s<<else>>&<</if>> wife
-<</switch>>
-&nbsp;&nbsp;&nbsp;&nbsp;
-<<break>>
-<</if>>
-<</for>>
-<<elseif _Slave.relationship == -3>>
-	Your wife
-	&nbsp;&nbsp;&nbsp;&nbsp;
-<<elseif _Slave.relationship == -2>>
-	E Bonded
-	&nbsp;&nbsp;&nbsp;&nbsp;
-<<elseif _Slave.relationship == -1>>
-	E Slut
-	&nbsp;&nbsp;&nbsp;&nbsp;
-<</if>>
-@@
-<<if _Slave.rivalry != 0>>
-<<for _ssj = 0; _ssj < _SL; _ssj++>>
-<<if _Slave.rivalryTarget == $slaves[_ssj].ID>>
-@@.lightsalmon;
-<<if _Slave.rivalry <= 1>>
-	Disl $slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>
-<<elseif _Slave.rivalry <= 2>>
-	$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s rival
-<<else>>
-	Hates $slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>
-<</if>>
-&nbsp;&nbsp;&nbsp;&nbsp;
-@@
-<<break>>
-<</if>>
-<</for>>
-<</if>>
-<<elseif $abbreviateMental == 2>>
-<<if _Slave.relation != 0>>
-<<for _ssj = 0; _ssj < _SL; _ssj++>>
-<<if _Slave.relationTarget == $slaves[_ssj].ID>>
-	$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s
-	<<if _Slave.relationshipTarget != _Slave.relationTarget>>
-		@@.lightgreen;_Slave.relation@@.
-	<<else>>
-		@@.lightgreen;_Slave.relation@@
-	<</if>>
-	<<if _Slave.relationship <= 0>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-	<<break>>
-<</if>>
-<</for>>
-<</if>>
-<<if _Slave.relationship > 0>>
-<<for _ssj = 0; _ssj < _SL; _ssj++>>
-<<if _Slave.relationshipTarget == $slaves[_ssj].ID>>
-<<switch _Slave.relationship>>
-<<case 1>>
-	<<if _Slave.relationshipTarget != _Slave.relationTarget>>$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s<<else>>and<</if>> @@.lightgreen;friend.@@
-<<case 2>>
-	<<if _Slave.relationshipTarget != _Slave.relationTarget>>$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s<<else>>and<</if>> @@.lightgreen;best friend.@@
-<<case 3>>
-	<<if _Slave.relationshipTarget != _Slave.relationTarget>>$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s<<else>>and<</if>> @@.lightgreen;FWB.@@
-<<case 4>>
-	<<if _Slave.relationshipTarget != _Slave.relationTarget>>$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s<<else>>and<</if>> @@.lightgreen;lover.@@
-<<case 5>>
-	<<if _Slave.relationshipTarget != _Slave.relationTarget>>$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s<<else>>and<</if>> @@.lightgreen;slave wife.@@
-<</switch>>
-&nbsp;&nbsp;&nbsp;&nbsp;
-<<break>>
-<</if>>
-<</for>>
-<<elseif _Slave.relationship == -3>>
-	@@.lightgreen;Your wife.@@
-	&nbsp;&nbsp;&nbsp;&nbsp;
-<<elseif _Slave.relationship == -2>>
-	@@.lightgreen;Emotionally bonded to you.@@
-	&nbsp;&nbsp;&nbsp;&nbsp;
-<<elseif _Slave.relationship == -1>>
-	@@.lightgreen;Emotional slut.@@
-	&nbsp;&nbsp;&nbsp;&nbsp;
-<</if>>
-<<if _Slave.rivalry != 0>>
-<<for _ssj = 0; _ssj < _SL; _ssj++>>
-<<if _Slave.rivalryTarget == $slaves[_ssj].ID>>
-<<if _Slave.rivalry <= 1>>
-	@@.lightsalmon;Dislikes@@ $slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>.
-	&nbsp;&nbsp;&nbsp;&nbsp;
-<<elseif _Slave.rivalry <= 2>>
-	$slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>'s @@.lightsalmon;rival.@@
-	&nbsp;&nbsp;&nbsp;&nbsp;
-<<else>>
-	@@.lightsalmon;Hates@@ $slaves[_ssj].slaveName<<if $slaves[_ssj].slaveSurname>> $slaves[_ssj].slaveSurname<</if>>.
-	&nbsp;&nbsp;&nbsp;&nbsp;
-<</if>>
-<<break>>
-<</if>>
-<</for>>
-<</if>>
-<</if>>
-
-<<if _Slave.fuckdoll == 0>>
-<<if $abbreviateClothes == 2>>
-<<if _Slave.choosesOwnClothes == 1>>
-	Dressing herself.
-<</if>>
-<<switch _Slave.clothes>>
-<<case "attractive lingerie">>
-	Lingerie.
-<<case "a succubus outfit">>
-	Succubus outfit.
-<<case "a string bikini">>
-	String bikini.
-<<case "cutoffs and a t-shirt">>
-	Cutoffs, t-shirt.
-<<case "a slutty outfit">>
-	Slutty outfit.
-<<case "uncomfortable straps">>
-	Leather straps.
-<<case "a fallen nuns habit">>
-	Slutty habit.
-<<case "a chattel habit">>
-	Chattel habit.
-<<case "a penitent nuns habit">>
-	Cilice.
-<<case "slutty jewelry">>
-	Bangles.
-<<case "harem gauze">>
-	Harem outfit.
-<<case "a slave gown">>
-	Gown.
-<<case "a halter top dress">>
-	Halter top dress.
-<<case "a mini dress">>
-	Mini dress.
-<<case "a ball gown">>
-	Ball gown.
-<<case "slutty business attire">>
-	Slutty suit.
-<<case "nice business attire">>
-	Nice suit.
-<<case "a comfortable bodysuit">>
-	Bodysuit.
-<<case "a military uniform">>
-	Military uniform.
-<<case "a leotard">>
-	Leotard.
-<<case "a bunny outfit">>
-	Bunny outfit.
-<<case "a slutty maid outfit">>
-	Slutty maid.
-<<case "a nice maid outfit">>
-	Nice maid.
-<<case "a slutty nurse outfit">>
-	Slutty nurse.
-<<case "a nice nurse outfit">>
-	Nice nurse.
-<<case "a schoolgirl outfit">>
-	Schoolgirl outfit.
-<<case "a kimono">>
-	Kimono.
-<<case "a hijab and abaya">>
-	Hijab and abaya.
-<<case "battledress">>
-	Battledress.
-<<case "a latex catsuit">>
-	Nice latex.
-<<case "restrictive latex">>
-	Bondage latex.
-<<case "conservative clothing">>
-	Conservative clothing.
-<<case "chains">>
-	Chains.
-<<case "a cheerleader outfit">>
-	Cheerleader.
-<<case "clubslut netting">>
-	Netting.
-<<case "shibari ropes">>
-	Shibari.
-<<case "Western clothing">>
-	Chaps.
-<<case "body oil">>
-	Body oil.
-<<case "a toga">>
-	Toga.
-<<case "a huipil">>
-	Huipil.
-<<case "a slutty qipao">>
-	Qipao.
-<<default>>
-	Naked.
-<</switch>>
-<<switch _Slave.collar>>
-<<case "uncomfortable leather">>
-	Leather collar.
-<<case "tight steel">>
-	Steel collar.
-<<case "cruel retirement counter">>
-	Cruel counter collar.
-<<case "shock punishment">>
-	Shock collar.
-<<case "dildo gag">>
-	Dildo gag.
-<<case "neck corset">>
-	Neck corset.
-<<case "stylish leather">>
-	Stylish leather collar.
-<<case "satin choker">>
-	Satin choker.
-<<case "heavy gold">>
-	Gold collar.
-<<case "bowtie">>
-	Bowtie collar.
-<<case "pretty jewelry">>
-	Pretty collar.
-<<case "nice retirement counter">>
-	Nice counter collar.
-<<case "leather with cowbell">>
-	Cowbell collar.
-<<case "ancient Egyptian">>
-	Wesekh.
-<<case "ball gag">>
-	Ball gag.
-<<case "bit gag">>
-	Bit gag.
-<</switch>>
-<<switch _Slave.bellyAccessory>>
-<<case "shapewear">>
-	Shapewear.
-<<case "a small empathy belly">>
-	Small fake belly.
-<<case "a medium empathy belly">>
-	Medium fake belly.
-<<case "a large empathy belly">>
-	Large fake belly.
-<<case "a huge empathy belly">>
-	Huge fake belly.
-<<case "a corset">>
-	Corset.
-<<case "an extreme corset">>
-	Extreme corsetage.
-<</switch>>
-<<if canWalk(_Slave)>>
-<<if _Slave.shoes == "heels">>
-	Heels.
-<<elseif _Slave.shoes == "extreme heels">>
-	Extreme heels.
-<<elseif _Slave.shoes == "boots">>
-	Boots.
-<<elseif _Slave.heels == 1>>
-	@@.yellow;Crawling.@@
-<<elseif _Slave.shoes == "flats">>
-	Flats.
-<</if>>
-<</if>>
-<<switch _Slave.vaginalAccessory>>
-<<case "chastity belt">>
-	Vaginal chastity.
-<<case "combined chastity">>
-	Combined chastity.
-<<case "anal chastity">>
-	Anal chastity.
-<<case "dildo">>
-	Vaginal dildo.
-<<case "large dildo">>
-	Large vaginal dildo.
-<<case "huge dildo">>
-	Huge vaginal dildo.
-<</switch>>
-<<if _Slave.dickAccessory == "chastity">>
-	Chastity cage.
-<<elseif _Slave.dickAccessory == "combined chastity">>
-	Combined chastity.
-<<elseif _Slave.dickAccessory == "anal chastity">>
-	Anal chastity.
-<</if>>
-<<switch _Slave.buttplug>>
-<<case "plug">>
-	Buttplug.
-<<case "large plug">>
-	Large buttplug.
-<<case "huge plug">>
-	Huge buttplug.
-<<case "tailed plug">>
-	Tailed buttplug.
-<<case "large tailed plug">>
-	Large tailed buttplug.
-<<case "huge tailed plug">>
-	Huge tailed buttplug.
-<</switch>>
-<</if>>
-<</if>>
-
-&nbsp;&nbsp;&nbsp;&nbsp;
-<<if _Slave.useRulesAssistant == 0>>
-	@@.lightgreen;RA-Exempt@@
-<<elseif $abbreviateRulesets == 2 && (def _Slave.currentRules) && (_Slave.currentRules.length > 0)>>
-	<<for _s = 0; _s < $defaultRules.length; _s++>>
-		<<set _currentRule = $defaultRules[_s], _num = (_s+1)>>
-		<<if ruleApplied(_Slave, _currentRule.ID)>>
-			Rule _num (_currentRule.name).
-		<</if>>
-	<</for>>
-<</if>>
-
-<<if $abbreviateOrigins == 2 && _Slave.origin != 0>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-    @@.gray;_Slave.origin@@
-<</if>>
-
-<<set $slaves[_ssi] = _Slave>>
 
 <<switch _Pass>>
 <<case "Main">>

--- a/src/uncategorized/summaryOptions.tw
+++ b/src/uncategorized/summaryOptions.tw
@@ -2,6 +2,10 @@
 
 <<set $nextButton = "Back to Main", $nextLink = "Main">>
 
+<<for _i=0;_i<$slaves.length;_i++>>
+	<<set $slaves[_i].currentSummary = 0>>
+<</for>>
+
 //These options will affect the short slave summaries that appear on the main menu and the facility management screens.//
 
 <br><br>

--- a/src/uncategorized/walkPast.tw
+++ b/src/uncategorized/walkPast.tw
@@ -13,6 +13,8 @@
 <</if>>
 
 <<SlavePronouns $activeSlave>>
+/* Persistent Summary flag - this is here because if the slave gets used it can change her summary */
+<<set $slaves[_i].currentSummary = 0>>
 
 <span id="walk">
 

--- a/src/utility/raWidgets.tw
+++ b/src/utility/raWidgets.tw
@@ -2470,7 +2470,8 @@ Relationship rules: ''$currentRule.relationshipRules.''
                     <<continue>>
                 <</if>>
 
-                <<CheckAutoRulesActivate $slaves[_rai]>> /* does not use or modify $currentRule */
+                <<set $slaves[_rai].currentSummary = 0>>
+		<<CheckAutoRulesActivate $slaves[_rai]>> /* does not use or modify $currentRule */
                 <<DefaultRules $slaves[_rai]>>           /* does not use or modify $currentRule */
             <</for>>
         <</replace>>

--- a/src/utility/summaryWidgets.tw
+++ b/src/utility/summaryWidgets.tw
@@ -2822,6 +2822,12 @@ will
 	<<set $args[0].summary += "Large buttplug. ">>
 <<case "huge plug">>
 	<<set $args[0].summary += "Huge buttplug. ">>
+<<case "tailed plug">>
+	<<set $args[0].summary += "Tailed buttplug. ">>
+<<case "large tailed plug">>
+	<<set $args[0].summary += "Large tailed buttplug. ">>
+<<case "huge tailed plug">>
+	<<set $args[0].summary += "Huge tailed buttplug. ">>
 <</switch>>
 <</if>>
 <</if>>

--- a/src/utility/summaryWidgets.tw
+++ b/src/utility/summaryWidgets.tw
@@ -1,0 +1,2841 @@
+:: Summary Widgets [widget nobr]
+
+/%
+ Call as <<SlaveStatClamp $slave>>
+%/
+<<widget "SlaveStatClamp">>
+<<set $args[0].energy = Math.clamp($args[0].energy, 0, 100)>>
+
+<<if $args[0].devotion > 100>>
+	<<if $args[0].trust < -95>>
+		<<set $args[0].trust = -100>>
+	<<elseif ($args[0].trust < 100) && ($args[0].trust >= -20)>>
+		<<set $args[0].trust += Math.trunc($args[0].devotion-100)>>
+	<<else>>
+		<<set $rep += 10*($args[0].devotion-100)>>
+	<</if>>
+	<<set $args[0].devotion = 100>>
+<<elseif $args[0].devotion < -95>>
+	<<set $args[0].devotion = -100>>
+<</if>>
+<<if $args[0].trust > 100>>
+	<<if $args[0].devotion < -95>>
+		<<set $args[0].devotion = -100>>
+	<<elseif $args[0].devotion < 100>>
+		<<set $args[0].devotion += Math.trunc($args[0].trust-100)>>
+	<<else>>
+		<<set $rep += 10*($args[0].trust-100)>>
+	<</if>>
+	<<set $args[0].trust = 100>>
+<<elseif $args[0].trust < -95>>
+	<<set $args[0].trust = -100>>
+<</if>>
+<<if $args[0].trust < -100>><<set $args[0].trust = -100>><</if>>
+<<if $args[0].devotion < -100>><<set $args[0].devotion = -100>><</if>>
+<</widget>>
+
+/% 
+ Call as <<SlaveSummary $slave>>
+	Calling this widget will create a summary for the passed slave if needed.
+	It should be preceeded by the slave selection link, as it starts "will (assignment)".
+	Includes the general population simple links
+%/
+<<widget "SlaveSummary">>
+
+/*
+<<set _slaveName = $args[0].slaveName>>
+<<if $args[0].slaveSurname>><<set _slaveName += " " + $args[0].slaveSurname>><</if>>
+
+<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt $args[0] 1>></div><</if>>
+		<<print "[[_slaveName|Slave Interact][$activeSlave = $args[0] ]]">>
+/**/
+will
+<<if ($args[0].assignment == "rest") && ($args[0].health >= -20)>>
+	''__@@.lawngreen;rest.@@__''
+<<elseif ($args[0].assignment == "stay confined") && (($args[0].devotion > 20) || (($args[0].trust < -20) && ($args[0].devotion >= -20)) || (($args[0].trust < -50) && ($args[0].devotion >= -50)))>>
+	''__@@.lawngreen;stay confined.@@__''<<if $args[0].sentence > 0>> ($args[0].sentence weeks)<</if>>
+<<else>>
+	<<if $args[0].choosesOwnAssignment == 1>>choose her own job<<else>>$args[0].assignment<<if $args[0].sentence > 0>> ($args[0].sentence weeks)<</if>><</if>>.
+<</if>>
+
+<<if ($displayAssignments == 1) && (_Pass == "Main") && ($args[0].ID != $HeadGirl.ID) && ($args[0].ID != $Recruiter.ID) && ($args[0].ID != $Bodyguard.ID)>>
+	<span style="float:right;">
+	//Improve:// 
+	<<if $args[0].assignment != "rest">>
+		<<print "[[Rest|Rest Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		Rest
+	<</if>>
+	
+	<<if $args[0].fuckdoll == 0>>
+		<<if ($args[0].assignment != "stay confined")>>
+			| <<print "[[Confinement|Confinement Workaround][$i = "+_ssi+"]]">>
+		<<else>>
+			| Confinement
+		<</if>>
+	<</if>>
+	
+	<<if $args[0].fuckdoll == 0>>
+		<<if ($args[0].assignment != "take classes")>>
+			<<if ($args[0].intelligenceImplant != 1) && (($args[0].devotion >= -20) || (($args[0].trust < -20) && ($args[0].devotion >= -50)) || ($args[0].trust < -50)) && ($args[0].fetish != "mindbroken")>>
+				| <<print "[[Classes|Classes Workaround][$i = "+_ssi+"]]">>
+			<</if>>
+		<<else>>
+			| Classes
+		<</if>>
+	<</if>>
+	
+	&nbsp;&nbsp;&nbsp;&nbsp;
+	//Work:// 
+	
+	<<if $args[0].assignment != "please you">>
+		<<print "[[Fucktoy|Fucktoy Workaround][$i = "+_ssi+"]]">>
+	<<else>>
+		Fucktoy
+	<</if>>
+	
+	<<if $args[0].fuckdoll == 0>>
+		<<if ($args[0].assignment != "whore")>>
+			| <<print "[[Whore|Whore Workaround][$i = "+_ssi+"]]">>
+		<<else>>
+			| Whore
+		<</if>>
+	<</if>>
+				
+	<<if $args[0].fuckdoll == 0>>
+		<<if ($args[0].assignment != "serve the public")>>
+			| <<print "[[Public Servant|Public Servant Workaround][$i = "+_ssi+"]]">>
+		<<else>>
+			| Public Servant
+		<</if>>
+	<</if>>
+	
+	<<if $args[0].fuckdoll == 0>>
+		<<if ($args[0].assignment != "be a servant")>>
+			<<if (($args[0].devotion >= -20) || (($args[0].trust < -20) && ($args[0].devotion >= -50)) || ($args[0].trust < -50)) && canWalk($args[0]) && canSee($args[0])>>
+				| <<print "[[House Servant|Servant Workaround][$i = "+_ssi+"]]">>
+			<</if>>
+		<<else>>
+			| House Servant
+		<</if>>
+	<</if>>
+		
+	<<if $args[0].fuckdoll == 0>>
+		<<if ($args[0].lactation > 0) || ($args[0].balls > 0)>>
+			<<if ($args[0].assignment != "get milked")>>
+				| <<print "[[Milked|Milking Workaround][$i = "+_ssi+"]]">>
+			<<else>>
+				| Milked
+			<</if>>
+		<</if>>
+	<</if>>	
+
+	<<if $args[0].indentureRestrictions <= 0>>
+		<<if $args[0].assignment != "work a glory hole">>
+			| <<print "[[Gloryhole|Hole Workaround][$i = "+_ssi+"]]">>
+		<<else>>
+			| Hole
+		<</if>>
+	<</if>>
+	</span>
+<</if>>
+
+/**/
+<<if $args[0].currentSummary != 1>>
+	<<GenerateSlaveSummary $args[0]>>
+	<<set $args[0].currentSummary = 1>>
+<</if>>
+/**/
+
+<<print $args[0].summary>>
+
+/**/
+<<if $abbreviateOrigins == 2 && $args[0].origin != 0>>
+	<br>
+	<<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>
+		&nbsp;&nbsp;&nbsp;&nbsp;
+	<</if>>
+	@@.gray;$args[0].origin@@
+<</if>>
+<</widget>>
+
+/%
+ Call as <<GenerateSlaveSummary $slave>>
+   WIP to speed up SlaveSummary.tw and the places that call it.
+%/
+<<widget "GenerateSlaveSummary">>
+<<set _slaveName = $args[0].slaveName>>
+<<set _break = "<br>&nbsp;">>
+<<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>
+	<<set _break += "&nbsp;&nbsp;&nbsp;&nbsp;">>
+<</if>>
+
+/* - Line 1 - ******************************************************/
+<<set $args[0].summary = _break>>
+
+<<if $args[0].fetish == "mindbroken">>
+	<<if $abbreviateDevotion == 1>>
+		<<set $args[0].summary += "@@.red;MB@@ ">>
+	<<elseif $abbreviateDevotion == 2>>
+		<<set $args[0].summary += "@@.red;Mindbroken@@ ">>
+	<</if>>
+<<elseif $abbreviateDevotion == 1>>
+	<<if $args[0].devotion < -95>>
+		<<set $args[0].summary += "@@.darkviolet;VHate">>
+	<<elseif $args[0].devotion < -50>>
+		<<set $args[0].summary += "@@.darkviolet;Hate">>
+	<<elseif $args[0].devotion < -20>>
+		<<set $args[0].summary += "@@.mediumorchid;Res">>
+	<<elseif $args[0].devotion <= 20>>
+		<<set $args[0].summary += "@@.yellow;Ambiv">>
+	<<elseif $args[0].devotion <= 50>>
+		<<set $args[0].summary += "@@.hotpink;Accept">>
+	<<elseif $args[0].devotion <= 95>>
+		<<set $args[0].summary += "@@.deeppink;Devo">>
+	<<else>>
+		<<set $args[0].summary += "@@.magenta;Wor">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += "["+$args[0].devotion+"]@@ ">>
+	<<else>>
+		<<set $args[0].summary += "@@ ">>
+	<</if>>
+	<<if $args[0].trust < -95>>
+		<<set $args[0].summary += "@@.darkgoldenrod;ETerr">>
+	<<elseif $args[0].trust < -50>>
+		<<set $args[0].summary += "@@.goldenrod;Terr">>
+	<<elseif $args[0].trust < -20>>
+		<<set $args[0].summary += "@@.gold;Fright">>
+	<<elseif $args[0].trust <= 20>>
+		<<set $args[0].summary += "@@.yellow;Fear">>
+	<<elseif $args[0].trust <= 50>>
+		<<set $args[0].summary += "@@.mediumaquamarine;Caref">>
+	<<elseif $args[0].trust < 95>>
+		<<set $args[0].summary += "@@.mediumseagreen;Trust">>
+	<<else>>
+		<<set $args[0].summary += "@@.seagreen;VTrust">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += "["+$args[0].trust+"]@@ ">>
+	<<else>>
+		<<set $args[0].summary += "@@ ">>
+	<</if>>
+<<elseif $abbreviateDevotion == 2>>
+	<<if $args[0].devotion < -95>>
+		<<set $args[0].summary += "@@.darkviolet;Very hateful">>
+	<<elseif $args[0].devotion < -50>>
+		<<set $args[0].summary += "@@.darkviolet;Hateful">>
+	<<elseif $args[0].devotion < -20>>
+		<<set $args[0].summary += "@@.mediumorchid;Resistant">>
+	<<elseif $args[0].devotion <= 20>>
+		<<set $args[0].summary += "@@.yellow;Ambivalent">>
+	<<elseif $args[0].devotion <= 50>>
+		<<set $args[0].summary += "@@.hotpink;Accepting">>
+	<<elseif $args[0].devotion <= 95>>
+		<<set $args[0].summary += "@@.deeppink;Devoted">>
+	<<else>>
+		<<set $args[0].summary += "@@.magenta;Worshipful">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += " ["+$args[0].devotion+"].@@ ">>
+	<<else>>
+		<<set $args[0].summary += ".@@ ">>
+	<</if>>
+	<<if $args[0].trust < -95>>
+		<<set $args[0].summary += "@@.darkgoldenrod;Extremely terrified">>
+	<<elseif $args[0].trust < -50>>
+		<<set $args[0].summary += "@@.goldenrod;Terrified">>
+	<<elseif $args[0].trust < -20>>
+		<<set $args[0].summary += "@@.gold;Frightened">>
+	<<elseif $args[0].trust <= 20>>
+		<<set $args[0].summary += "@@.yellow;Fearful">>
+	<<elseif $args[0].trust <= 50>>
+		<<set $args[0].summary += "@@.mediumaquamarine;Careful">>
+	<<elseif $args[0].trust < 95>>
+		<<set $args[0].summary += "@@.mediumseagreen;Trusting">>
+	<<else>>
+		<<set $args[0].summary += "@@.seagreen;Profoundly trusting">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += " ["+$args[0].trust+"].@@ ">>
+	<<else>>
+		<<set $args[0].summary += ".@@ ">>
+	<</if>>
+<</if>>
+
+<<if $args[0].fuckdoll == 0>>
+<<if $abbreviateRules == 1>>
+<<switch $args[0].livingRules>>
+<<case "luxurious">>
+	<<set $args[0].summary += "''LS:Lux'' ">>
+<<case "normal">>
+	<<set $args[0].summary += "''LS:Nor'' ">>
+<<default>>
+	<<set $args[0].summary += "''LS:Spa'' ">>
+<</switch>>
+<<if canTalk($args[0])>>
+<<switch $args[0].speechRules>>
+<<case "permissive">>
+	<<set $args[0].summary += "''SpR:P'' ">>
+<<case "accent elimination">>
+	<<set $args[0].summary += "''SpR:NoAcc'' ">>
+<<default>>
+	<<set $args[0].summary += "''SpR:R'' ">>
+<</switch>>
+<</if>>
+<<switch $args[0].relationshipRules>>
+<<case "permissive">>
+	<<set $args[0].summary += "''ReR:P'' ">>
+<<case "just friends">>
+	<<set $args[0].summary += "''ReR:Fr'' ">>
+<<default>>
+	<<set $args[0].summary += "''ReR:R'' ">>
+<</switch>>
+<<switch $args[0].standardPunishment>>
+<<case "confinement">>
+	<<set $args[0].summary += "''Pun:Conf'' ">>
+<<case "whipping">>
+	<<set $args[0].summary += "''Pun:Whip'' ">>
+<<case "chastity">>
+	<<set $args[0].summary += "''Pun:Chas'' ">>
+<<default>>
+	<<set $args[0].summary += "''Pun:Situ'' ">>
+<</switch>>
+<<switch $args[0].standardReward>>
+<<case "relaxation">>
+	<<set $args[0].summary += "''Rew:Relx'' ">>
+<<case "drugs">>
+	<<set $args[0].summary += "''Rew:Drug'' ">>
+<<case "orgasm">>
+	<<set $args[0].summary += "''Rew:Orga'' ">>
+<<default>>
+	<<set $args[0].summary += "''Rew:Situ'' ">>
+<</switch>>
+<<switch $args[0].releaseRules>>
+<<case "permissive">>
+	<<set $args[0].summary += "''MaR:P'' ">>
+<<case "sapphic">>
+	<<set $args[0].summary += "''MaR:S'' ">>
+<<default>>
+	<<set $args[0].summary += "''MaR:R'' ">>
+<</switch>>
+<<elseif $abbreviateRules == 2>>
+	<<set $args[0].summary += "Living standard: "+$args[0].livingRules+". ">>
+	<<if canTalk($args[0])>>
+		<<set $args[0].summary += "Speech rules: "+$args[0].speechRules+". ">>
+	<</if>>
+	<<set $args[0].summary += "Relationship rules: "+$args[0].relationshipRules+". ">>
+	<<set $args[0].summary += "Typical punishment: "+$args[0].standardPunishment+". ">>
+	<<set $args[0].summary += "Typical reward: "+$args[0].standardReward+". ">>
+	<<set $args[0].summary += "Release rules: "+$args[0].releaseRules+". ">>
+<</if>>
+<</if>>
+
+<<if $args[0].tired != 0>><<set $args[0].summary += "Tired. ">><</if>>
+
+<<set _color = 0>>
+<<if $abbreviateDiet == 1>>
+	<<if $args[0].weight < -95>>
+		<<set _color = 1>>
+		<<set $args[0].summary += "''@@.red;W---">>
+	<<elseif $args[0].weight < -30>>
+		<<if $args[0].hips < -1>>
+			<<set $args[0].summary += "''W--">>
+		<<else>>
+			<<set _color = 1>>
+			<<set $args[0].summary += "''@@.red;W--">>
+		<</if>>
+	<<elseif $args[0].weight < -10>>
+		<<set $args[0].summary += "''W-">>
+	<<elseif $args[0].weight <= 10 >>
+		<<set $args[0].summary += "''W">>
+	<<elseif $args[0].weight <= 30>>
+		<<set $args[0].summary += "''W+">>
+	<<elseif $args[0].weight <= 95>>
+		<<if $args[0].hips > 1>>
+			<<set $args[0].summary += "''W++">>
+		<<else>>
+			<<set _color = 1>>
+			<<set $args[0].summary += "''@@.red;W++">>
+		<</if>>
+	<<else>>
+		<<set _color = 1>>
+		<<set $args[0].summary += "''@@.red;W+++">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += "["+$args[0].weight+"]">>
+	<</if>>
+	<<if _color == 1>>
+		<<set $args[0].summary += "@@'' ">>
+	<<else>>
+		<<set $args[0].summary += "'' ">>
+	<</if>>
+	
+<<elseif $abbreviateDiet == 2>>
+	<<set _color = 0>>
+	<<if $args[0].weight < -95>>
+		<<set _color = 1>>
+		<<set $args[0].summary += "@@.red;Emaciated">>
+	<<elseif $args[0].weight < -30>>
+		<<if $args[0].hips < -1>>
+			<<set $args[0].summary += "Model-thin">>
+		<<else>>
+			<<set _color = 1>>
+			<<set $args[0].summary += "@@.red;Very thin">>
+		<</if>>
+	<<elseif $args[0].weight < -10>>
+		<<set $args[0].summary += "Thin">>
+	<<elseif $args[0].weight <= 10 >>
+		<<set $args[0].summary += "Trim">>
+	<<elseif $args[0].weight <= 30>>
+		<<set $args[0].summary += "Plush">>
+	<<elseif $args[0].weight <= 95>>
+		<<if $args[0].hips > 1>>
+			<<set $args[0].summary += "Nicely chubby">>
+		<<else>>
+			<<set _color = 1>>
+			<<set $args[0].summary += "@@.red;Overweight">>
+		<</if>>
+	<<else>>
+		<<set _color = 1>>
+		<<set $args[0].summary += "@@.red;Fat">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += " ["+$args[0].weight+"].">>
+	<</if>>
+	<<if _color == 1>>
+		<<set $args[0].summary += "@@ ">>
+	<<else>>
+		<<set $args[0].summary += " ">>
+	<</if>>
+	
+<</if>>
+
+<<if $abbreviateDiet == 1>>
+	<<switch $args[0].diet>>
+	<<case "restricted">>
+		<<set $args[0].summary += "''Di:W-'' ">>
+	<<case "fattening">>
+		<<set $args[0].summary += "''Di:W+'' ">>
+	<<case "muscle building">>
+		<<set $args[0].summary += "''Di:M+'' ">>
+	<<case "slimming">>
+		<<set $args[0].summary += "''Di:M-'' ">>
+	<</switch>>
+	<<if $args[0].dietCum == 2>>
+		<<set $args[0].summary += "''Cum++'' ">>
+	<<elseif (($args[0].dietCum == 1) && ($args[0].dietMilk == 0))>>
+		<<set $args[0].summary += "''Cum+'' ">>
+	<<elseif (($args[0].dietCum == 1) && ($args[0].dietMilk == 1))>>
+		<<set $args[0].summary += "''Cum+ Milk+'' ">>
+	<<elseif (($args[0].dietCum == 0) && ($args[0].dietMilk == 1))>>
+		<<set $args[0].summary += "''Milk+'' ">>
+	<<elseif ($args[0].dietMilk == 2)>>
+		<<set $args[0].summary += "''Milk++'' ">>
+	<</if>>
+<<elseif $abbreviateDiet == 2>>
+	<<switch $args[0].diet>>
+	<<case "restricted">>
+		<<set $args[0].summary += "Dieting. ">>
+	<<case "fattening">>
+		<<set $args[0].summary += "Gaining weight. ">>
+	<<case "muscle building">>
+		<<set $args[0].summary += "Pumping iron. ">>
+	<<case "slimming">>
+		<<set $args[0].summary += "Slimming down. ">>
+	<</switch>>
+	<<if $args[0].dietCum == 2>>
+		<<set $args[0].summary += "Diet Base: @@.cyan;Cum Based.@@ ">>
+	<<elseif (($args[0].dietCum == 1) && ($args[0].dietMilk == 0))>>
+		<<set $args[0].summary += "Diet Base: Cum Added. ">>
+	<<elseif (($args[0].dietCum == 1) && ($args[0].dietMilk == 1))>>
+		<<set $args[0].summary += "Diet Base: Milk & Cum Added. ">>
+	<<elseif (($args[0].dietCum == 0) && ($args[0].dietMilk == 1))>>
+		<<set $args[0].summary += "Diet Base: Milk Added. ">>
+	<<elseif ($args[0].dietMilk == 2)>>
+		<<set $args[0].summary += "Diet Base: @@.cyan;Milk Based.@@ ">>
+	<</if>>
+<</if>>
+
+<<if $abbreviateHealth == 1>>
+	<<if $args[0].health < -20>>
+		<<set $args[0].summary += "''@@.red;H">>
+	<<elseif $args[0].health <= 20>>
+		<<set $args[0].summary += "''@@.yellow;H">>
+	<<elseif $args[0].health > 20>>
+		<<set $args[0].summary += "''@@.green;H">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += " ["+$args[0].health+"]@@'' ">>
+	<<else>>
+		<<set $args[0].summary += "@@'' ">>
+	<</if>>
+<<elseif $abbreviateHealth == 2>>
+	<<if $args[0].health < -90>>
+		<<set $args[0].summary += "@@.red;On the edge of death">>
+	<<elseif $args[0].health < -50>>
+		<<set $args[0].summary += "@@.red;Extremely unhealthy">>
+	<<elseif $args[0].health < -20>>
+		<<set $args[0].summary += "@@.red;Unhealthy">>
+	<<elseif $args[0].health <= 20>>
+		<<set $args[0].summary += "@@.yellow;Healthy">>
+	<<elseif $args[0].health <= 50>>
+		<<set $args[0].summary += "@@.green;Very healthy">>
+	<<elseif $args[0].health <= 90>>
+		<<set $args[0].summary += "@@.green;Extremely healthy">>
+	<<else>>
+		<<set $args[0].summary += "@@.green;Unnaturally healthy">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += " ["+$args[0].health+"].@@ ">>
+	<<else>>
+		<<set $args[0].summary += "@@ ">>
+	<</if>>
+<</if>>
+
+<<if $abbreviateDrugs == 1>>
+	<<switch $args[0].drugs>>
+	<<case "breast injections">>
+		<<set $args[0].summary += "''Dr:Boobs+'' ">>
+	<<case "butt injections">>
+		<<set $args[0].summary += "''Dr:Butt+'' ">>
+	<<case "lip injections">>
+		<<set $args[0].summary += "''Dr:Lip+'' ">>
+	<<case "fertility drugs">>
+		<<set $args[0].summary += "''Dr:Fert+'' ">>
+	<<case "penis enhancement">>
+		<<set $args[0].summary += "''Dr:Dick+'' ">>
+	<<case "testicle enhancement">>
+		<<set $args[0].summary += "''Dr:Balls+'' ">>
+	<<case "psychosuppressants">>
+		<<set $args[0].summary += "''Dr:Psych'' ">>
+	<<case "steroids">>
+		<<set $args[0].summary += "''Dr:Ster'' ">>
+	<<case "hormone enhancers">>
+		<<set $args[0].summary += "''Dr:Horm+'' ">>
+	<</switch>>
+	<<if $args[0].curatives == 2>>
+		<<set $args[0].summary += "''Cura'' ">>
+	<<elseif $args[0].curatives == 1>>
+		<<set $args[0].summary += "''Prev'' ">>
+	<</if>>
+	<<if $args[0].addict != 0>>
+		<<switch $args[0].aphrodisiacs>>
+		<<case 0>>
+			<<set $args[0].summary += "@@.cyan;Add@@ ">>
+		<<case 1>>
+			<<set $args[0].summary += "@@.cyan;Aph@@ ">>
+		<<case 2>>
+			<<set $args[0].summary += "@@.cyan;Aph++@@ ">>
+		<</switch>>
+	<<else>>
+		<<switch $args[0].aphrodisiacs>>
+		<<case 1>>
+			<<set $args[0].summary += "Aph ">>
+		<<case 2>>
+			<<set $args[0].summary += "Aph++ ">>
+		<</switch>>
+	<</if>>
+	<<if $args[0].hormones > 1>>
+		<<set $args[0].summary += "''Ho:F+'' ">>
+	<<elseif $args[0].hormones > 0>>
+		<<set $args[0].summary += "''Ho:F'' ">>
+	<<elseif $args[0].hormones < -1>>
+		<<set $args[0].summary += "''Ho:M+'' ">>
+	<<elseif $args[0].hormones < 0>>
+		<<set $args[0].summary += "''Ho:M'' ">>
+	<</if>>
+	<<if (($args[0].preg == -2) || ($args[0].ovaries == 0)) && ($args[0].vagina != -1)>>
+		<<set $args[0].summary += "''Barr'' ">>
+	<<elseif $args[0].preg == -1>>
+		<<set $args[0].summary += "''CC'' ">>
+	<<elseif $args[0].preg == 0>>
+		<<set $args[0].summary += "''Fert+'' ">>
+	<<elseif ($args[0].preg < 4) && ($args[0].preg > 0)>>
+		<<set $args[0].summary += "''Preg?'' ">>
+	<<elseif $args[0].preg >= 4>>
+		<<set $args[0].summary += "''"+$args[0].preg+" wks preg'' ">>
+	<</if>>
+
+<<elseif $abbreviateDrugs == 2>>
+	<<if ($args[0].drugs != "no drugs") && ($args[0].drugs != "none")>>
+		<<set $args[0].summary += "On "+$args[0].drugs+". ">>
+	<</if>>
+	<<if $args[0].curatives == 2>>
+		<<set $args[0].summary += "On curatives. ">>
+	<<elseif $args[0].curatives == 1>>
+		<<set $args[0].summary += "On preventatives. ">>
+	<</if>>
+	<<if $args[0].aphrodisiacs > 1>>
+		<<set $args[0].summary += "On extreme aphrodisiacs. ">>
+	<<elseif $args[0].aphrodisiacs > 0>>
+		<<set $args[0].summary += "On aphrodisiacs. ">>
+	<</if>>
+	<<if $args[0].addict != 0>>
+		<<set $args[0].summary += "@@.cyan;Addict.@@">>
+	<</if>>
+	<<if $args[0].hormones > 1>>
+		<<set $args[0].summary += "''Heavy female hormones.'' ">>
+	<<elseif $args[0].hormones > 0>>
+		<<set $args[0].summary += "''Female hormones.'' ">>
+	<<elseif $args[0].hormones < -1>>
+		<<set $args[0].summary += "''Heavy male hormones.'' ">>
+	<<elseif $args[0].hormones < 0>>
+		<<set $args[0].summary += "''Male hormones.'' ">>
+	<</if>>
+	<<if (($args[0].preg == -2) || ($args[0].ovaries == 0)) && ($args[0].vagina != -1)>>
+		<<set $args[0].summary += "Barren. ">>
+	<<elseif $args[0].preg == -1>>
+		<<set $args[0].summary += "On contraceptives. ">>
+	<<elseif $args[0].preg == 0>>
+		<<set $args[0].summary += "Fertile. ">>
+	<<elseif ($args[0].preg < 4) && ($args[0].preg > 0)>>
+		<<set $args[0].summary += "May be pregnant. ">>
+	<<elseif $args[0].preg >= 4>>
+		<<if $args[0].pregType < 2>>
+			<<set $args[0].summary += ""+$args[0].preg+" weeks pregnant. ">>
+		<<else>>
+			<<set $args[0].summary += ""+$args[0].preg+" weeks pregnant with">>
+			<<if $args[0].pregType > 4>>
+				<<set $args[0].summary += "quintuplets. ">>
+			<<elseif $args[0].pregType == 4>>
+				<<set $args[0].summary += "quadruplets. ">>
+			<<elseif $args[0].pregType == 3>>
+				<<set $args[0].summary += "triplets. ">>
+			<<else>>
+				<<set $args[0].summary += "twins. ">>
+			<</if>>
+		<</if>>
+	<</if>>
+<</if>>
+
+/* - Line 2 - ******************************************************/
+<<if $abbreviateNationality+$abbreviateGenitalia+$abbreviatePhysicals+$abbreviateSkills+$abbreviateMental != 0>>
+	<<set $args[0].summary += _break>>
+<</if>>
+
+<<SlaveTitle $args[0]>>
+<<set $seed = $desc.substring(0,1)>>
+<<set $seed = $seed.toUpperCase()>>
+<<set $desc = $seed + $desc.substring(1)>>
+<<set $args[0].summary += "''@@.coral;"+$desc>>
+
+<<if $abbreviatePhysicals == 2>>
+	<<set $args[0].summary += ".">>
+<</if>>
+<<set $args[0].summary += "@@'' ">>
+
+<<if $seeRace == 1>>
+	<<set $args[0].summary += "@@.tan;">>
+	<<if $abbreviateRace == 1>>
+		<<switch $args[0].race>>
+		<<case "white">>
+			<<set $args[0].summary += "C">>
+		<<case "asian">>
+			<<set $args[0].summary += "A">>
+		<<case "indo-aryan">>
+			<<set $args[0].summary += "I">>
+		<<case "latina">>
+			<<set $args[0].summary += "L">>
+		<<case "middle eastern">>
+			<<set $args[0].summary += "ME">>
+		<<case "black">>
+			<<set $args[0].summary += "B">>
+		<<case "pacific islander">>
+			<<set $args[0].summary += "PI">>
+		<<case "malay">>
+			<<set $args[0].summary += "M">>
+		<<case "amerindian">>
+			<<set $args[0].summary += "AI">>
+		<<case "semitic">>
+			<<set $args[0].summary += "S">>
+		<<case "southern european">>
+			<<set $args[0].summary += "SE">>
+		<<case "mixed race">>
+			<<set $args[0].summary += "MR">>
+		<<default>>
+			<<set $args[0].summary += $args[0].race.charAt(0).toUpperCase() + $args[0].race.charAt(1) + $args[0].race.charAt(2)>>
+		<</switch>>
+
+	<<elseif $abbreviateRace == 2>>
+		<<switch $args[0].race>>
+		<<case "white">>
+			<<set $args[0].summary += "Caucasian.">>
+		<<case "asian">>
+			<<set $args[0].summary += "Asian.">>
+		<<case "indo-aryan">>
+			<<set $args[0].summary += "Indo-aryan.">>
+		<<case "latina">>
+			<<set $args[0].summary += "Latina.">>
+		<<case "middle eastern">>
+			<<set $args[0].summary += "Middle Eastern.">>
+		<<case "black">>
+			<<set $args[0].summary += "Black.">>
+		<<case "pacific islander">>
+			<<set $args[0].summary += "Pacific Islander.">>
+		<<case "malay">>
+			<<set $args[0].summary += "Malay.">>
+		<<case "amerindian">>
+			<<set $args[0].summary += "Amerindian.">>
+		<<case "semitic">>
+			<<set $args[0].summary += "Semitic.">>
+		<<case "southern european">>
+			<<set $args[0].summary += "Southern European.">>
+		<<case "mixed race">>
+			<<set $args[0].summary += "Mixed race.">>
+		<<default>>
+			<<set $args[0].summary += $args[0].race.charAt(0).toUpperCase() + $args[0].race.slice(1)+".">>
+		<</switch>>
+	<</if>>
+	<<set $args[0].summary += "@@ ">>
+<</if>>
+
+<<if $abbreviateNationality == 1>>
+	<<set $args[0].summary += "@@.tan;">>
+	<<switch $args[0].nationality>>
+	<<case "American">>
+		<<set $args[0].summary += "US">>
+	<<case "Canadian">>
+		<<set $args[0].summary += "Can">>
+	<<case "Puerto Rican">>
+		<<set $args[0].summary += "PR">>
+	<<case "Cuban">>
+		<<set $args[0].summary += "Cub">>
+	<<case "Haitian">>
+		<<set $args[0].summary += "Hai">>
+	<<case "Jamaican">>
+		<<set $args[0].summary += "Jam">>
+	<<case "Mexican">>
+		<<set $args[0].summary += "Mex">>
+	<<case "Peruvian">>
+		<<set $args[0].summary += "Per">>
+	<<case "Venezuelan">>
+		<<set $args[0].summary += "Ven">>
+	<<case "Bolivian">>
+		<<set $args[0].summary += "Bol">>
+	<<case "Guatemalan">>
+		<<set $args[0].summary += "Gtm">>
+	<<case "Brazilian">>
+		<<set $args[0].summary += "Bra">>
+	<<case "Argentinian">>
+		<<set $args[0].summary += "Arg">>
+	<<case "Chilean">>
+		<<set $args[0].summary += "Chl">>
+	<<case "Colombian">>
+		<<set $args[0].summary += "Col">>
+	<<case "Egyptian">>
+		<<set $args[0].summary += "Egy">>
+	<<case "Turkish">>
+		<<set $args[0].summary += "Tur">>
+	<<case "Iranian">>
+		<<set $args[0].summary += "Irn">>
+	<<case "Armenian">>
+		<<set $args[0].summary += "Arm">>
+	<<case "Israeli">>
+		<<set $args[0].summary += "Isr">>
+	<<case "Saudi">>
+		<<set $args[0].summary += "Sau">>
+	<<case "Moroccan">>
+		<<set $args[0].summary += "Mor">>
+	<<case "Nigerian">>
+		<<set $args[0].summary += "Ng">>
+	<<case "Kenyan">>
+		<<set $args[0].summary += "Ken">>
+	<<case "Zimbabwean">>
+		<<set $args[0].summary += "Zwe">>
+	<<case "Ugandan">>
+		<<set $args[0].summary += "Uga">>
+	<<case "Tanzanian">>
+		<<set $args[0].summary += "Tza">>
+	<<case "Ghanan">>
+		<<set $args[0].summary += "Gha">>
+	<<case "Congolese">>
+		<<set $args[0].summary += "Cog">>
+	<<case "Ethiopian">>
+		<<set $args[0].summary += "Eth">>
+	<<case "South African">>
+		<<set $args[0].summary += "RSA">>
+	<<case "Chinese">>
+		<<set $args[0].summary += "Chi">>
+	<<case "Korean">>
+		<<set $args[0].summary += "Kor">>
+	<<case "Japanese">>
+		<<set $args[0].summary += "Jpn">>
+	<<case "Thai">>
+		<<set $args[0].summary += "Tha">>
+	<<case "Vietnamese">>
+		<<set $args[0].summary += "Vnm">>
+	<<case "Indonesian">>
+		<<set $args[0].summary += "Idn">>
+	<<case "Filipina">>
+		<<set $args[0].summary += "Phl">>
+	<<case "Burmese">>
+		<<set $args[0].summary += "Bur">>
+	<<case "Nepalese">>
+		<<set $args[0].summary += "Npl">>
+	<<case "Uzbek">>
+		<<set $args[0].summary += "Uzb">>
+	<<case "Afghan">>
+		<<set $args[0].summary += "Afg">>
+	<<case "Algerian">>
+		<<set $args[0].summary += "Alg">>
+	<<case "Libyan">>
+		<<set $args[0].summary += "Lby">>
+	<<case "Tunisian">>
+		<<set $args[0].summary += "Tun">>
+	<<case "Lebanese">>
+		<<set $args[0].summary += "Lbn">>
+	<<case "Jordanian">>
+		<<set $args[0].summary += "Jor">>
+	<<case "Emirati">>
+		<<set $args[0].summary += "AE">>
+	<<case "Omani">>
+		<<set $args[0].summary += "Omn">>
+	<<case "Malian">>
+		<<set $args[0].summary += "Mal">>
+	<<case "Sudanese">>
+		<<set $args[0].summary += "Sud">>
+	<<case "Yemeni">>
+		<<set $args[0].summary += "Yem">>
+	<<case "Iraqi">>
+		<<set $args[0].summary += "Irq">>
+	<<case "Indian">>
+		<<set $args[0].summary += "Ind">>
+	<<case "Malaysian">>
+		<<set $args[0].summary += "Mys">>
+	<<case "Kazakh">>
+		<<set $args[0].summary += "Kaz">>
+	<<case "Pakistani">>
+		<<set $args[0].summary += "Pak">>
+	<<case "Bangladeshi">>
+		<<set $args[0].summary += "Bgd">>
+	<<case "Russian">>
+		<<set $args[0].summary += "Rus">>
+	<<case "Ukrainian">>
+		<<set $args[0].summary += "Ukr">>
+	<<case "Irish">>
+		<<set $args[0].summary += "Irl">>
+	<<case "Icelandic">>
+		<<set $args[0].summary += "Isl">>
+	<<case "Finnish">>
+		<<set $args[0].summary += "Fin">>
+	<<case "Swiss">>
+		<<set $args[0].summary += "Swi">>
+	<<case "Danish">>
+		<<set $args[0].summary += "Dan">>
+	<<case "Norwegian">>
+		<<set $args[0].summary += "Nor">>
+	<<case "Austrian">>
+		<<set $args[0].summary += "Aut">>
+	<<case "Slovak">>
+		<<set $args[0].summary += "Svk">>
+	<<case "Dutch">>
+		<<set $args[0].summary += "Nld">>
+	<<case "Belgian">>
+		<<set $args[0].summary += "Bel">>
+	<<case "Czech">>
+		<<set $args[0].summary += "Cze">>
+	<<case "Serbian">>
+		<<set $args[0].summary += "Srb">>
+	<<case "Portuguese">>
+		<<set $args[0].summary += "Por">>
+	<<case "Hungarian">>
+		<<set $args[0].summary += "Hun">>
+	<<case "Estonian">>
+		<<set $args[0].summary += "Est">>
+	<<case "Polish">>
+		<<set $args[0].summary += "Pol">>
+	<<case "Lithuanian">>
+		<<set $args[0].summary += "Lit">>
+	<<case "Romanian">>
+		<<set $args[0].summary += "Rom">>
+	<<case "German">>
+		<<set $args[0].summary += "Ger">>
+	<<case "Swedish">>
+		<<set $args[0].summary += "Swe">>
+	<<case "French">>
+		<<set $args[0].summary += "Fra">>
+	<<case "Italian">>
+		<<set $args[0].summary += "Ita">>
+	<<case "Greek">>
+		<<set $args[0].summary += "Gre">>
+	<<case "Spanish">>
+		<<set $args[0].summary += "Spa">>
+	<<case "British">>
+		<<set $args[0].summary += "GB">>
+	<<case "Australian">>
+		<<set $args[0].summary += "Aus">>
+	<<case "a New Zealander">>
+		<<set $args[0].summary += "NZ">>
+	<<case "Ancient Egyptian Revivalist">>
+		<<set $args[0].summary += "Egy Rev">>
+	<<case "Ancient Chinese Revivalist">>
+		<<set $args[0].summary += "Chi Rev">>
+	<<case "Edo Revivalist">>
+		<<set $args[0].summary += "Edo Rev">>
+	<<case "Roman Revivalist">>
+		<<set $args[0].summary += "Rom Rev">>
+	<<case "Aztec Revivalist">>
+		<<set $args[0].summary += "Azt Rev">>
+	<<case "Arabian Revivalist">>
+		<<set $args[0].summary += "Ara Rev">>
+	<<case "slave" "none" "">>
+		<<set $args[0].summary += "None">>
+	<<default>>
+		<<set $args[0].summary += $args[0].nationality.charAt(0) + $args[0].nationality.charAt(1) + $args[0].nationality.charAt(2)>>
+	<</switch>>
+	<<set $args[0].summary += "@@ ">>
+<<elseif $abbreviateNationality == 2>>
+	<<set $args[0].summary += "@@.tan;">>
+	<<switch $args[0].nationality>>
+	<<case "slave" "none" "">>
+		<<set $args[0].summary += "Stateless.">>
+	<<default>>
+		<<set $args[0].summary += $args[0].nationality+".">>
+	<</switch>>
+	<<set $args[0].summary += "@@ ">>
+<</if>>
+
+<<set $args[0].summary += "@@.pink;">>
+<<if $abbreviatePhysicals == 1>>
+	<<switch $args[0].skin>>
+	<<case "light brown">>
+		<<set $args[0].summary += "L. Br">>
+	<<case "extremely pale">>
+		<<set $args[0].summary += "Ex. Pa">>
+	<<case "tanned">>
+		<<set $args[0].summary += "Tan">>
+	<<case "dark" "fair" "pale">>
+		<<set $args[0].summary += $args[0].skin.charAt(0).toUpperCase() + $args[0].skin.slice(1)>>
+	<<default>>
+		<<set $args[0].summary += $args[0].skin.charAt(0).toUpperCase() + $args[0].skin.charAt(1) + $args[0].skin.charAt(2)>>
+	<</switch>>
+	<<set $args[0].summary += " ">>
+<<else>>
+	<<set $args[0].summary += $args[0].skin.charAt(0).toUpperCase() + $args[0].skin.slice(1) +" skin. ">>
+<</if>>
+
+<<if $abbreviateGenitalia == 1>>
+	<<if $args[0].dick > 0>>
+		<<if $args[0].balls == 0>>
+			<<set $args[0].summary += "Geld ">>
+		<</if>>
+		<<if ($args[0].dick > 8) && ($args[0].balls > 5)>>
+			<<set $args[0].summary += "Junk+++ ">>
+		<<elseif ($args[0].dick > 5) && ($args[0].balls > 5)>>
+			<<set $args[0].summary += "Junk++ ">>
+		<<elseif ($args[0].dick > 4) && ($args[0].balls > 4)>>
+			<<set $args[0].summary += "Junk+ ">>
+		<<elseif ($args[0].dick > 3) && ($args[0].balls > 3)>>
+			<<set $args[0].summary += "Junk ">>
+		<<elseif $args[0].dick > 8>>
+			<<set $args[0].summary += "Dick+++ ">>
+		<<elseif $args[0].dick > 5>>
+			<<set $args[0].summary += "Dick++ ">>
+		<<elseif $args[0].dick > 4>>
+			<<set $args[0].summary += "Dick+ ">>
+		<<elseif $args[0].dick > 3>>
+			<<set $args[0].summary += "Dick ">>
+		<<elseif $args[0].balls > 5>>
+			<<set $args[0].summary += "Balls++ ">>
+		<<elseif $args[0].balls > 4>>
+			<<set $args[0].summary += "Balls+ ">>
+		<<elseif $args[0].balls > 3>>
+			<<set $args[0].summary += "Balls ">>
+		<</if>>
+	<</if>>
+	<<if $args[0].vagina == 0>>
+		<<set $args[0].summary += "@@ @@.lime;VV@@ @@.pink;">>
+	<<elseif ($args[0].preg > 0) && canWalk($args[0]) && ($args[0].clothes == "no clothing") && ($args[0].shoes == "none")>>
+		<<set $args[0].summary += "NBP ">>
+	<</if>>
+	<<if $args[0].anus == 0>>
+		<<set $args[0].summary += "@@ @@.lime;AV@@ @@.pink;">>
+	<</if>>
+
+	<<if ($args[0].vagina > 3) && ($args[0].anus > 3)>>
+		<<set $args[0].summary += "V++A++ ">>
+	<<elseif ($args[0].vagina > 2) && ($args[0].anus > 2)>>
+		<<set $args[0].summary += "V+A+ ">>
+	<<elseif $args[0].vagina > 3>>
+		<<set $args[0].summary += "V++ ">>
+	<<elseif $args[0].vagina > 2>>
+		<<set $args[0].summary += "V+ ">>
+	<<elseif $args[0].anus > 3>>
+		<<set $args[0].summary += "A++ ">>
+	<<elseif $args[0].anus > 2>>
+		<<set $args[0].summary += "A+ ">>
+	<</if>>
+
+<<elseif $abbreviateGenitalia == 2>>
+	<<if $args[0].dick > 0>>
+		<<if $args[0].balls == 0>>
+			<<set $args[0].summary += "Gelded.">>
+		<</if>>
+		<<if ($args[0].dick > 8) && ($args[0].balls > 5)>>
+			<<set $args[0].summary += "Hyper dick & balls.">>
+		<<elseif ($args[0].dick > 5) && ($args[0].balls > 5)>>
+			<<set $args[0].summary += "Monster dick & balls.">>
+		<<elseif ($args[0].dick > 4) && ($args[0].balls > 4)>>
+			<<set $args[0].summary += "Huge dick & balls.">>
+		<<elseif ($args[0].dick > 3) && ($args[0].balls > 3)>>
+			<<set $args[0].summary += "Big dick & balls.">>
+		<<elseif $args[0].dick > 8>>
+			<<set $args[0].summary += "Hyper dong.">>
+		<<elseif $args[0].dick > 5>>
+			<<set $args[0].summary += "Monster dong.">>
+		<<elseif $args[0].dick > 4>>
+			<<set $args[0].summary += "Huge dick.">>
+		<<elseif $args[0].dick > 3>>
+			<<set $args[0].summary += "Big dick.">>
+		<<elseif $args[0].balls > 5>>
+			<<set $args[0].summary += "Monstrous balls.">>
+		<<elseif $args[0].balls > 4>>
+			<<set $args[0].summary += "Huge balls.">>
+		<<elseif $args[0].balls > 3>>
+			<<set $args[0].summary += "Big balls.">>
+		<</if>>
+	<</if>>
+
+	<<if $args[0].vagina == 0>>
+		<<set $args[0].summary += "@@.lime;Virgin.@@ ">>
+	<<elseif ($args[0].preg > 0) && canWalk($args[0]) && ($args[0].clothes == "no clothing") && ($args[0].shoes == "none")>>
+		<<set $args[0].summary += "@@.pink;Naked, barefoot, and pregnant.@@ ">>
+	<</if>>
+	<<if $args[0].anus == 0>>
+		<<set $args[0].summary += "@@.lime;Anal virgin.@@ ">>
+	<</if>>
+	
+	<<if ($args[0].vagina > 3) && ($args[0].anus > 3)>>
+		<<set $args[0].summary += "Blown out holes.">>
+	<<elseif ($args[0].vagina > 2) && ($args[0].anus > 2)>>
+		<<set $args[0].summary += "High mileage.">>
+	<<elseif $args[0].vagina > 3>>
+		<<set $args[0].summary += "Cavernous pussy.">>
+	<<elseif $args[0].vagina > 2>>
+		<<set $args[0].summary += "Loose pussy.">>
+	<<elseif $args[0].anus > 3>>
+		<<set $args[0].summary += "Permagaped anus.">>
+	<<elseif $args[0].anus > 2>>
+		<<set $args[0].summary += "Gaping anus.">>
+	<</if>>
+	
+<</if>>
+/**/
+<<if $abbreviatePhysicals == 1>>
+
+<<if $showAgeDetail == 1>>
+	<<set $args[0].summary += ""+$args[0].age +" ">>
+<<elseif $args[0].age >= 40>>
+	<<set $args[0].summary += "40s ">>
+<<elseif $args[0].age >= 35>>
+	<<set $args[0].summary += "Lt30s ">>
+<<elseif $args[0].age >= 30>>
+	<<set $args[0].summary += "Ea30s ">>
+<<elseif $args[0].age >= 25>>
+	<<set $args[0].summary += "Lt20s ">>
+<<elseif $args[0].age >= 20>>
+	<<set $args[0].summary += "Ea20s ">>
+<<elseif $args[0].age >= 18>>
+	<<set $args[0].summary += ""+$args[0].age + " ">>
+<</if>>
+<<if $args[0].ageImplant == 1>>
+	<<set $args[0].summary += "Age-">>
+<</if>>
+
+<<set _color = 1>>
+<<if $args[0].face < -95>>
+	<<set $args[0].summary += "@@ @@.red;Face---">>
+<<elseif $args[0].face < -40>>
+	<<set $args[0].summary += "@@ @@.red;Face--">>
+<<elseif $args[0].face < -10>>
+	<<set $args[0].summary += "@@ @@.red;Face-">>
+<<elseif $args[0].face <= 10>>
+	<<set $args[0].summary += "Face">>
+<<elseif $args[0].face <= 40>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Face+">>
+<<elseif $args[0].face <= 95>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Face++">>
+<<else>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Face+++">>
+<</if>>
+<<if $summaryStats>>
+	<<set $args[0].summary += "["+$args[0].face+"] ">>
+<</if>>
+<<if _color>>
+	<<set $args[0].summary += "@@ @@.pink;">>
+<<else>>
+	<<set $args[0].summary += " ">>
+<</if>>
+<<if $args[0].eyes == -2>>
+	<<set $args[0].summary += "@@ @@.red;Blind@@ @@.pink;">>
+<<elseif $args[0].eyes == -1 && ($args[0].eyewear != "corrective glasses") && ($args[0].eyewear != "corrective contacts")>>
+	<<set $args[0].summary += "@@ @@.yellow;Sight-@@ @@.pink;">>
+<</if>>
+
+<<if $args[0].markings != "none">>
+	<<set $args[0].summary += "Markings ">>
+<</if>>
+
+<<if $args[0].lips > 95>>
+	<<set $args[0].summary += "Facepussy ">>
+<<else>>
+	<<set _color = 0>>
+	<<if $args[0].lips > 70>>
+		<<set $args[0].summary += "Lips+++">>
+	<<elseif $args[0].lips > 40>>
+		<<set $args[0].summary += "Lips++">>
+	<<elseif $args[0].lips > 20>>
+		<<set $args[0].summary += "Lips+">>
+	<<elseif $args[0].lips > 10>>
+		<<set $args[0].summary += "Lips">>
+	<<else>>
+		<<set _color = 1>>
+		<<set $args[0].summary += "@@ @@.red;Lips-">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += "["+$args[0].lips+"]">>
+	<</if>>
+	<<if _color>>
+		<<set $args[0].summary += "@@ @@.pink;">>
+	<<else>>
+		<<set $args[0].summary += " ">>
+	<</if>>
+<</if>>
+<<if $args[0].teeth == "crooked">>
+	<<set $args[0].summary += "@@ @@.yellow;Cr Teeth@@ @@.pink;">>
+<<elseif $args[0].teeth == "cosmetic braces">>
+	<<set $args[0].summary += "Cos Braces ">>
+<<elseif $args[0].teeth == "straightening braces">>
+	<<set $args[0].summary += "Braces ">>
+<<elseif $args[0].teeth == "removable">>
+	<<set $args[0].summary += "Rem Teeth ">>
+<<elseif $args[0].teeth == "pointy">>
+	<<set $args[0].summary += "Fangs ">>
+<</if>>
+<<if $args[0].muscles > 95>>
+	<<set $args[0].summary += "Musc++">>
+<<elseif $args[0].muscles > 30>>
+	<<set $args[0].summary += "Musc+">>
+<<elseif $args[0].muscles > 5>>
+	<<set $args[0].summary += "Toned">>
+<<else>>
+	<<set $args[0].summary += "Musc-">>
+<</if>>
+<<if $summaryStats>>
+	<<set $args[0].summary += "["+$args[0].muscles+"] ">>
+<<else>>
+	<<set $args[0].summary += " ">>
+<</if>>
+<<if $args[0].amp != 0>>
+<<if $args[0].amp == -1>>
+	<<set $args[0].summary += "P-Limbs ">>
+<<elseif $args[0].amp == -2>>
+	<<set $args[0].summary += "Sex P-Limbs ">>
+<<elseif $args[0].amp == -3>>
+	<<set $args[0].summary += "Beauty P-Limbs ">>
+<<elseif $args[0].amp == -4>>
+	<<set $args[0].summary += "Combat P-Limbs ">>
+<<elseif $args[0].amp == -5>>
+	<<set $args[0].summary += "Cyber P-Limbs ">>
+<<else>>
+	<<set $args[0].summary += "Amp ">>
+<</if>>
+<</if>>
+<<if !canWalk($args[0])>>
+	<<set $args[0].summary += "Immob ">>
+<</if>>
+<<if $args[0].heels == 1>>
+	<<set $args[0].summary += "Heel ">>
+<</if>>
+
+<<if $args[0].voice == 0>>
+	<<set $args[0].summary += "Mute">>
+<<else>>
+	<<if $args[0].accent == 3>>
+		<<set $args[0].summary += "@@ @@.red;Acc--@@ @@.pink;">>
+	<<elseif $args[0].accent == 2>>
+		<<set $args[0].summary += "@@ Acc- @@.pink;">>
+	<<elseif $args[0].accent == 1>>
+		<<set $args[0].summary += "Acc ">>
+	<</if>>
+<</if>>
+
+<<if ($args[0].boobs > 10000) && ($args[0].butt > 9)>>
+	<<set $args[0].summary += "T&A+++ ">>
+<<elseif ($args[0].boobs > 4000) && ($args[0].butt > 8)>>
+	<<set $args[0].summary += "T&A++ ">>
+<<elseif ($args[0].boobs > 2000) && ($args[0].butt > 6)>>
+	<<set $args[0].summary += "T&A+ ">>
+<<elseif ($args[0].boobs > 800) && ($args[0].butt > 4)>>
+	<<set $args[0].summary += "T&A ">>
+<<elseif ($args[0].boobs < 500) && ($args[0].butt < 3) && ($args[0].weight <= 10) && ($args[0].muscles <= 30)>>
+	<<set $args[0].summary += "Girlish ">>
+<<elseif $args[0].boobs > 10000>>
+	<<set $args[0].summary += "Boobs+++ ">>
+<<elseif $args[0].boobs > 4000>>
+	<<set $args[0].summary += "Boobs++ ">>
+<<elseif $args[0].boobs > 2000>>
+	<<set $args[0].summary += "Boobs+ ">>
+<<elseif $args[0].boobs > 800>>
+	<<set $args[0].summary += "Boobs ">>
+<<elseif $args[0].butt > 9>>
+	<<set $args[0].summary += "Ass+++ ">>
+<<elseif $args[0].butt > 8>>
+	<<set $args[0].summary += "Ass++ ">>
+<<elseif $args[0].butt > 6>>
+	<<set $args[0].summary += "Ass+ ">>
+<<elseif $args[0].butt > 4>>
+	<<set $args[0].summary += "Ass ">>
+<</if>>
+
+<<if $args[0].hips < -1>>
+<<if $args[0].butt > 2 && $arcologies[0].FSTransformationFetishist < 20>>
+	<<set $args[0].summary += "@@ @@.red;Disp@@ @@.pink;">>
+<</if>>
+<<elseif $args[0].hips < 0>>
+<<if $args[0].butt > 4 && $arcologies[0].FSTransformationFetishist < 20>>
+	<<set $args[0].summary += "@@ @@.red;Disp@@ @@.pink;">>
+<</if>>
+<<elseif $args[0].hips > 1>>
+<<if $args[0].butt <= 3>>
+	<<set $args[0].summary += "@@ @@.red;Disp@@ @@.pink;">>
+<</if>>
+<<elseif $args[0].hips > 0>>
+<<if $args[0].butt > 8>>
+<<if $arcologies[0].FSTransformationFetishist < 20>>
+	<<set $args[0].summary += "@@ @@.red;Disp@@ @@.pink;">>
+<</if>>
+<<elseif $args[0].butt <= 2>>
+	<<set $args[0].summary += "@@ @@.red;Disp@@ @@.pink;">>
+<</if>>
+<<else>>
+<<if $args[0].butt > 6>>
+<<if $arcologies[0].FSTransformationFetishist < 20>>
+	<<set $args[0].summary += "@@ @@.red;Disp@@ @@.pink;">>
+<</if>>
+<<elseif $args[0].butt <= 1>>
+	<<set $args[0].summary += "@@ @@.red;Disp@@ @@.pink;">>
+<</if>>
+<</if>>
+
+<<set _color = 1>>
+<<if $args[0].waist > 95>>
+	<<set $args[0].summary += "@@ @@.red;Wst---">>
+<<elseif $args[0].waist > 40>>
+	<<set $args[0].summary += "@@ @@.red;Wst--">>
+<<elseif $args[0].waist > 10>>
+	<<set $args[0].summary += "@@ @@.red;Wst-">>
+<<elseif $args[0].waist >= -10>>
+	<<set $args[0].summary += "@@ @@.white;Wst">>
+<<elseif $args[0].waist >= -40>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Wst+">>
+<<elseif $args[0].waist >= -95>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Wst++">>
+<<else>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Wst+++">>
+<</if>>
+<<if $summaryStats>>
+	<<set $args[0].summary += "["+$args[0].waist+"]">>
+<</if>>
+<<if _color>>
+	<<set $args[0].summary += "@@ @@.pink;">>
+<<else>>
+	<<set $args[0].summary += " ">>
+<</if>>
+
+<<if ($args[0].boobsImplant == 0) && ($args[0].buttImplant == 0) && ($args[0].waist >= -95) && ($args[0].lipsImplant == 0) && ($args[0].faceImplant < 2)>>
+	<<set $args[0].summary += "Natr ">>
+<<else>>
+	<<set $args[0].summary += "Impl ">>
+<</if>>
+<<if $args[0].lactation == 1>>
+	<<set $args[0].summary += "Lact ">>
+<<elseif $args[0].lactation == 2>>
+	<<set $args[0].summary += "Lact++ ">>
+<</if>>
+<<modScore $args[0]>>
+<<if $args[0].corsetPiercing == 0 && $piercingScore < 3 && $tatScore < 2>>
+<<elseif $modScore > 15 || ($piercingScore > 8 && $tatScore > 5)>>
+	<<set $args[0].summary += "Mods++ ">>
+<<elseif $modScore > 7>>
+	<<set $args[0].summary += "Mods+ ">>
+<<else>>
+	<<set $args[0].summary += "Mods ">>
+<</if>>
+<<if $args[0].brand != 0>>
+	<<set $args[0].summary += "Br ">>
+<</if>>
+<<set $args[0].summary += "@@ ">>
+
+<<elseif $abbreviatePhysicals == 2>>
+
+<<if $showAgeDetail == 1>>
+	<<set $args[0].summary += "Age "+$args[0].age+". ">>
+<<elseif $args[0].age >= 40>>
+	<<set $args[0].summary += "Forties. ">>
+<<elseif $args[0].age >= 35>>
+	<<set $args[0].summary += "Late thirties. ">>
+<<elseif $args[0].age >= 30>>
+	<<set $args[0].summary += "Early thirties. ">>
+<<elseif $args[0].age >= 25>>
+	<<set $args[0].summary += "Late twenties. ">>
+<<elseif $args[0].age >= 20>>
+	<<set $args[0].summary += "Early twenties. ">>
+<<elseif $args[0].age >= 19>>
+	<<set $args[0].summary += "Nineteen. ">>
+<<else>>
+	<<set $args[0].summary += "Eighteen. ">>
+<</if>>
+<<if $args[0].ageImplant == 1>>
+	<<set $args[0].summary += "Looks younger. ">>
+<</if>>
+
+<<set _color = 1>>
+<<if $args[0].face < -95>>
+	<<set $args[0].summary += "@@ @@.red;Very ugly">>
+<<elseif $args[0].face < -40>>
+	<<set $args[0].summary += "@@ @@.red;Ugly">>
+<<elseif $args[0].face < -10>>
+	<<set $args[0].summary += "@@ @@.red;Unattractive">>
+<<elseif $args[0].face <= 10>>
+	<<set $args[0].summary += "@@ @@.white;Average">>
+<<elseif $args[0].face <= 40>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Attractive">>
+<<elseif $args[0].face <= 95>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Beautiful">>
+<<else>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Very beautiful">>
+<</if>>
+<<if $summaryStats>>
+	<<set $args[0].summary += " ["+$args[0].face+"] ">>
+<</if>>
+<<if _color>>
+	<<set $args[0].summary += "@@ @@.pink;">>
+<<else>>
+	<<set $args[0].summary += " ">>
+<</if>>
+<<set $args[0].summary += ""+$args[0].faceShape+" face. ">>
+<<if $args[0].eyes <= -2>>
+	<<set $args[0].summary += "@@ @@.red;Blind.@@ @@.pink;">>
+<<elseif $args[0].eyes <= -1>>
+	<<set $args[0].summary += "@@ @@.yellow;Nearsighted.@@ @@.pink;">>
+<</if>>
+
+<<if $args[0].lips > 95>>
+	<<set $args[0].summary += "Facepussy">>
+<<elseif $args[0].lips > 70>>
+	<<set $args[0].summary += "Huge lips">>
+<<elseif $args[0].lips > 40>>
+	<<set $args[0].summary += "Big lips">>
+<<elseif $args[0].lips > 20>>
+	<<set $args[0].summary += "Pretty lips">>
+<<elseif $args[0].lips > 10>>
+	<<set $args[0].summary += "Normal lips">>
+<<else>>
+	<<set $args[0].summary += "@@ @@.red;Thin lips@@ @@.pink;">>
+<</if>>
+<<if $summaryStats>>
+	<<set $args[0].summary += " ["+$args[0].lips+"]. ">>
+<<else>>
+	<<set $args[0].summary += ". ">>
+<</if>>
+
+<<if $args[0].teeth == "crooked">>
+	<<set $args[0].summary += "@@ @@.yellow;Crooked teeth.@@ @@.pink;">>
+<<elseif $args[0].teeth == "cosmetic braces">>
+	<<set $args[0].summary += "Cosmetic braces. ">>
+<<elseif $args[0].teeth == "straightening braces">>
+	<<set $args[0].summary += "Braces. ">>
+<<elseif $args[0].teeth == "removable">>
+	<<set $args[0].summary += "Removable teeth. ">>
+<<elseif $args[0].teeth == "pointy">>
+	<<set $args[0].summary += "Sharp fangs. ">>
+<</if>>
+<<if $args[0].muscles > 95>>
+	<<set $args[0].summary += "Hugely muscular">>
+<<elseif $args[0].muscles > 30>>
+	<<set $args[0].summary += "Muscular">>
+<<elseif $args[0].muscles > 5>>
+	<<set $args[0].summary += "Toned">>
+<<else>>
+	<<set $args[0].summary += "Soft">>
+<</if>>
+<<if $summaryStats>>
+	<<set $args[0].summary += " ["+$args[0].muscles+"]. ">>
+<<else>>
+	<<set $args[0].summary += ". ">>
+<</if>>
+<<if $args[0].amp != 0>>
+	<<if $args[0].amp == -1>>
+	<<set $args[0].summary += "Prosthetic limbs. ">>
+	<<elseif $args[0].amp == -2>>
+	<<set $args[0].summary += "Sexy prosthetic limbs. ">>
+	<<elseif $args[0].amp == -3>>
+	<<set $args[0].summary += "Beautiful prosthetic limbs. ">>
+	<<elseif $args[0].amp == -4>>
+	<<set $args[0].summary += "Deadly prosthetic limbs. ">>
+	<<elseif $args[0].amp == -5>>
+	<<set $args[0].summary += "Cyber prosthetic limbs. ">>
+	<<else>>
+	<<set $args[0].summary += "Amputee. ">>
+	<</if>>
+<</if>>
+<<if !canWalk($args[0])>>
+	<<set $args[0].summary += "Immobile. ">>
+<</if>>
+<<if $args[0].heels == 1>>
+	<<set $args[0].summary += "Heeled. ">>
+<</if>>
+
+<<if $args[0].voice == 0>>
+	<<set $args[0].summary += "Mute. ">>
+<<else>>
+	<<if $args[0].accent == 3>>
+		<<set $args[0].summary += "@@ @@.red;Bad accent.@@ @@.pink;">>
+	<<elseif $args[0].accent == 2>>
+		<<set $args[0].summary += "@@ @@.white;Accent.@@ @@.pink;">>
+	<<elseif $args[0].accent == 1>>
+		<<set $args[0].summary += "Cute accent. ">>
+	<</if>>
+<</if>>
+
+<<if ($args[0].boobs > 10000) && ($args[0].butt > 9)>>
+	<<set $args[0].summary += "Hyper T&A. ">>
+<<elseif ($args[0].boobs > 4000) && ($args[0].butt > 8)>>
+	<<set $args[0].summary += "Enormous T&A. ">>
+<<elseif ($args[0].boobs > 2000) && ($args[0].butt > 6)>>
+	<<set $args[0].summary += "Huge T&A. ">>
+<<elseif ($args[0].boobs > 800) && ($args[0].butt > 4)>>
+	<<set $args[0].summary += "Big T&A. ">>
+<<elseif ($args[0].boobs < 500) && ($args[0].butt < 3) && ($args[0].weight <= 10) && ($args[0].muscles <= 30)>>
+	<<set $args[0].summary += "Girlish figure. ">>
+<<elseif $args[0].boobs > 10000>>
+	<<set $args[0].summary += "Immobilizing tits. ">>
+<<elseif $args[0].boobs > 4000>>
+	<<set $args[0].summary += "Monstrous tits. ">>
+<<elseif $args[0].boobs > 2000>>
+	<<set $args[0].summary += "Huge tits. ">>
+<<elseif $args[0].boobs > 800>>
+	<<set $args[0].summary += "Big tits. ">>
+<<elseif $args[0].butt > 9>>
+	<<set $args[0].summary += "Hyper ass. ">>
+<<elseif $args[0].butt > 8>>
+	<<set $args[0].summary += "Titanic ass. ">>
+<<elseif $args[0].butt > 6>>
+	<<set $args[0].summary += "Huge ass. ">>
+<<elseif $args[0].butt > 4>>
+	<<set $args[0].summary += "Big ass. ">>
+<</if>>
+
+<<if $args[0].hips < -1>>
+<<if $args[0].butt > 2 && $arcologies[0].FSTransformationFetishist < 20>>
+	<<set $args[0].summary += "@@ @@.red;Disproportionately big butt.@@ @@.pink;">>
+<</if>>
+<<elseif $args[0].hips < 0>>
+<<if $args[0].butt > 4 && $arcologies[0].FSTransformationFetishist < 20>>
+	<<set $args[0].summary += "@@ @@.red;Disproportionately big butt.@@ @@.pink;">>
+<</if>>
+<<elseif $args[0].hips > 1>>
+<<if $args[0].butt <= 3>>
+	<<set $args[0].summary += "@@ @@.red;Disproportionately small butt.@@ @@.pink;">>
+<</if>>
+<<elseif $args[0].hips > 0>>
+<<if $args[0].butt > 8>>
+<<if $arcologies[0].FSTransformationFetishist < 20>>
+	<<set $args[0].summary += "@@ @@.red;Disproportionately big butt.@@ @@.pink;">>
+<</if>>
+<<elseif $args[0].butt <= 2>>
+	<<set $args[0].summary += "@@ @@.red;Disproportionately small butt.@@ @@.pink;">>
+<</if>>
+<<else>>
+<<if $args[0].butt > 6>>
+<<if $arcologies[0].FSTransformationFetishist < 20>>
+	<<set $args[0].summary += "@@ @@.red;Disproportionately big butt.@@ @@.pink;">>
+<</if>>
+<<elseif $args[0].butt <= 1>>
+	<<set $args[0].summary += "@@ @@.red;Disproportionately small butt.@@ @@.pink;">>
+<</if>>
+<</if>>
+
+<<set _color = 1>>
+<<if $args[0].waist > 95>>
+	<<set $args[0].summary += "@@ @@.red;Masculine waist">>
+<<elseif $args[0].waist > 40>>
+	<<set $args[0].summary += "@@ @@.red;Ugly waist">>
+<<elseif $args[0].waist > 10>>
+	<<set $args[0].summary += "@@ @@.red;Unattractive waist">>
+<<elseif $args[0].waist >= -10>>
+	<<set $args[0].summary += "@@ @@.white; Average waist">>
+<<elseif $args[0].waist >= -40>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Feminine waist">>
+<<elseif $args[0].waist >= -95>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Hourglass waist">>
+<<else>>
+	<<set _color = 0>>
+	<<set $args[0].summary += "Absurdly narrow waist">>
+<</if>>
+<<if $summaryStats>>
+	<<set $args[0].summary += " ["+$args[0].waist+"].">>
+<<else>>
+	<<set $args[0].summary += ".">>
+<</if>>
+<<if _color>>
+	<<set $args[0].summary += "@@ @@.pink;">>
+<<else>>
+	<<set $args[0].summary += " ">>
+<</if>>
+
+<<if ($args[0].boobsImplant != 0) || ($args[0].buttImplant != 0) || ($args[0].lipsImplant != 0)>>
+	<<set $args[0].summary += "Implants. ">>
+<<elseif ($args[0].faceImplant >= 2) || ($args[0].waist < -95)>>
+	<<set $args[0].summary += "Surgery enhanced. ">>
+<<else>>
+	<<set $args[0].summary += "All natural. ">>
+<</if>>
+<<if $args[0].lactation == 1>>
+	<<set $args[0].summary += "Lactating naturally. ">>
+<<elseif $args[0].lactation == 2>>
+	<<set $args[0].summary += "Heavy lactation. ">>
+<</if>>
+<<modScore $args[0]>>
+<<if $args[0].corsetPiercing == 0 && $piercingScore < 3 && $tatScore < 2>>
+<<elseif $modScore > 15 || ($piercingScore > 8 && $tatScore > 5)>>
+	<<set $args[0].summary += "Extensive body mods. ">>
+<<elseif $modScore > 7>>
+	<<set $args[0].summary += "Noticeable body mods. ">>
+<<else>>
+	<<set $args[0].summary += "Light body mods. ">>
+<</if>>
+<<if $args[0].brand != 0>>
+	<<set $args[0].summary += "Branded. ">>
+<</if>>
+<<set $args[0].summary += "@@ ">>
+<</if>>
+
+/* - Line 3 - ******************************************************/
+<<set $args[0].summary += _break>>
+
+<<if $abbreviateSkills == 1>>
+<<if $args[0].fetish == "mindbroken">>
+<<elseif $args[0].intelligenceImplant == 1>>
+<<switch $args[0].intelligence>>
+<<case 3>>
+	<<set $args[0].summary += "@@.deepskyblue;I+++(e)@@ ">>
+<<case 2>>
+	<<set $args[0].summary += "@@.deepskyblue;I++(e)@@ ">>
+<<case 1>>
+	<<set $args[0].summary += "@@.deepskyblue;I+(e)@@ ">>
+<<case -1>>
+	<<set $args[0].summary += "@@.orangered;I-(e)@@ ">>
+<<case -2>>
+	<<set $args[0].summary += "@@.orangered;I--(e)@@ ">>
+<<case -3>>
+	<<set $args[0].summary += "@@.orangered;I---(e)@@ ">>
+<<default>>
+	<<set $args[0].summary += "I(e) ">>
+<</switch>>
+<<else>>
+<<switch $args[0].intelligence>>
+<<case 3>>
+	<<set $args[0].summary += "@@.deepskyblue;I+++@@ ">>
+<<case 2>>
+	<<set $args[0].summary += "@@.deepskyblue;I++@@ ">>
+<<case 1>>
+	<<set $args[0].summary += "@@.deepskyblue;I+@@ ">>
+<<case -1>>
+	<<set $args[0].summary += "@@.orangered;I-@@ ">>
+<<case -2>>
+	<<set $args[0].summary += "@@.orangered;I--@@ ">>
+<<case -3>>
+	<<set $args[0].summary += "@@.orangered;I---@@ ">>
+<<default>>
+	<<set $args[0].summary += "I ">>
+<</switch>>
+<</if>>
+
+<<set _SSkills = $args[0].analSkill+$args[0].oralSkill>>
+<<set $args[0].summary += "@@.aquamarine; ">>
+<<if ((_SSkills+$args[0].whoreSkill+$args[0].entertainSkill) >= 400) && (($args[0].vagina < 0) || ($args[0].vaginalSkill >= 100))>>
+	<<set $args[0].summary += "MSS ">>
+<<else>>
+	<<set _SSkills += $args[0].vaginalSkill>>
+	<<set _SSkills = Math.trunc(_SSkills)>>
+	<<if _SSkills > 180>>
+		<<set $args[0].summary += "S++">>
+	<<elseif (_SSkills > 120) && ($args[0].vagina < 0)>>
+		<<set $args[0].summary += "Sh++">>
+	<<elseif _SSkills > 90>>
+		<<set $args[0].summary += "S+">>
+	<<elseif _SSkills > 30>>
+		<<set $args[0].summary += "S">>
+	<<else>>
+		<<set $args[0].summary += "S-">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += "["+_SSkills+"] ">>
+	<</if>>
+	<<if $args[0].whoreSkill >= 100>>
+		<<set $args[0].summary += "W+++">>
+	<<elseif $args[0].whoreSkill > 60>>
+		<<set $args[0].summary += "W++">>
+	<<elseif $args[0].whoreSkill > 30>>
+		<<set $args[0].summary += "W+">>
+	<<elseif $args[0].whoreSkill > 10>>
+		<<set $args[0].summary += "W">>
+	<</if>>
+	<<if $args[0].whoreSkill > 10>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += "["+$args[0].whoreSkill+"] ">>
+	<</if>>
+	<</if>>
+	<<if $args[0].entertainSkill >= 100>>
+		<<set $args[0].summary += "E+++">>
+	<<elseif $args[0].entertainSkill > 60>>
+		<<set $args[0].summary += "E++">>
+	<<elseif $args[0].entertainSkill > 30>>
+		<<set $args[0].summary += "E+">>
+	<<elseif $args[0].entertainSkill > 10>>
+		<<set $args[0].summary += "E">>
+	<</if>>
+	<<if $args[0].entertainSkill > 10>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += "["+$args[0].entertainSkill+"] ">>
+	<</if>>
+	<</if>>
+<</if>>
+<<if $args[0].combatSkill > 0>>
+	<<set $args[0].summary += "C ">>
+<</if>>
+<<set $args[0].summary += "@@ ">>
+
+<<if $args[0].prestige > 0>>
+<<set $args[0].summary += "@@.green;">>
+<<if $args[0].prestige > 2>>
+	<<set $args[0].summary += "Prest++">>
+<<elseif $args[0].prestige == 2>>
+	<<set $args[0].summary += "Prest+">>
+<<elseif $args[0].prestige == 1>>
+	<<set $args[0].summary += "Prest">>
+<</if>>
+<<set $args[0].summary += "@@ ">>
+<</if>>
+
+<<elseif $abbreviateSkills == 2>>
+<<if $args[0].fetish == "mindbroken">>
+<<elseif $args[0].intelligenceImplant == 1>>
+<<switch $args[0].intelligence>>
+<<case 3>>
+	<<set $args[0].summary += "@@.deepskyblue;Brilliant, educated.@@ ">>
+<<case 2>>
+	<<set $args[0].summary += "@@.deepskyblue;Very smart, educated.@@ ">>
+<<case 1>>
+	<<set $args[0].summary += "@@.deepskyblue;Smart, educated.@@ ">>
+<<case -1>>
+	<<set $args[0].summary += "@@.orangered;Slow, educated.@@ ">>
+<<case -2>>
+	<<set $args[0].summary += "@@.orangered;Very slow, educated.@@ ">>
+<<case -3>>
+	<<set $args[0].summary += "@@.orangered;Moronic, educated.@@ ">>
+<<default>>
+	<<set $args[0].summary += "Average intelligence, educated. ">>
+<</switch>>
+<<else>>
+<<switch $args[0].intelligence>>
+<<case 3>>
+	<<set $args[0].summary += "@@.deepskyblue;Brilliant.@@ ">>
+<<case 2>>
+	<<set $args[0].summary += "@@.deepskyblue;Very smart.@@ ">>
+<<case 1>>
+	<<set $args[0].summary += "@@.deepskyblue;Smart.@@ ">>
+<<case -1>>
+	<<set $args[0].summary += "@@.orangered;Slow.@@ ">>
+<<case -2>>
+	<<set $args[0].summary += "@@.orangered;Very slow.@@ ">>
+<<case -3>>
+	<<set $args[0].summary += "@@.orangered;Moronic.@@ ">>
+<<default>>
+	<<set $args[0].summary += "Average intelligence. ">>
+<</switch>>
+<</if>>
+
+<<set _SSkills = ($args[0].analSkill+$args[0].oralSkill)>>
+<<set $args[0].summary += "@@.aquamarine;">>
+<<if ((_SSkills+$args[0].whoreSkill+$args[0].entertainSkill) >= 400) && (($args[0].vagina < 0) || ($args[0].vaginalSkill >= 100))>>
+	<<set $args[0].summary += "Masterful Sex Slave. ">>
+<<else>>
+	<<set _SSkills += $args[0].vaginalSkill>>
+	<<set _SSkills = Math.trunc(_SSkills)>>
+	<<if _SSkills > 180>>
+		<<set $args[0].summary += "Sex master">>
+	<<elseif (_SSkills > 120) && ($args[0].vagina < 0)>>
+		<<set $args[0].summary += "Masterful shemale">>
+	<<elseif _SSkills > 90>>
+		<<set $args[0].summary += "Sexual expert">>
+	<<elseif _SSkills > 30>>
+		<<set $args[0].summary += "Sexually skilled">>
+	<<else>>
+		<<set $args[0].summary += "Sexually unskilled">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += " ["+_SSkills+"]. ">>
+	<<else>>
+		<<set $args[0].summary += ". ">>
+	<</if>>
+	<<if $args[0].whoreSkill >= 100>>
+		<<set $args[0].summary += "Masterful whore">>
+	<<elseif $args[0].whoreSkill >= 60>>
+		<<set $args[0].summary += "Expert whore">>
+	<<elseif $args[0].whoreSkill >= 30>>
+		<<set $args[0].summary += "Skilled whore">>
+	<<elseif $args[0].whoreSkill >= 10>>
+		<<set $args[0].summary += "Basic whore">>
+	<</if>>
+	<<if $args[0].whoreSkill >= 10>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += " ["+$args[0].whoreSkill+"]. ">>
+	<<else>>
+		<<set $args[0].summary += ". ">>
+	<</if>>
+	<</if>>
+	<<if $args[0].entertainSkill >= 100>>
+		<<set $args[0].summary += "Masterful entertainer">>
+	<<elseif $args[0].entertainSkill >= 60>>
+		<<set $args[0].summary += "Expert entertainer">>
+	<<elseif $args[0].entertainSkill >= 30>>
+		<<set $args[0].summary += "Skilled entertainer">>
+	<<elseif $args[0].entertainSkill >= 10>>
+		<<set $args[0].summary += "Basic entertainer">>
+	<</if>>
+	<<if $args[0].entertainSkill >= 10>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += " ["+$args[0].entertainSkill+"]. ">>
+	<<else>>
+		<<set $args[0].summary += ". ">>
+	<</if>>
+	<</if>>
+<</if>>
+<<if $args[0].combatSkill > 0>>
+	<<set $args[0].summary += "Trained fighter. ">>
+<</if>>
+<<set $args[0].summary += "@@ ">>
+
+<<if $args[0].prestige > 0>>
+<<set $args[0].summary += "@@.green;">>
+<<if $args[0].prestige > 2>>
+	<<set $args[0].summary += "Extremely prestigious.">>
+<<elseif $args[0].prestige == 2>>
+	<<set $args[0].summary += "Very prestigious.">>
+<<elseif $args[0].prestige == 1>>
+	<<set $args[0].summary += "Prestigious.">>
+<</if>>
+<<set $args[0].summary += "@@ ">>
+<</if>>
+<</if>>
+
+<<if $abbreviateMental == 1>>
+	<<if $args[0].fetish != "mindbroken">>
+	<<if $args[0].fetishKnown == 1>>
+	<<set $args[0].summary += "@@.lightcoral;">>
+	<<switch $args[0].fetish>>
+	<<case "submissive">>
+	<<if $args[0].fetishStrength > 95>>
+		<<set $args[0].summary += "Sub++">>
+	<<elseif $args[0].fetishStrength > 60>>
+		<<set $args[0].summary += "Sub+">>
+	<<else>>
+		<<set $args[0].summary += "Sub">>
+	<</if>>
+	<<case "cumslut">>
+	<<if $args[0].fetishStrength > 95>>
+		<<set $args[0].summary += "Oral++">>
+	<<elseif $args[0].fetishStrength > 60>>
+		<<set $args[0].summary += "Oral+">>
+	<<else>>
+		<<set $args[0].summary += "Oral">>
+	<</if>>
+	<<case "humiliation">>
+	<<if $args[0].fetishStrength > 95>>
+		<<set $args[0].summary += "Humil++">>
+	<<elseif $args[0].fetishStrength > 60>>
+		<<set $args[0].summary += "Humil+">>
+	<<else>>
+		<<set $args[0].summary += "Humil">>
+	<</if>>
+	<<case "buttslut">>
+	<<if $args[0].fetishStrength > 95>>
+		<<set $args[0].summary += "Anal++">>
+	<<elseif $args[0].fetishStrength > 60>>
+		<<set $args[0].summary += "Anal+">>
+	<<else>>
+		<<set $args[0].summary += "Anal">>
+	<</if>>
+	<<case "boobs">>
+	<<if $args[0].fetishStrength > 95>>
+		<<set $args[0].summary += "Boobs++">>
+	<<elseif $args[0].fetishStrength > 60>>
+		<<set $args[0].summary += "Boobs+">>
+	<<else>>
+		<<set $args[0].summary += "Boobs">>
+	<</if>>
+	<<case "sadist">>
+	<<if $args[0].fetishStrength > 95>>
+		<<set $args[0].summary += "Sadist++">>
+	<<elseif $args[0].fetishStrength > 60>>
+		<<set $args[0].summary += "Sadist+">>
+	<<else>>
+		<<set $args[0].summary += "Sadist">>
+	<</if>>
+	<<case "masochist">>
+	<<if $args[0].fetishStrength > 95>>
+		<<set $args[0].summary += "Pain++">>
+	<<elseif $args[0].fetishStrength > 60>>
+		<<set $args[0].summary += "Pain+">>
+	<<else>>
+		<<set $args[0].summary += "Pain">>
+	<</if>>
+	<<case "dom">>
+	<<if $args[0].fetishStrength > 95>>
+		<<set $args[0].summary += "Dom++">>
+	<<elseif $args[0].fetishStrength > 60>>
+		<<set $args[0].summary += "Dom+">>
+	<<else>>
+		<<set $args[0].summary += "Dom">>
+	<</if>>
+	<<case "pregnancy">>
+	<<if $args[0].fetishStrength > 95>>
+		<<set $args[0].summary += "Preg++">>
+	<<elseif $args[0].fetishStrength > 60>>
+		<<set $args[0].summary += "Preg+">>
+	<<else>>
+		<<set $args[0].summary += "Preg">>
+	<</if>>
+	<<default>>
+		<<set $args[0].summary += "Vanilla">>
+	<</switch>>
+	
+	<<if $summaryStats>>
+		<<set $args[0].summary += "["+$args[0].fetishStrength+"] ">>
+	<</if>>
+	<<set $args[0].summary += "@@ ">>
+	<</if>>
+	
+	<<if $args[0].attrKnown == 1>>
+	<<set _stats = $summaryStats>>
+	<<if $args[0].attrXY <= 5>>
+		<<set $args[0].summary += "@@.red;XY---">>
+	<<elseif $args[0].attrXY <= 15>>
+		<<set $args[0].summary += "@@.red;XY--">>
+	<<elseif $args[0].attrXY <= 35>>
+		<<set $args[0].summary += "@@.red;XY-">>
+	<<elseif $args[0].attrXY <= 65>>
+		<<set $args[0].summary += "@@.white;XY">>
+	<<elseif $args[0].attrXY <= 85>>
+		<<set $args[0].summary += "@@.green;XY+">>
+	<<elseif $args[0].attrXY <= 95>>
+		<<set $args[0].summary += "@@.green;XY++">>
+	<<elseif $args[0].attrXX > 95>>
+		<<set _stats = 0>>
+		<<if $args[0].energy <= 95>>
+			<<set $args[0].summary += "@@.green;Omni!">>
+		<<else>>
+			<<set $args[0].summary += "@@.green;Omni+Nympho!!">>
+		<</if>>
+	<<else>>
+		<<set $args[0].summary += "@@.green;XY+++">>
+	<</if>>
+	<<if _stats == 1>>
+		<<set $args[0].summary += "["+$args[0].attrXY+"]@@ ">>
+	<<else>>
+		<<set $args[0].summary += "@@ ">>
+	<</if>>
+	
+	<<if $args[0].attrXX <= 5>>
+		<<set $args[0].summary += "@@.red;XX---">>
+	<<elseif $args[0].attrXX <= 15>>
+		<<set $args[0].summary += "@@.red;XX--">>
+	<<elseif $args[0].attrXX <= 35>>
+		<<set $args[0].summary += "@@.red;XX-">>
+	<<elseif $args[0].attrXX <= 65>>
+		<<set $args[0].summary += "@@.white;XX">>
+	<<elseif $args[0].attrXX <= 85>>
+		<<set $args[0].summary += "@@.green;XX+">>
+	<<elseif $args[0].attrXX <= 95>>
+		<<set $args[0].summary += "@@.green;XX++">>
+	<<elseif $args[0].attrXY <= 95>>
+		<<set $args[0].summary += "@@.green;XX+++">>
+	<</if>>
+	<<if $summaryStats>>
+		<<set $args[0].summary += "["+$args[0].attrXX+"]@@ ">>
+	<<else>>
+		<<set $args[0].summary += "@@ ">>
+	<</if>>
+	<<set _stats = $summaryStats>>
+	<<if $args[0].energy > 95>>
+		<<set _stats = 0>>
+		<<if ($args[0].attrXY <= 95) || ($args[0].attrXX <= 95)>>
+			<<set $args[0].summary += "@@.green;Nympho!">>
+		<</if>>
+	<<elseif $args[0].energy > 80>>
+		<<set $args[0].summary += "@@.green;SD++">>
+	<<elseif $args[0].energy > 60>>
+		<<set $args[0].summary += "@@.green;SD+">>
+	<<elseif $args[0].energy > 40>>
+		<<set $args[0].summary += "@@.yellow;SD ">>
+	<<elseif $args[0].energy > 20>>
+		<<set $args[0].summary += "@@.red;SD-">>
+	<<else>>
+		<<set $args[0].summary += "@@.red;SD--">>
+	<</if>>
+	<<if _stats == 1>>
+		<<set $args[0].summary += "["+$args[0].attrXY+"]@@ ">>
+	<<else>>
+		<<set $args[0].summary += "@@ ">>
+	<</if>>
+	<</if>>
+	<</if>>
+	<<if $args[0].clitPiercing == 3>>
+	<<if $args[0].fetishKnown == 1>>
+	<<if $args[0].clitSetting == "off">>
+		<<set $args[0].summary += "SP- ">>
+	<<elseif (($args[0].fetish != "submissive") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "submissive")>>
+		<<set $args[0].summary += "SP:sub ">>
+	<<elseif (($args[0].fetish != "cumslut") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "oral")>>
+		<<set $args[0].summary += "SP:oral ">>
+	<<elseif (($args[0].fetish != "humiliation") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "humiliation")>>
+		<<set $args[0].summary += "SP:humil ">>
+	<<elseif (($args[0].fetish != "buttslut") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "anal")>>
+		<<set $args[0].summary += "SP:anal ">>
+	<<elseif (($args[0].fetish != "boobs") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "boobs")>>
+		<<set $args[0].summary += "SP:boobs ">>
+	<<elseif (($args[0].fetish != "sadist") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "sadist")>>
+		<<set $args[0].summary += "SP:sade ">>
+	<<elseif (($args[0].fetish != "masochist") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "masochist")>>
+		<<set $args[0].summary += "SP:pain ">>
+	<<elseif (($args[0].fetish != "dom") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "dom")>>
+		<<set $args[0].summary += "SP:dom ">>
+	<<elseif (($args[0].fetish != "pregnancy") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "pregnancy")>>
+		<<set $args[0].summary += "SP:preg ">>
+	<<elseif (($args[0].fetish != "none") && ($args[0].clitSetting == "vanilla"))>>
+		<<set $args[0].summary += "SP:vanilla ">>
+	<<elseif ($args[0].energy <= 95) && ($args[0].clitSetting == "all")>>
+		<<set $args[0].summary += "SP:all ">>
+	<<elseif ($args[0].energy > 5) && ($args[0].clitSetting == "none")>>
+		<<set $args[0].summary += "SP:none ">>
+	<</if>>
+	<<else>>
+	<<switch $args[0].clitSetting>>
+	<<case "off">>
+		<<set $args[0].summary += "SP- ">>
+	<<case "submissive">>
+		<<set $args[0].summary += "SP:sub ">>
+	<<case "lesbian">>
+		<<set $args[0].summary += "SP:les ">>
+	<<case "oral">>
+		<<set $args[0].summary += "SP:oral ">>
+	<<case "humiliation">>
+		<<set $args[0].summary += "SP:humil ">>
+	<<case "anal">>
+		<<set $args[0].summary += "SP:anal ">>
+	<<case "boobs">>
+		<<set $args[0].summary += "SP:boobs ">>
+	<<case "sadist">>
+		<<set $args[0].summary += "SP:sade ">>
+	<<case "masochist">>
+		<<set $args[0].summary += "SP:pain ">>
+	<<case "dom">>
+		<<set $args[0].summary += "SP:dom ">>
+	<<case "pregnancy">>
+		<<set $args[0].summary += "SP:pregnancy ">>
+	<<case "vanilla">>
+		<<set $args[0].summary += "SP:vanilla ">>
+	<<case "all">>
+		<<set $args[0].summary += "SP:all ">>
+	<<case "none">>
+		<<set $args[0].summary += "SP:none ">>
+	<</switch>>
+	<</if>>
+	
+	<<if $args[0].attrKnown == 1>>
+		<<if $args[0].clitSetting == "women">>
+			<<if $args[0].attrXX < 95>><<set $args[0].summary += "SP:women ">><</if>>
+		<<elseif $args[0].clitSetting == "men">>
+			<<if $args[0].attrXY < 95>><<set $args[0].summary += "SP:men ">><</if>>
+		<<elseif $args[0].clitSetting == "anti-women">>
+			<<if $args[0].attrXX > 0>><<set $args[0].summary += "SP:anti-women ">><</if>>
+		<<elseif $args[0].clitSetting == "anti-men">>
+			<<if $args[0].attrXY > 0>><<set $args[0].summary += "SP:anti-men ">><</if>>
+		<</if>>
+	<<else>>
+		<<if $args[0].clitSetting == "women">>
+			<<set $args[0].summary += "SP:women ">>
+		<<elseif $args[0].clitSetting == "men">>
+			<<set $args[0].summary += "SP:men ">>
+		<<elseif $args[0].clitSetting == "anti-women">>
+			<<set $args[0].summary += "SP:anti-women ">>
+		<<elseif $args[0].clitSetting == "anti-men">>
+			<<set $args[0].summary += "SP:anti-men ">>
+		<</if>>
+	<</if>>
+	<</if>>
+	<<set $args[0].summary += "@@.red;">>
+	<<switch $args[0].behavioralFlaw>>
+	<<case "arrogant">>
+		<<set $args[0].summary += "Arrog">>
+	<<case "bitchy">>
+		<<set $args[0].summary += "Bitchy">>
+	<<case "odd">>
+		<<set $args[0].summary += "Odd">>
+	<<case "hates men">>
+		<<set $args[0].summary += "Men-">>
+	<<case "hates women">>
+		<<set $args[0].summary += "Women-">>
+	<<case "gluttonous">>
+		<<set $args[0].summary += "Glut">>
+	<<case "anorexic">>
+		<<set $args[0].summary += "Ano">>
+	<<case "devout">>
+		<<set $args[0].summary += "Dev">>
+	<<case "liberated">>
+		<<set $args[0].summary += "Lib">>
+	<<default>>
+		<<set $args[0].behavioralFlaw = "none">>
+	<</switch>>
+	<<set $args[0].summary += "@@ ">>
+	<<switch $args[0].sexualFlaw>>
+	<<case "hates oral">>
+		<<set $args[0].summary += "@@.red;Oral-@@ ">>
+	<<case "hates anal">>
+		<<set $args[0].summary += "@@.red;Anal-@@ ">>
+	<<case "hates penetration">>
+		<<set $args[0].summary += "@@.red;Fuck-@@ ">>
+	<<case "shamefast">>
+		<<set $args[0].summary += "@@.red;Shame@@ ">>
+	<<case "idealistic">>
+		<<set $args[0].summary += "@@.red;Ideal@@ ">>
+	<<case "repressed">>
+		<<set $args[0].summary += "@@.red;Repre@@ ">>
+	<<case "apathetic">>
+		<<set $args[0].summary += "@@.red;Apath@@ ">>
+	<<case "crude">>
+		<<set $args[0].summary += "@@.red;Crude@@ ">>
+	<<case "judgemental">>
+		<<set $args[0].summary += "@@.red;Judge@@ ">>
+	<<case "cum addict">>
+		<<set $args[0].summary += "@@.yellow;CumAdd@@ ">>
+	<<case "anal addict">>
+		<<set $args[0].summary += "@@.yellow;AnalAdd@@ ">>
+	<<case "attention whore">>
+		<<set $args[0].summary += "@@.yellow;Attention@@ ">>
+	<<case "breast growth">>
+		<<set $args[0].summary += "@@.yellow;BoobObsess@@ ">>
+	<<case "abusive">>
+		<<set $args[0].summary += "@@.yellow;Abusive@@ ">>
+	<<case "malicious">>
+		<<set $args[0].summary += "@@.yellow;Malice@@ ">>
+	<<case "self hating">>
+		<<set $args[0].summary += "@@.yellow;SelfHatr@@ ">>
+	<<case "neglectful">>
+		<<set $args[0].summary += "@@.yellow;SelfNeglect@@ ">>
+	<<case "breeder">>
+		<<set $args[0].summary += "@@.yellow;BreedObsess@@ ">>
+	<<default>>
+		<<set $args[0].sexualFlaw = "none">>
+	<</switch>>
+	<<set $args[0].summary += "@@.green;">>
+	<<switch $args[0].behavioralQuirk>>
+	<<case "confident">>
+		<<set $args[0].summary += "Confid ">>
+	<<case "cutting">>
+		<<set $args[0].summary += "Cutting ">>
+	<<case "funny">>
+		<<set $args[0].summary += "Funny ">>
+	<<case "fitness">>
+		<<set $args[0].summary += "Fit ">>
+	<<case "adores women">>
+		<<set $args[0].summary += "Women+ ">>
+	<<case "adores men">>
+		<<set $args[0].summary += "Men+ ">>
+	<<case "insecure">>
+		<<set $args[0].summary += "Insec ">>
+	<<case "sinful">>
+		<<set $args[0].summary += "Sinf ">>
+	<<case "advocate">>
+		<<set $args[0].summary += "Advoc ">>
+	<<default>>
+		<<set $args[0].behavioralQuirk = "none">>
+	<</switch>>
+	<<switch $args[0].sexualQuirk>>
+	<<case "gagfuck queen">>
+		<<set $args[0].summary += "Gagfuck">>
+	<<case "painal queen">>
+		<<set $args[0].summary += "Painal">>
+	<<case "strugglefuck queen">>
+		<<set $args[0].summary += "Struggle">>
+	<<case "tease">>
+		<<set $args[0].summary += "Tease">>
+	<<case "romantic">>
+		<<set $args[0].summary += "Romantic">>
+	<<case "perverted">>
+		<<set $args[0].summary += "Perverted">>
+	<<case "caring">>
+		<<set $args[0].summary += "Caring">>
+	<<case "unflinching">>
+		<<set $args[0].summary += "Unflinch">>
+	<<case "size queen">>
+		<<set $args[0].summary += "SizeQ">>
+	<<default>>
+		<<set $args[0].sexualQuirk = "none">>
+	<</switch>>
+	<<set $args[0].summary += "@@ ">>
+	
+<<elseif $abbreviateMental == 2>>
+	<<if $args[0].fetish != "mindbroken">>
+	<<if $args[0].fetishKnown == 1>>
+		<<set $args[0].summary += "@@.lightcoral;">>
+		<<switch $args[0].fetish>>
+		<<case "submissive">>
+			<<if $args[0].fetishStrength > 95>>
+				<<set $args[0].summary += "Complete submissive">>
+			<<elseif $args[0].fetishStrength > 60>>
+				<<set $args[0].summary += "Submissive">>
+			<<else>>
+				<<set $args[0].summary += "Submissive tendencies">>
+			<</if>>
+		<<case "cumslut">>
+			<<if $args[0].fetishStrength > 95>>
+				<<set $args[0].summary += "Cumslut">>
+			<<elseif $args[0].fetishStrength > 60>>
+				<<set $args[0].summary += "Oral fixation">>
+			<<else>>
+				<<set $args[0].summary += "Prefers oral">>
+			<</if>>
+		<<case "humiliation">>
+			<<if $args[0].fetishStrength > 95>>
+				<<set $args[0].summary += "Humiliation slut">>
+			<<elseif $args[0].fetishStrength > 60>>
+				<<set $args[0].summary += "Exhibitionist">>
+			<<else>>
+				<<set $args[0].summary += "Interest in humiliation">>
+			<</if>>
+		<<case "buttslut">>
+			<<if $args[0].fetishStrength > 95>>
+				<<set $args[0].summary += "Buttslut">>
+			<<elseif $args[0].fetishStrength > 60>>
+				<<set $args[0].summary += "Anal fixation">>
+			<<else>>
+				<<set $args[0].summary += "Prefers anal">>
+			<</if>>
+		<<case "boobs">>
+			<<if $args[0].fetishStrength > 95>>
+				<<set $args[0].summary += "Boobslut">>
+			<<elseif $args[0].fetishStrength > 60>>
+				<<set $args[0].summary += "Breast fixation">>
+			<<else>>
+				<<set $args[0].summary += "Loves boobs">>
+			<</if>>
+		<<case "sadist">>
+			<<if $args[0].fetishStrength > 95>>
+				<<set $args[0].summary += "Complete sadist">>
+			<<elseif $args[0].fetishStrength > 60>>
+				<<set $args[0].summary += "Sadist">>
+			<<else>>
+				<<set $args[0].summary += "Sadistic tendencies">>
+			<</if>>
+		<<case "masochist">>
+			<<if $args[0].fetishStrength > 95>>
+				<<set $args[0].summary += "Complete masochist">>
+			<<elseif $args[0].fetishStrength > 60>>
+				<<set $args[0].summary += "Masochist">>
+			<<else>>
+				<<set $args[0].summary += "Masochistic tendencies">>
+			<</if>>
+		<<case "dom">>
+			<<if $args[0].fetishStrength > 95>>
+				<<set $args[0].summary += "Complete dom">>
+			<<elseif $args[0].fetishStrength > 60>>
+				<<set $args[0].summary += "Dominant">>
+			<<else>>
+				<<set $args[0].summary += "Dominant tendencies">>
+			<</if>>
+		<<case "pregnancy">>
+			<<if $args[0].fetishStrength > 95>>
+				<<set $args[0].summary += "Pregnancy fetish">>
+			<<elseif $args[0].fetishStrength > 60>>
+				<<set $args[0].summary += "Pregnancy kink">>
+			<<else>>
+				<<set $args[0].summary += "Interest in impregnation">>
+			<</if>>
+		<<default>>
+			<<set $args[0].summary += "Sexually vanilla">>
+		<</switch>>
+		
+		<<if $summaryStats>>
+			<<set $args[0].summary += " ["+$args[0].fetishStrength+"].@@ ">>
+		<<else>>
+			<<set $args[0].summary += ".@@ ">>
+		<</if>>
+
+	<</if>>
+	<</if>>
+	<<if $args[0].attrKnown == 1>>
+		<<set _stats = $summaryStats, _comma = 1>>
+		<<if $args[0].attrXY <= 5>>
+			<<set $args[0].summary += "@@.red;Disgusted by men">>
+		<<elseif $args[0].attrXY <= 15>>
+			<<set $args[0].summary += "@@.red;Turned off by men">>
+		<<elseif $args[0].attrXY <= 35>>
+			<<set $args[0].summary += "@@.red;Not attracted to men">>
+		<<elseif $args[0].attrXY <= 65>>
+			<<set $args[0].summary += "@@.white;Indifferent to men">>
+		<<elseif $args[0].attrXY <= 85>>
+			<<set $args[0].summary += "@@.green;Attracted to men">>
+		<<elseif $args[0].attrXY <= 95>>
+			<<set $args[0].summary += "@@.green;Aroused by men">>
+		<<elseif $args[0].attrXX > 95>>
+			<<if $args[0].energy <= 95>>
+				<<set _stats = 0, _comma = 0>>
+				<<set $args[0].summary += "@@.green;Omnisexual!">>
+			<<else>>
+				<<set _stats = 0, _comma = 0>>
+				<<set $args[0].summary += "@@.green;Omnisexual nymphomaniac!">>
+			<</if>>
+		<<else>>
+			<<set $args[0].summary += "@@.green;Passionate about men">>
+		<</if>>
+		<<if _stats>>
+			<<set $args[0].summary += " ["+$args[0].attrXY+"]">>
+		<</if>>
+		<<if _comma>>
+			<<set $args[0].summary += ",@@ ">>
+		<<else>>
+			<<set $args[0].summary += "@@ ">>
+		<</if>>
+		<<set _stats = $summaryStats, _comma = 1>>
+		<<if $args[0].attrXX <= 5>>
+			<<set $args[0].summary += "@@.red;disgusted by women">>
+		<<elseif $args[0].attrXX <= 15>>
+			<<set $args[0].summary += "@@.red;turned off by women">>
+		<<elseif $args[0].attrXX <= 35>>
+			<<set $args[0].summary += "@@.red;not attracted to women">>
+		<<elseif $args[0].attrXX <= 65>>
+			<<set $args[0].summary += "@@.white;indifferent to women">>
+		<<elseif $args[0].attrXX <= 85>>
+			<<set $args[0].summary += "@@.green;attracted to women">>
+		<<elseif $args[0].attrXX <= 95>>
+			<<set $args[0].summary += "@@.green;aroused by women">>
+		<<elseif $args[0].attrXY <= 95>>
+			<<set $args[0].summary += "@@.green;passionate about women">>
+		<</if>>
+		<<if _stats>>
+			<<set $args[0].summary += " ["+$args[0].attrXX+"].@@ ">>
+		<<else>>
+			<<set $args[0].summary += ".@@ ">>
+		<</if>>
+		
+		<<if $args[0].energy > 95>>
+			<<if ($args[0].attrXY <= 95) || ($args[0].attrXX <= 95)>>
+				<<set _stats = 0, _comma = 0>>
+				<<set $args[0].summary += "@@.green;Nymphomaniac!">>
+			<</if>>
+		<<elseif $args[0].energy > 80>>
+			<<set $args[0].summary += "@@.green;Powerful sex drive">>
+		<<elseif $args[0].energy > 60>>
+			<<set $args[0].summary += "@@.green;Good sex drive">>
+		<<elseif $args[0].energy > 40>>
+			<<set $args[0].summary += "@@.yellow;Average sex drive">>
+		<<elseif $args[0].energy > 20>>
+			<<set $args[0].summary += "@@.red;Poor sex drive">>
+		<<else>>
+			<<set $args[0].summary += "@@.red;No sex drive">>
+		<</if>>
+		<<if _stats>>
+			<<set $args[0].summary += " ["+$args[0].energy+"]">>
+		<</if>>
+		<<if _comma>>
+			<<set $args[0].summary += ".@@ ">>
+		<<else>>
+			<<set $args[0].summary += "@@ ">>
+		<</if>>
+	<</if>>
+	
+	<<if $args[0].clitPiercing == 3>>
+		<<if $args[0].fetishKnown == 1>>
+			<<if $args[0].clitSetting == "off">>
+				<<set $args[0].summary += "SP off. ">>
+			<<elseif (($args[0].fetish != "submissive") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "submissive")>>
+				<<set $args[0].summary += "SP: submissive. ">>
+			<<elseif (($args[0].fetish != "cumslut") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "oral")>>
+				<<set $args[0].summary += "SP: oral. ">>
+			<<elseif (($args[0].fetish != "humiliation") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "humiliation")>>
+				<<set $args[0].summary += "SP: humiliation. ">>
+			<<elseif (($args[0].fetish != "buttslut") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "anal")>>
+				<<set $args[0].summary += "SP: anal. ">>
+			<<elseif (($args[0].fetish != "boobs") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "boobs")>>
+				<<set $args[0].summary += "SP: breasts. ">>
+			<<elseif (($args[0].fetish != "sadist") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "sadist")>>
+				<<set $args[0].summary += "SP: sadism. ">>
+			<<elseif (($args[0].fetish != "masochist") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "masochist")>>
+				<<set $args[0].summary += "SP: masochism. ">>
+			<<elseif (($args[0].fetish != "dom") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "dom")>>
+				<<set $args[0].summary += "SP: dominance. ">>
+			<<elseif (($args[0].fetish != "pregnancy") || ($args[0].fetishStrength <= 95)) && ($args[0].clitSetting == "pregnancy")>>
+				<<set $args[0].summary += "SP: pregnancy. ">>
+			<<elseif ($args[0].fetish != "none") && ($args[0].clitSetting == "vanilla")>>
+				<<set $args[0].summary += "SP: vanilla. ">>
+			<<elseif ($args[0].energy <= 95) && ($args[0].clitSetting == "all")>>
+				<<set $args[0].summary += "SP: all. ">>
+			<<elseif ($args[0].energy > 5) && ($args[0].clitSetting == "none")>>
+				<<set $args[0].summary += "SP: none. ">>
+			<</if>>
+		<<else>>
+			<<switch $args[0].clitSetting>>
+			<<case "off">>
+				<<set $args[0].summary += "SP off. ">>
+			<<case "submissive">>
+				<<set $args[0].summary += "SP: submissive. ">>
+			<<case "oral">>
+				<<set $args[0].summary += "SP: oral. ">>
+			<<case "humiliation">>
+				<<set $args[0].summary += "SP: humiliation. ">>
+			<<case "anal">>
+				<<set $args[0].summary += "SP: anal. ">>
+			<<case "boobs">>
+				<<set $args[0].summary += "SP: breasts. ">>
+			<<case "sadist">>
+				<<set $args[0].summary += "SP: sadism. ">>
+			<<case "masochist">>
+				<<set $args[0].summary += "SP: masochism. ">>
+			<<case "dom">>
+				<<set $args[0].summary += "SP: dominance. ">>
+			<<case "pregnancy">>
+				<<set $args[0].summary += "SP: pregnancy. ">>
+			<<case "vanilla">>
+				<<set $args[0].summary += "SP: vanilla. ">>
+			<<case "all">>
+				<<set $args[0].summary += "SP: all. ">>
+			<<case "none">>
+				<<set $args[0].summary += "SP: none. ">>
+			<</switch>>
+		<</if>>
+		<<if $args[0].attrKnown == 1>>
+			<<if ($args[0].attrXX < 100) && ($args[0].clitSetting == "women")>>
+				<<set $args[0].summary += "SP: women. ">>
+			<<elseif ($args[0].attrXY < 100) && ($args[0].clitSetting == "men")>>
+				<<set $args[0].summary += "SP: men. ">>
+			<</if>>
+		<<else>>
+			<<if $args[0].clitSetting == "women">>
+				<<set $args[0].summary += "SP: women. ">>
+			<<elseif $args[0].clitSetting == "men">>
+				<<set $args[0].summary += "SP: men. ">>
+			<</if>>
+		<</if>>
+	<</if>>
+	
+	<<set $args[0].summary += "@@.red;">>
+	<<switch $args[0].behavioralFlaw>>
+	<<case "arrogant">>
+		<<set $args[0].summary += "Arrogant.">>
+	<<case "bitchy">>
+		<<set $args[0].summary += "Bitchy.">>
+	<<case "odd">>
+		<<set $args[0].summary += "Odd.">>
+	<<case "hates men">>
+		<<set $args[0].summary += "Hates men.">>
+	<<case "hates women">>
+		<<set $args[0].summary += "Hates women.">>
+	<<case "gluttonous">>
+		<<set $args[0].summary += "Stress eater.">>
+	<<case "anorexic">>
+		<<set $args[0].summary += "Anorexic.">>
+	<<case "devout">>
+		<<set $args[0].summary += "Devoutly religious.">>
+	<<case "liberated">>
+		<<set $args[0].summary += "Mentally liberated.">>
+	<<default>>
+		<<set $args[0].behavioralFlaw = "none">>
+	<</switch>>
+	<<set $args[0].summary += "@@ ">>
+	<<switch $args[0].sexualFlaw>>
+	<<case "hates oral">>
+		<<set $args[0].summary += "@@.red;Hates oral.@@ ">>
+	<<case "hates anal">>
+		<<set $args[0].summary += "@@.red;Hates anal.@@ ">>
+	<<case "hates penetration">>
+		<<set $args[0].summary += "@@.red;Hates penetration.@@ ">>
+	<<case "shamefast">>
+		<<set $args[0].summary += "@@.red;Shamefast.@@ ">>
+	<<case "idealistic">>
+		<<set $args[0].summary += "@@.red;Sexually idealistic.@@ ">>
+	<<case "repressed">>
+		<<set $args[0].summary += "@@.red;Sexually repressed.@@ ">>
+	<<case "apathetic">>
+		<<set $args[0].summary += "@@.red;Sexually apathetic.@@ ">>
+	<<case "crude">>
+		<<set $args[0].summary += "@@.red;Sexually crude.@@ ">>
+	<<case "judgemental">>
+		<<set $args[0].summary += "@@.red;Sexually judgemental.@@ ">>
+	<<case "cum addict">>
+		<<set $args[0].summary += "@@.yellow;Cum addict.@@ ">>
+	<<case "anal addict">>
+		<<set $args[0].summary += "@@.yellow;Anal addict.@@ ">>
+	<<case "attention whore">>
+		<<set $args[0].summary += "@@.yellow;Attention whore.@@ ">>
+	<<case "breast growth">>
+		<<set $args[0].summary += "@@.yellow;Breast obsession.@@ ">>
+	<<case "abusive">>
+		<<set $args[0].summary += "@@.yellow;Sexually abusive.@@ ">>
+	<<case "malicious">>
+		<<set $args[0].summary += "@@.yellow;Sexually malicious.@@ ">>
+	<<case "self hating">>
+		<<set $args[0].summary += "@@.yellow;Self hatred.@@ ">>
+	<<case "neglectful">>
+		<<set $args[0].summary += "@@.yellow;Self neglectful.@@ ">>
+	<<case "breeder">>
+		<<set $args[0].summary += "@@.yellow;Breeding obsession.@@ ">>
+	<<default>>
+		<<set $args[0].sexualFlaw = "none">>
+	<</switch>>
+	<<set $args[0].summary += "@@.green;">>
+	<<switch $args[0].behavioralQuirk>>
+	<<case "confident">>
+		<<set $args[0].summary += "Confident. ">>
+	<<case "cutting">>
+		<<set $args[0].summary += "Cutting. ">>
+	<<case "funny">>
+		<<set $args[0].summary += "Funny. ">>
+	<<case "fitness">>
+		<<set $args[0].summary += "Fitness. ">>
+	<<case "adores women">>
+		<<set $args[0].summary += "Adores women. ">>
+	<<case "adores men">>
+		<<set $args[0].summary += "Adores men. ">>
+	<<case "insecure">>
+		<<set $args[0].summary += "Insecure. ">>
+	<<case "sinful">>
+		<<set $args[0].summary += "Sinful. ">>
+	<<case "advocate">>
+		<<set $args[0].summary += "Advocate. ">>
+	<<default>>
+		<<set $args[0].behavioralQuirk = "none">>
+	<</switch>>
+	<<switch $args[0].sexualQuirk>>
+	<<case "gagfuck queen">>
+		<<set $args[0].summary += "Gagfuck queen.">>
+	<<case "painal queen">>
+		<<set $args[0].summary += "Painal queen.">>
+	<<case "strugglefuck queen">>
+		<<set $args[0].summary += "Strugglefuck queen.">>
+	<<case "tease">>
+		<<set $args[0].summary += "Tease.">>
+	<<case "romantic">>
+		<<set $args[0].summary += "Romantic.">>
+	<<case "perverted">>
+		<<set $args[0].summary += "Perverted.">>
+	<<case "caring">>
+		<<set $args[0].summary += "Caring.">>
+	<<case "unflinching">>
+		<<set $args[0].summary += "Unflinching.">>
+	<<case "size queen">>
+		<<set $args[0].summary += "Size queen.">>
+	<<default>>
+		<<set $args[0].sexualQuirk = "none">>
+	<</switch>>
+	<<set $args[0].summary += "@@ ">>
+<</if>>
+
+<<if $args[0].customLabel != "">><<set $args[0].summary += "''@@.yellow;$args[0].customLabel@@'' ">><</if>>
+
+/* - Line 4 - ******************************************************/
+<<if ($args[0].relationship != 0) || ($args[0].relation != 0) || ($abbreviateClothes == 2) || ($abbreviateRulesets == 2)>>
+	<<set $args[0].summary += _break>>
+<</if>>
+<<if $abbreviateMental == 1>>
+<<set $args[0].summary += "@@.lightgreen;">>
+
+<<if $args[0].relation != 0>>
+<<for _ssj = 0; _ssj < _SL; _ssj++>>
+	<<if $args[0].relationTarget == $slaves[_ssj].ID>>
+		<<set $args[0].summary += ""+$slaves[_ssj].slaveName>>
+		<<if $slaves[_ssj].slaveSurname>> 
+			<<set $args[0].summary += " "+$slaves[_ssj].slaveSurname>>
+		<</if>>
+		<<set $args[0].summary += "'s "+$args[0].relation>>
+		<<if $args[0].relationship <= 0>>
+			<<set $args[0].summary += "&nbsp;&nbsp;&nbsp;&nbsp;">>
+		<</if>>
+		<<break>>
+	<</if>>
+<</for>>
+<</if>>
+
+<<if $args[0].relationship > 0>>
+<<for _ssj = 0; _ssj < _SL; _ssj++>>
+	<<if $args[0].relationshipTarget == $slaves[_ssj].ID>>
+
+		<<if $args[0].relationshipTarget != $args[0].relationTarget>>
+			<<set $args[0].summary += $slaves[_ssj].slaveName>>
+			<<if $slaves[_ssj].slaveSurname>>
+				<<set $args[0].summary += " "+$slaves[_ssj].slaveSurname>>
+			<</if>>
+			<<set $args[0].summary += "'s">>
+		<<else>>
+			<<set $args[0].summary += " &">>
+		<</if>>
+		<<switch $args[0].relationship>>
+		<<case 1>>
+			<<set $args[0].summary += " friend">>
+		<<case 2>>
+			<<set $args[0].summary += " BFF">>
+		<<case 3>>
+			<<set $args[0].summary += " FWB">>
+		<<case 4>>
+			<<set $args[0].summary += " lover">>
+		<<case 5>>
+			<<set $args[0].summary += " wife">>
+		<</switch>>
+		<<set $args[0].summary += "&nbsp;&nbsp;&nbsp;&nbsp;">>
+		<<break>>
+	<</if>>
+<</for>>
+
+<<elseif $args[0].relationship == -3>>
+	<<set $args[0].summary += "Your wife&nbsp;&nbsp;&nbsp;&nbsp;">>
+<<elseif $args[0].relationship == -2>>
+	<<set $args[0].summary += "E Bonded&nbsp;&nbsp;&nbsp;&nbsp;">>
+<<elseif $args[0].relationship == -1>>
+	<<set $args[0].summary += "E Slut&nbsp;&nbsp;&nbsp;&nbsp;">>
+<</if>>
+<<set $args[0].summary += "@@ ">>
+
+<<if $args[0].rivalry != 0>>
+<<for _ssj = 0; _ssj < _SL; _ssj++>>
+	<<if $args[0].rivalryTarget == $slaves[_ssj].ID>>
+		<<set $args[0].summary += "@@.lightsalmon;">>
+		<<if $args[0].rivalry <= 1>>
+			<<set $args[0].summary += "Disl "+$slaves[_ssj].slaveName>>
+			<<if $slaves[_ssj].slaveSurname>>
+				<<set $args[0].summary += " "+$slaves[_ssj].slaveSurname>>
+			<</if>>
+		<<elseif $args[0].rivalry <= 2>>
+			<<set $args[0].summary += ""+$slaves[_ssj].slaveName>>
+			<<if $slaves[_ssj].slaveSurname>>
+				<<set $args[0].summary += " "+$slaves[_ssj].slaveSurname>>
+			<</if>>
+			<<set $args[0].summary += "'s rival">>
+		<<else>>
+			<<set $args[0].summary += "Hates "+$slaves[_ssj].slaveName>>
+			<<if $slaves[_ssj].slaveSurname>>
+				<<set $args[0].summary += " "+$slaves[_ssj].slaveSurname>>
+			<</if>>
+		<</if>>
+		<<set $args[0].summary += "&nbsp;&nbsp;&nbsp;&nbsp;@@ ">>
+		<<break>>
+	<</if>>
+<</for>>
+<</if>>
+
+<<elseif $abbreviateMental == 2>>
+<<if $args[0].relation != 0>>
+<<for _ssj = 0; _ssj < _SL; _ssj++>>
+	<<if $args[0].relationTarget == $slaves[_ssj].ID>>
+		<<set $args[0].summary += $slaves[_ssj].slaveName>>
+		<<if $slaves[_ssj].slaveSurname>>
+			<<set $args[0].summary += " "+$slaves[_ssj].slaveSurname>>
+		<</if>>
+		<<set $args[0].summary += "'s ">>
+		<<if $args[0].relationshipTarget != $args[0].relationTarget>>
+			<<set $args[0].summary += "@@.lightgreen;"+$args[0].relation+"@@. ">>
+		<<else>>
+			<<set $args[0].summary += "@@.lightgreen;"+$args[0].relation+"@@ ">>
+		<</if>>
+		<<if $args[0].relationship <= 0>>
+			<<set $args[0].summary += "&nbsp;&nbsp;&nbsp;&nbsp;">>
+		<</if>>
+		<<break>>
+	<</if>>
+<</for>>
+<</if>>
+
+<<if $args[0].relationship > 0>>
+<<for _ssj = 0; _ssj < _SL; _ssj++>>
+	<<if $args[0].relationshipTarget == $slaves[_ssj].ID>>
+		<<if $args[0].relationshipTarget != $args[0].relationTarget>>
+			<<set $args[0].summary += $slaves[_ssj].slaveName>>
+			<<if $slaves[_ssj].slaveSurname>>
+				<<set $args[0].summary += " "+$slaves[_ssj].slaveSurname>>
+			<</if>>
+			<<set $args[0].summary += "'s ">>
+		<<else>>
+			<<set $args[0].summary += " and ">>
+		<</if>>
+
+		<<switch $args[0].relationship>>
+		<<case 1>>
+			<<set $args[0].summary += "@@.lightgreen;friend.@@ ">>
+		<<case 2>>
+			<<set $args[0].summary += "@@.lightgreen;best friend.@@ ">>
+		<<case 3>>
+			<<set $args[0].summary += "@@.lightgreen;FWB.@@ ">>
+		<<case 4>>
+			<<set $args[0].summary += "@@.lightgreen;lover.@@ ">>
+		<<case 5>>
+			<<set $args[0].summary += "@@.lightgreen;slave wife.@@ ">>
+		<</switch>>
+		<<set $args[0].summary += "&nbsp;&nbsp;&nbsp;&nbsp;">>
+		<<break>>
+	<</if>>
+<</for>>
+
+<<elseif $args[0].relationship == -3>>
+	<<set $args[0].summary += "@@.lightgreen;Your wife.@@&nbsp;&nbsp;&nbsp;&nbsp;">>
+<<elseif $args[0].relationship == -2>>
+	<<set $args[0].summary += "@@.lightgreen;Emotionally bonded to you.@@&nbsp;&nbsp;&nbsp;&nbsp;">>
+<<elseif $args[0].relationship == -1>>
+	<<set $args[0].summary += "@@.lightgreen;Emotional slut.@@&nbsp;&nbsp;&nbsp;&nbsp;">>
+<</if>>
+
+<<if $args[0].rivalry != 0>>
+<<for _ssj = 0; _ssj < _SL; _ssj++>>
+	<<if $args[0].rivalryTarget == $slaves[_ssj].ID>>
+		<<if $args[0].rivalry <= 1>>
+			<<set $args[0].summary += "@@.lightsalmon;Dislikes@@ "+$slaves[_ssj].slaveName>>
+			<<if $slaves[_ssj].slaveSurname>>
+				<<set $args[0].summary += " "+$slaves[_ssj].slaveSurname>>
+			<</if>>
+			<<set $args[0].summary += ".&nbsp;&nbsp;&nbsp;&nbsp;">>
+		<<elseif $args[0].rivalry <= 2>>
+			<<set $args[0].summary += $slaves[_ssj].slaveName>>
+			<<if $slaves[_ssj].slaveSurname>> 
+				<<set $args[0].summary += " "+$slaves[_ssj].slaveSurname>>
+			<</if>>
+			<<set $args[0].summary += "'s @@.lightsalmon;rival.@@&nbsp;&nbsp;&nbsp;&nbsp;">>
+		<<else>>
+			<<set $args[0].summary += "@@.lightsalmon;Hates@@ "+$slaves[_ssj].slaveName>>
+			<<if $slaves[_ssj].slaveSurname>> 
+				<<set $args[0].summary += " "+$slaves[_ssj].slaveSurname>>
+			<</if>>
+			<<set $args[0].summary += ".&nbsp;&nbsp;&nbsp;&nbsp;">>
+		<</if>>
+		<<break>>
+	<</if>>
+<</for>>
+<</if>>
+
+<</if>>
+
+<<if $args[0].fuckdoll == 0>>
+<<if $abbreviateClothes == 2>>
+<<if $args[0].choosesOwnClothes == 1>>
+	<<set $args[0].summary += "Dressing herself. ">>
+<</if>>
+<<switch $args[0].clothes>>
+<<case "attractive lingerie">>
+	<<set $args[0].summary += "Lingerie. ">>
+<<case "a succubus outfit">>
+	<<set $args[0].summary += "Succubus outfit. ">>
+<<case "a string bikini">>
+	<<set $args[0].summary += "String bikini. ">>
+<<case "cutoffs and a t-shirt">>
+	<<set $args[0].summary += "Cutoffs, t-shirt. ">>
+<<case "a slutty outfit">>
+	<<set $args[0].summary += "Slutty outfit. ">>
+<<case "uncomfortable straps">>
+	<<set $args[0].summary += "Leather straps. ">>
+<<case "a fallen nuns habit">>
+	<<set $args[0].summary += "Slutty habit. ">>
+<<case "a chattel habit">>
+	<<set $args[0].summary += "Chattel habit. ">>
+<<case "a penitent nuns habit">>
+	<<set $args[0].summary += "Cilice. ">>
+<<case "slutty jewelry">>
+	<<set $args[0].summary += "Bangles. ">>
+<<case "harem gauze">>
+	<<set $args[0].summary += "Harem outfit. ">>
+<<case "a slave gown">>
+	<<set $args[0].summary += "Gown. ">>
+<<case "a halter top dress">>
+	<<set $args[0].summary += "Halter top dress. ">>
+<<case "a mini dress">>
+	<<set $args[0].summary += "Mini dress. ">>
+<<case "a ball gown">>
+	<<set $args[0].summary += "Ball gown. ">>
+<<case "slutty business attire">>
+	<<set $args[0].summary += "Slutty suit. ">>
+<<case "nice business attire">>
+	<<set $args[0].summary += "Nice suit. ">>
+<<case "a comfortable bodysuit">>
+	<<set $args[0].summary += "Bodysuit. ">>
+<<case "a military uniform">>
+	<<set $args[0].summary += "Military uniform. ">>
+<<case "a leotard">>
+	<<set $args[0].summary += "Leotard. ">>
+<<case "a bunny outfit">>
+	<<set $args[0].summary += "Bunny outfit. ">>
+<<case "a slutty maid outfit">>
+	<<set $args[0].summary += "Slutty maid. ">>
+<<case "a nice maid outfit">>
+	<<set $args[0].summary += "Nice maid. ">>
+<<case "a slutty nurse outfit">>
+	<<set $args[0].summary += "Slutty nurse. ">>
+<<case "a nice nurse outfit">>
+	<<set $args[0].summary += "Nice nurse. ">>
+<<case "a schoolgirl outfit">>
+	<<set $args[0].summary += "Schoolgirl outfit. ">>
+<<case "a kimono">>
+	<<set $args[0].summary += "Kimono. ">>
+<<case "a hijab and abaya">>
+	<<set $args[0].summary += "Hijab and abaya. ">>
+<<case "battledress">>
+	<<set $args[0].summary += "Battledress. ">>
+<<case "a latex catsuit">>
+	<<set $args[0].summary += "Nice latex. ">>
+<<case "restrictive latex">>
+	<<set $args[0].summary += "Bondage latex. ">>
+<<case "conservative clothing">>
+	<<set $args[0].summary += "Conservative clothing. ">>
+<<case "chains">>
+	<<set $args[0].summary += "Chains. ">>
+<<case "a cheerleader outfit">>
+	<<set $args[0].summary += "Cheerleader. ">>
+<<case "clubslut netting">>
+	<<set $args[0].summary += "Netting. ">>
+<<case "shibari ropes">>
+	<<set $args[0].summary += "Shibari. ">>
+<<case "Western clothing">>
+	<<set $args[0].summary += "Chaps. ">>
+<<case "body oil">>
+	<<set $args[0].summary += "Body oil. ">>
+<<case "a toga">>
+	<<set $args[0].summary += "Toga. ">>
+<<case "a huipil">>
+	<<set $args[0].summary += "Huipil. ">>
+<<case "a slutty qipao">>
+	<<set $args[0].summary += "Qipao. ">>
+<<default>>
+	<<set $args[0].summary += "Naked. ">>
+<</switch>>
+
+<<switch $args[0].collar>>
+<<case "uncomfortable leather">>
+	<<set $args[0].summary += "Leather collar. ">>
+<<case "tight steel">>
+	<<set $args[0].summary += "Steel collar. ">>
+<<case "cruel retirement counter">>
+	<<set $args[0].summary += "Cruel counter collar. ">>
+<<case "shock punishment">>
+	<<set $args[0].summary += "Shock collar. ">>
+<<case "dildo gag">>
+	<<set $args[0].summary += "Dildo gag. ">>
+<<case "neck corset">>
+	<<set $args[0].summary += "Neck corset. ">>
+<<case "stylish leather">>
+	<<set $args[0].summary += "Stylish leather collar. ">>
+<<case "satin choker">>
+	<<set $args[0].summary += "Satin choker. ">>
+<<case "heavy gold">>
+	<<set $args[0].summary += "Gold collar. ">>
+<<case "bowtie">>
+	<<set $args[0].summary += "Bowtie collar. ">>
+<<case "pretty jewelry">>
+	<<set $args[0].summary += "Pretty collar. ">>
+<<case "nice retirement counter">>
+	<<set $args[0].summary += "Nice counter collar. ">>
+<<case "leather with cowbell">>
+	<<set $args[0].summary += "Cowbell collar. ">>
+<<case "ancient Egyptian">>
+	<<set $args[0].summary += "Wesekh. ">>
+<<case "ball gag">>
+	<<set $args[0].summary += "Ball gag. ">>
+<<case "bit gag">>
+	<<set $args[0].summary += "Bit gag. ">>
+<</switch>>
+
+<<switch $args[0].bellyAccessory>>
+<<case "shapewear">>
+	<<set $args[0].summary += "Shapewear. ">>
+<<case "a small empathy belly">>
+	<<set $args[0].summary += "Small fake belly. ">>
+<<case "a medium empathy belly">>
+	<<set $args[0].summary += "Medium fake belly. ">>
+<<case "a large empathy belly">>
+	<<set $args[0].summary += "Large fake belly. ">>
+<<case "a huge empathy belly">>
+	<<set $args[0].summary += "Huge fake belly. ">>
+<<case "a corset">>
+	<<set $args[0].summary += "Corset. ">>
+<<case "an extreme corset">>
+	<<set $args[0].summary += "Extreme corsetage. ">>
+<</switch>>
+
+<<if canWalk($args[0])>>
+<<if $args[0].shoes == "heels">>
+	<<set $args[0].summary += "Heels. ">>
+<<elseif $args[0].shoes == "extreme heels">>
+	<<set $args[0].summary += "Extreme heels. ">>
+<<elseif $args[0].shoes == "boots">>
+	<<set $args[0].summary += "Boots. ">>
+<<elseif $args[0].heels == 1>>
+	<<set $args[0].summary += "@@.yellow;Crawling.@@ ">>
+<<elseif $args[0].shoes == "flats">>
+	<<set $args[0].summary += "Flats. ">>
+<</if>>
+<</if>>
+
+<<switch $args[0].vaginalAccessory>>
+<<case "chastity belt">>
+	<<set $args[0].summary += "Vaginal chastity. ">>
+<<case "combined chastity">>
+	<<set $args[0].summary += "Combined chastity. ">>
+<<case "anal chastity">>
+	<<set $args[0].summary += "Anal chastity. ">>
+<<case "dildo">>
+	<<set $args[0].summary += "Vaginal dildo. ">>
+<<case "large dildo">>
+	<<set $args[0].summary += "Large vaginal dildo. ">>
+<<case "huge dildo">>
+	<<set $args[0].summary += "Huge vaginal dildo. ">>
+<</switch>>
+<<if $args[0].dickAccessory == "chastity">>
+	<<set $args[0].summary += "Chastity cage. ">>
+<<elseif $args[0].dickAccessory == "combined chastity">>
+	<<set $args[0].summary += "Combined chastity. ">>
+<<elseif $args[0].dickAccessory == "anal chastity">>
+	<<set $args[0].summary += "Anal chastity. ">>
+<</if>>
+<<switch $args[0].buttplug>>
+<<case "plug">>
+	<<set $args[0].summary += "Buttplug. ">>
+<<case "large plug">>
+	<<set $args[0].summary += "Large buttplug. ">>
+<<case "huge plug">>
+	<<set $args[0].summary += "Huge buttplug. ">>
+<</switch>>
+<</if>>
+<</if>>
+
+<<set $args[0].summary += "&nbsp;&nbsp;&nbsp;&nbsp;">>
+<<if $args[0].useRulesAssistant == 0>>
+	<<set $args[0].summary += "@@.lightgreen;RA-Exempt@@ ">>
+<<elseif $abbreviateRulesets == 2 && (def $args[0].currentRules) && ($args[0].currentRules.length > 0)>>
+	<<for _s = 0; _s < $defaultRules.length; _s++>>
+		<<set _currentRule = $defaultRules[_s], _num = (_s+1)>>
+		<<if ruleApplied($args[0], _currentRule.ID)>>
+			<<set $args[0].summary += "Rule "+_num+" ("+_currentRule.name+"). ">>
+		<</if>>
+	<</for>>
+<</if>>
+
+<</widget>>


### PR DESCRIPTION
A rework of how the game handles the individual slave summaries.  Instead of creating each slaves summary from scratch each time it is displayed this makes it use a stored string instead, generating a new string when needed.

Using a 190 dairy cow save for timing, the first dairy load averaged ~15% slower (16.5 -> 19.5), but subsequent loads were ~40% faster (15 -> 9).  More speed can probably be found by reducing dependence upon the Slave Summary passage.

Situations that makes the game decide it needs a new summary for a slave:
- Any newly created slave
- All slaves at the end of the week (during the Next Week passage, after events)
- A slave's inspection page (covers personally changing slave's rules, drugs, or applying surgery)
- Toy Box options (bottom of main page)
- Manually Re-applying Rules Assistant (from main page or RA options page)

While I have tested this, I haven't been able to try all summary combinations.  It should generate functionally identical summaries to the current system across all option settings and slave values.