### PR TITLE
Rules assistant parser string fix

### DIFF
--- a/src/js/rulesAssistantParser.tw
+++ b/src/js/rulesAssistantParser.tw
@@ -303,7 +303,7 @@ var parserBuilder = new ASTBuilder("(end)")
         nud: function(p) {
             return {
                 id: "(string)",
-                value: this.value,
+                value: this.value.replace(/^\"|\"$/g, ""),
             };
         }
     })


### PR DESCRIPTION
When trying to set up custom rules involving strings, such as `livingRules = "normal"`, it would store the string with the quotes intact. 