### PR TITLE
Made compiler work while running as admin

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -1,10 +1,13 @@
 @echo off
 :: Free Cities Basic Compiler - Windows
 
+:: Set working directory
+cd %~dp0
+
 :: Will add all *.tw files to StoryIncludes.
 del src\config\start.tw
 copy src\config\start.tw.proto start.tw.tmp >nul
->>start.tw.tmp (for /r "src" %%F in (*.tw) do echo %%F)
+>>start.tw.tmp (for /r "src" %%F in (*.tw) do @echo %%F)
 move start.tw.tmp src\config\start.tw >nul
 
 :: Run the appropriate compiler for the user's CPU architecture.

--- a/compile_debug.bat
+++ b/compile_debug.bat
@@ -1,11 +1,13 @@
 @echo off
 :: Free Cities Basic Compiler - Windows
-:: Will wait for keypress before terminating.
+
+:: Set working directory
+cd %~dp0
 
 :: Will add all *.tw files to StoryIncludes.
 del src\config\start.tw
 copy src\config\start.tw.proto start.tw.tmp >nul
->>start.tw.tmp (for /r "src" %%F in (*.tw) do echo %%F)
+>>start.tw.tmp (for /r "src" %%F in (*.tw) do @echo %%F)
 move start.tw.tmp src\config\start.tw >nul
 
 :: Run the appropriate compiler for the user's CPU architecture.


### PR DESCRIPTION
If you run as admin on the batch files, the working directory is set to C:/Windows/System32. The previous echo command would also include extra text.