### PR TITLE
Fixes admin, again

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -2,7 +2,7 @@
 :: Free Cities Basic Compiler - Windows
 
 :: Set working directory
-cd %~dp0
+pushd %~dp0
 
 :: Will add all *.tw files to StoryIncludes.
 del src\config\start.tw
@@ -16,5 +16,5 @@ if %PROCESSOR_ARCHITECTURE% == AMD64 (
 ) else (
     CALL "%~dp0devTools\tweeGo\tweego_win86.exe" -o "%~dp0bin/FC.html" "%~dp0src\config\start.tw"
 )
-
+popd
 ECHO Done

--- a/compile_debug.bat
+++ b/compile_debug.bat
@@ -2,7 +2,7 @@
 :: Free Cities Basic Compiler - Windows
 
 :: Set working directory
-cd %~dp0
+pushd %~dp0
 
 :: Will add all *.tw files to StoryIncludes.
 del src\config\start.tw
@@ -16,6 +16,6 @@ if %PROCESSOR_ARCHITECTURE% == AMD64 (
 ) else (
     CALL "%~dp0devTools\tweeGo\tweego_win86.exe" -o "%~dp0bin/FC.html" "%~dp0src\config\start.tw"
 )
-
+popd
 ECHO Done
 PAUSE


### PR DESCRIPTION
For what it's worth, not only does this allow the batch files to be run as admin, but they can be run by any other program.

If you use notepad, tap f5, choose compile.bat, and it's a few less steps every time you go to test.