### PR TITLE
Add links to rivals and relations, color them appropriately.

### DIFF
--- a/src/gui/css/mainStyleSheet.tw
+++ b/src/gui/css/mainStyleSheet.tw
@@ -95,6 +95,42 @@ object {
 .yellow { color: yellow }
 .yellowgreen { color: yellowgreen }
 
+.link a { color: #68D } /* link color */
+.aquamarine a { color: aquamarine }
+.coral a { color: coral }
+.cyan a { color: cyan }
+.darkgoldenrod a { color: darkgoldenrod }
+.darkred a { color: darkred }
+.darkviolet a { color: darkviolet }
+.deeppink a { color: deeppink }
+.deepskyblue a { color: deepskyblue }
+.gold a { color: gold }
+.goldenrod a { color: goldenrod }
+.gray a { color: gray }
+.green a { color: green }
+.hotpink a { color: hotpink }
+.lawngreen a { color: lawngreen }
+.lightcoral a { color: lightcoral }
+.lightgreen a { color: lightgreen }
+.lightpink a { color: lightpink }
+.lightsalmon a { color: lightsalmon }
+.lime a { color: lime }
+.limegreen a { color: limegreen }
+.magenta a { color: magenta }
+.mediumaquamarine a { color: mediumaquamarine }
+.mediumorchid a { color: mediumorchid }
+.mediumseagreen a { color: mediumseagreen }
+.orange a { color: orange }
+.orangered a { color: orangered }
+.orchid a { color: orchid }
+.pink a { color: pink }
+.red a { color: red }
+.seagreen a { color: seagreen }
+.springgreen a { color: springgreen }
+.tan a { color: tan }
+.yellow a { color: yellow }
+.yellowgreen a { color: yellowgreen }
+
 /*! <<checkvars>> macro for SugarCube 2.x */
 #ui-dialog-body.checkvars{padding:1em}#ui-dialog-body.checkvars h1{font-size:1.5em;margin-top:0}#ui-dialog-body.checkvars table{border-collapse:collapse;border-spacing:0}#ui-dialog-body.checkvars thead tr{border-bottom:2px solid #444}#ui-dialog-body.checkvars tr:not(:first-child){border-top:1px solid #444}#ui-dialog-body.checkvars td,#ui-dialog-body.checkvars th{padding:.25em 1em}#ui-dialog-body.checkvars td:first-child,#ui-dialog-body.checkvars th:first-child{padding-left:.5em;border-right:1px solid #444}#ui-dialog-body.checkvars td:last-child,#ui-dialog-body.checkvars th:last-child{padding-right:.5em}#ui-dialog-body.checkvars th:first-child{text-align:center}#ui-dialog-body.checkvars td:first-child{font-weight:700;text-align:right}#ui-dialog-body.checkvars td{font-family:monospace,monospace;vertical-align:top;white-space:pre-wrap}#ui-dialog-body.checkvars .scroll-pad{margin:0;padding:0}
 

--- a/src/uncategorized/longSlaveDescription.tw
+++ b/src/uncategorized/longSlaveDescription.tw
@@ -1112,10 +1112,22 @@ when a dick is pushed inside <<if $activeSlave.vagina >= -1>>either of its lower
   <<for _lsd = 0; _lsd < $slaves.length; _lsd++>>
 	<<if $slaves[_lsd].ID == $activeSlave.relationTarget>>
 		<<if ($slaves[_lsd].ID == $activeSlave.relationshipTarget) && ($activeSlave.relationship >= 3)>>
-			$pronounCap is @@.lightgreen;$slaves[_lsd].slaveName<<if $slaves[_lsd].slaveSurname>> $slaves[_lsd].slaveSurname<</if>>'s $activeSlave.relation, making their relationship incestuous.@@
+			$pronounCap is @@.lightgreen;
+			<<if $slaves[_lsd].slaveSurname>> 
+				<<set _relationName = ($slaves[_lsd].slaveName + " " + $slaves[_lsd].slaveSurname)>>
+			<<else>> 
+				<<set _relationName = ($slaves[_lsd].slaveName)>>
+			<</if>>
+			<span class=".lightgreen">[[_relationName|Slave Interact][$activeSlave = $slaves[_lsd]]]'s $activeSlave.relation, making their relationship incestuous.@@</span>
 			<<break>>
 		<<else>>
-			$pronounCap is @@.lightgreen;$slaves[_lsd].slaveName<<if $slaves[_lsd].slaveSurname>> $slaves[_lsd].slaveSurname<</if>>'s $activeSlave.relation.@@
+			$pronounCap is @@.lightgreen;
+			<<if $slaves[_lsd].slaveSurname>> 
+				<<set _relationName = ($slaves[_lsd].slaveName + " " + $slaves[_lsd].slaveSurname)>>
+			<<else>> 
+				<<set _relationName = ($slaves[_lsd].slaveName)>>
+			<</if>>
+			[[_relationName|Slave Interact][$activeSlave = $slaves[_lsd]]]'s $activeSlave.relation.@@
 			<<break>>
 		<</if>>
 	<</if>>
@@ -1127,12 +1139,18 @@ when a dick is pushed inside <<if $activeSlave.vagina >= -1>>either of its lower
 	<<if $slaves[_lsd].ID == $activeSlave.rivalryTarget>>
 		$pronounCap
 		<<if $activeSlave.rivalry <= 1>>
-			@@.lightsalmon;dislikes@@ $slaves[_lsd].slaveName<<if $slaves[_lsd].slaveSurname>> $slaves[_lsd].slaveSurname<</if>>.
+			@@.lightsalmon;dislikes@@ 
 		<<elseif $activeSlave.rivalry <= 2>>
 			is $slaves[_lsd].slaveName<<if $slaves[_lsd].slaveSurname>> $slaves[_lsd].slaveSurname<</if>>'s @@.lightsalmon;rival.@@
 		<<else>>
-			@@.lightsalmon;bitterly hates@@ $slaves[_lsd].slaveName<<if $slaves[_lsd].slaveSurname>> $slaves[_lsd].slaveSurname<</if>>.
+			@@.lightsalmon;bitterly hates@@ $slaves[_lsd].slaveName<<if $slaves[_lsd].slaveSurname>> $slaves[_lsd].slaveSurname<</if>>  [[(view)|Slave Interact][$activeSlave = $slaves[_lsd]]].
    		<</if>>
+		<<if $slaves[_lsd].slaveSurname>> 
+			<<set _rivalName = ($slaves[_lsd].slaveName + " " + $slaves[_lsd].slaveSurname)>>
+		<<else>> 
+			<<set _rivalName = ($slaves[_lsd].slaveName)>>
+		<</if>>
+		[[_rivalName|Slave Interact][$activeSlave = $slaves[_lsd]]].
 		<<break>>
 	<</if>>
   <</for>>

--- a/src/uncategorized/longSlaveDescription.tw
+++ b/src/uncategorized/longSlaveDescription.tw
@@ -1139,18 +1139,30 @@ when a dick is pushed inside <<if $activeSlave.vagina >= -1>>either of its lower
 	<<if $slaves[_lsd].ID == $activeSlave.rivalryTarget>>
 		$pronounCap
 		<<if $activeSlave.rivalry <= 1>>
-			@@.lightsalmon;dislikes@@ 
+			@@.lightsalmon;dislikes
+			<<if $slaves[_lsd].slaveSurname>> 
+				<<set _rivalName = ($slaves[_lsd].slaveName + " " + $slaves[_lsd].slaveSurname)>>
+			<<else>> 
+				<<set _rivalName = ($slaves[_lsd].slaveName)>>
+			<</if>>
+			[[_rivalName|Slave Interact][$activeSlave = $slaves[_lsd]]].@@
 		<<elseif $activeSlave.rivalry <= 2>>
-			is $slaves[_lsd].slaveName<<if $slaves[_lsd].slaveSurname>> $slaves[_lsd].slaveSurname<</if>>'s @@.lightsalmon;rival.@@
+			is @@.lightsalmon;$slaves[_lsd].slaveName
+			<<if $slaves[_lsd].slaveSurname>> 
+				<<set _rivalName = ($slaves[_lsd].slaveName + " " + $slaves[_lsd].slaveSurname)>>
+			<<else>> 
+				<<set _rivalName = ($slaves[_lsd].slaveName)>>
+			<</if>>
+			[[_rivalName|Slave Interact][$activeSlave = $slaves[_lsd]]]'s rival.@@
 		<<else>>
-			@@.lightsalmon;bitterly hates@@ $slaves[_lsd].slaveName<<if $slaves[_lsd].slaveSurname>> $slaves[_lsd].slaveSurname<</if>>  [[(view)|Slave Interact][$activeSlave = $slaves[_lsd]]].
+			@@.lightsalmon;bitterly hates 
+			<<if $slaves[_lsd].slaveSurname>> 
+				<<set _rivalName = ($slaves[_lsd].slaveName + " " + $slaves[_lsd].slaveSurname)>>
+			<<else>> 
+				<<set _rivalName = ($slaves[_lsd].slaveName)>>
+			<</if>>
+			[[_rivalName|Slave Interact][$activeSlave = $slaves[_lsd]]].@@
    		<</if>>
-		<<if $slaves[_lsd].slaveSurname>> 
-			<<set _rivalName = ($slaves[_lsd].slaveName + " " + $slaves[_lsd].slaveSurname)>>
-		<<else>> 
-			<<set _rivalName = ($slaves[_lsd].slaveName)>>
-		<</if>>
-		[[_rivalName|Slave Interact][$activeSlave = $slaves[_lsd]]].
 		<<break>>
 	<</if>>
   <</for>>


### PR DESCRIPTION
I hope it's ok to add this to the stylesheet, it's the only way I can get the color of the link to respect the color of the passage.

This will be useful elsewhere I'm sure, but it's also technically possible that someone else was assuming links would always be blue, and encased one in @@.  If that's the case, it's just a matter of correctly escaping the link itself from the palette choice.