### PR TITLE
Summary Sexuality fixes

### DIFF
--- a/src/utility/summaryWidgets.tw
+++ b/src/utility/summaryWidgets.tw
@@ -1832,7 +1832,7 @@ will
 	<</if>>
 	
 	<<if $args[0].attrKnown == 1>>
-		<<set _stats = $summaryStats, _comma = 1, _drive = $summaryStats>>
+		<<set _stats = $summaryStats, _comma = 1, _drive = 1>>
 		<<if $args[0].attrXY <= 5>>
 			<<set $args[0].summary += "@@.red;XY---">>
 		<<elseif $args[0].attrXY <= 15>>
@@ -1886,24 +1886,28 @@ will
 			<<set $args[0].summary += "@@ ">>
 		<</if>>
 	
-		<<if $args[0].energy > 95>>
-			<<set _drive = 0>>
-			<<if ($args[0].attrXY <= 95) || ($args[0].attrXX <= 95)>>
-				<<set $args[0].summary += "@@.green;Nympho!@@ ">>
-			<</if>>
-		<<elseif $args[0].energy > 80>>
-			<<set $args[0].summary += "@@.green;SD++">>
-		<<elseif $args[0].energy > 60>>
-			<<set $args[0].summary += "@@.green;SD+">>
-		<<elseif $args[0].energy > 40>>
-			<<set $args[0].summary += "@@.yellow;SD ">>
-		<<elseif $args[0].energy > 20>>
-			<<set $args[0].summary += "@@.red;SD-">>
-		<<else>>
-			<<set $args[0].summary += "@@.red;SD--">>
-		<</if>>
 		<<if _drive == 1>>
-			<<set $args[0].summary += "["+$args[0].energy+"]@@ ">>
+			<<set _stats = $summaryStats>>
+			<<if $args[0].energy > 95>>
+				<<set _stats = 0>>
+				<<if ($args[0].attrXY <= 95) || ($args[0].attrXX <= 95)>>
+					<<set $args[0].summary += "@@.green;Nympho!">>
+				<</if>>
+			<<elseif $args[0].energy > 80>>
+				<<set $args[0].summary += "@@.green;SD++">>
+			<<elseif $args[0].energy > 60>>
+				<<set $args[0].summary += "@@.green;SD+">>
+			<<elseif $args[0].energy > 40>>
+				<<set $args[0].summary += "@@.yellow;SD ">>
+			<<elseif $args[0].energy > 20>>
+				<<set $args[0].summary += "@@.red;SD-">>
+			<<else>>
+				<<set $args[0].summary += "@@.red;SD--">>
+			<</if>>
+			<<if _stats == 1>>
+				<<set $args[0].summary += "["+$args[0].energy+"]">>
+			<</if>>
+			<<set $args[0].summary += "@@ ">>
 		<</if>>
 	<</if>>
 	<</if>>
@@ -2192,7 +2196,7 @@ will
 	<</if>>
 	<</if>>
 	<<if $args[0].attrKnown == 1>>
-		<<set _stats = $summaryStats, _comma = 1, _drive = $summaryStats>>
+		<<set _stats = $summaryStats, _comma = 1, _drive = 1>>
 		<<if $args[0].attrXY <= 5>>
 			<<set $args[0].summary += "@@.red;Disgusted by men">>
 		<<elseif $args[0].attrXY <= 15>>
@@ -2249,28 +2253,28 @@ will
 			<<set $args[0].summary += ".@@ ">>
 		<</if>>
 		
-		<<set _comma = _drive>>
-		<<if $args[0].energy > 95>>
-			<<if ($args[0].attrXY <= 95) || ($args[0].attrXX <= 95)>>
-				<<set _drive = 0, _comma = 0>>
-				<<set $args[0].summary += "@@.green;Nymphomaniac!">>
-			<</if>>
-		<<elseif $args[0].energy > 80>>
-			<<set $args[0].summary += "@@.green;Powerful sex drive">>
-		<<elseif $args[0].energy > 60>>
-			<<set $args[0].summary += "@@.green;Good sex drive">>
-		<<elseif $args[0].energy > 40>>
-			<<set $args[0].summary += "@@.yellow;Average sex drive">>
-		<<elseif $args[0].energy > 20>>
-			<<set $args[0].summary += "@@.red;Poor sex drive">>
-		<<else>>
-			<<set $args[0].summary += "@@.red;No sex drive">>
-		<</if>>
 		<<if _drive == 1>>
-			<<set $args[0].summary += " ["+$args[0].energy+"]">>
-		<</if>>
-		<<if _comma == 1>>
-			<<set $args[0].summary += ".@@ ">>
+			<<set _stats = $summaryStats>>
+			<<if $args[0].energy > 95>>
+				<<if ($args[0].attrXY <= 95) || ($args[0].attrXX <= 95)>>
+					<<set _stats = 0>>
+					<<set $args[0].summary += "@@.green;Nymphomaniac!">>
+				<</if>>
+			<<elseif $args[0].energy > 80>>
+				<<set $args[0].summary += "@@.green;Powerful sex drive">>
+			<<elseif $args[0].energy > 60>>
+				<<set $args[0].summary += "@@.green;Good sex drive">>
+			<<elseif $args[0].energy > 40>>
+				<<set $args[0].summary += "@@.yellow;Average sex drive">>
+			<<elseif $args[0].energy > 20>>
+				<<set $args[0].summary += "@@.red;Poor sex drive">>
+			<<else>>
+				<<set $args[0].summary += "@@.red;No sex drive">>
+			<</if>>
+			<<if _stats == 1>>
+				<<set $args[0].summary += " ["+$args[0].energy+"].">>
+			<</if>>
+			<<set $args[0].summary += "@@ ">>
 		<</if>>
 	<</if>>
 	

--- a/src/utility/summaryWidgets.tw
+++ b/src/utility/summaryWidgets.tw
@@ -1832,82 +1832,79 @@ will
 	<</if>>
 	
 	<<if $args[0].attrKnown == 1>>
-	<<set _stats = $summaryStats>>
-	<<if $args[0].attrXY <= 5>>
-		<<set $args[0].summary += "@@.red;XY---">>
-	<<elseif $args[0].attrXY <= 15>>
-		<<set $args[0].summary += "@@.red;XY--">>
-	<<elseif $args[0].attrXY <= 35>>
-		<<set $args[0].summary += "@@.red;XY-">>
-	<<elseif $args[0].attrXY <= 65>>
-		<<set $args[0].summary += "@@.white;XY">>
-	<<elseif $args[0].attrXY <= 85>>
-		<<set $args[0].summary += "@@.green;XY+">>
-	<<elseif $args[0].attrXY <= 95>>
-		<<set $args[0].summary += "@@.green;XY++">>
-	<<elseif $args[0].attrXX > 95>>
-		<<set _stats = 0>>
-		<<if $args[0].energy <= 95>>
-			<<set $args[0].summary += "@@.green;Omni!">>
+		<<set _stats = $summaryStats, _comma = 1, _drive = $summaryStats>>
+		<<if $args[0].attrXY <= 5>>
+			<<set $args[0].summary += "@@.red;XY---">>
+		<<elseif $args[0].attrXY <= 15>>
+			<<set $args[0].summary += "@@.red;XY--">>
+		<<elseif $args[0].attrXY <= 35>>
+			<<set $args[0].summary += "@@.red;XY-">>
+		<<elseif $args[0].attrXY <= 65>>
+			<<set $args[0].summary += "@@.white;XY">>
+		<<elseif $args[0].attrXY <= 85>>
+			<<set $args[0].summary += "@@.green;XY+">>
+		<<elseif $args[0].attrXY <= 95>>
+			<<set $args[0].summary += "@@.green;XY++">>
+		<<elseif $args[0].attrXX > 95>>
+			<<set _stats = 0, _comma = 0>>
+			<<if $args[0].energy <= 95>>
+				<<set $args[0].summary += "@@.green;Omni!">>
+			<<else>>
+				<<set _drive = 0>>
+				<<set $args[0].summary += "@@.green;Omni+Nympho!!">>
+			<</if>>
 		<<else>>
-			<<set $args[0].summary += "@@.green;Omni+Nympho!!">>
+			<<set $args[0].summary += "@@.green;XY+++">>
 		<</if>>
-	<<else>>
-		<<set $args[0].summary += "@@.green;XY+++">>
-	<</if>>
-	<<if _stats == 1>>
-		<<set $args[0].summary += "["+$args[0].attrXY+"]@@ ">>
-	<<else>>
-		<<set $args[0].summary += "@@ ">>
-	<</if>>
-	
-	<<set _comma = 1>>
-	<<if $args[0].attrXX <= 5>>
-		<<set $args[0].summary += "@@.red;XX---">>
-	<<elseif $args[0].attrXX <= 15>>
-		<<set $args[0].summary += "@@.red;XX--">>
-	<<elseif $args[0].attrXX <= 35>>
-		<<set $args[0].summary += "@@.red;XX-">>
-	<<elseif $args[0].attrXX <= 65>>
-		<<set $args[0].summary += "@@.white;XX">>
-	<<elseif $args[0].attrXX <= 85>>
-		<<set $args[0].summary += "@@.green;XX+">>
-	<<elseif $args[0].attrXX <= 95>>
-		<<set $args[0].summary += "@@.green;XX++">>
-	<<elseif $args[0].attrXY <= 95>>
-		<<set $args[0].summary += "@@.green;XX+++">>
-	<<else>>
-		<<set _comma = 0>>
-	<</if>>
-	<<if _stats == 1>>
-		<<set $args[0].summary += "["+$args[0].attrXX+"]">>
-	<</if>>
-	<<if _comma == 1>>
-		<<set $args[0].summary += "@@ ">>
-	<</if>>
-	
-	<<set _stats = $summaryStats>>
-	<<if $args[0].energy > 95>>
-		<<set _stats = 0>>
-		<<if ($args[0].attrXY <= 95) || ($args[0].attrXX <= 95)>>
-			<<set $args[0].summary += "@@.green;Nympho!">>
+		<<if _stats == 1>>
+			<<set $args[0].summary += "["+$args[0].attrXY+"]@@ ">>
+		<<else>>
+			<<set $args[0].summary += "@@ ">>
 		<</if>>
-	<<elseif $args[0].energy > 80>>
-		<<set $args[0].summary += "@@.green;SD++">>
-	<<elseif $args[0].energy > 60>>
-		<<set $args[0].summary += "@@.green;SD+">>
-	<<elseif $args[0].energy > 40>>
-		<<set $args[0].summary += "@@.yellow;SD ">>
-	<<elseif $args[0].energy > 20>>
-		<<set $args[0].summary += "@@.red;SD-">>
-	<<else>>
-		<<set $args[0].summary += "@@.red;SD--">>
-	<</if>>
-	<<if _stats == 1>>
-		<<set $args[0].summary += "["+$args[0].energy+"]@@ ">>
-	<<else>>
-		<<set $args[0].summary += "@@ ">>
-	<</if>>
+	
+		<<if $args[0].attrXX <= 5>>
+			<<set $args[0].summary += "@@.red;XX---">>
+		<<elseif $args[0].attrXX <= 15>>
+			<<set $args[0].summary += "@@.red;XX--">>
+		<<elseif $args[0].attrXX <= 35>>
+			<<set $args[0].summary += "@@.red;XX-">>
+		<<elseif $args[0].attrXX <= 65>>
+			<<set $args[0].summary += "@@.white;XX">>
+		<<elseif $args[0].attrXX <= 85>>
+			<<set $args[0].summary += "@@.green;XX+">>
+		<<elseif $args[0].attrXX <= 95>>
+			<<set $args[0].summary += "@@.green;XX++">>
+		<<elseif $args[0].attrXY <= 95>>
+			<<set $args[0].summary += "@@.green;XX+++">>
+		<<else>>
+			<<set _stats = 0, _comma = 0>>
+		<</if>>
+		<<if _stats == 1>>
+			<<set $args[0].summary += "["+$args[0].attrXX+"]">>
+		<</if>>
+		<<if _comma == 1>>
+			<<set $args[0].summary += "@@ ">>
+		<</if>>
+	
+		<<if $args[0].energy > 95>>
+			<<set _drive = 0>>
+			<<if ($args[0].attrXY <= 95) || ($args[0].attrXX <= 95)>>
+				<<set $args[0].summary += "@@.green;Nympho!@@ ">>
+			<</if>>
+		<<elseif $args[0].energy > 80>>
+			<<set $args[0].summary += "@@.green;SD++">>
+		<<elseif $args[0].energy > 60>>
+			<<set $args[0].summary += "@@.green;SD+">>
+		<<elseif $args[0].energy > 40>>
+			<<set $args[0].summary += "@@.yellow;SD ">>
+		<<elseif $args[0].energy > 20>>
+			<<set $args[0].summary += "@@.red;SD-">>
+		<<else>>
+			<<set $args[0].summary += "@@.red;SD--">>
+		<</if>>
+		<<if _drive == 1>>
+			<<set $args[0].summary += "["+$args[0].energy+"]@@ ">>
+		<</if>>
 	<</if>>
 	<</if>>
 	<<if $args[0].clitPiercing == 3>>
@@ -2195,7 +2192,7 @@ will
 	<</if>>
 	<</if>>
 	<<if $args[0].attrKnown == 1>>
-		<<set _stats = $summaryStats, _comma = 1>>
+		<<set _stats = $summaryStats, _comma = 1, _drive = $summaryStats>>
 		<<if $args[0].attrXY <= 5>>
 			<<set $args[0].summary += "@@.red;Disgusted by men">>
 		<<elseif $args[0].attrXY <= 15>>
@@ -2209,11 +2206,11 @@ will
 		<<elseif $args[0].attrXY <= 95>>
 			<<set $args[0].summary += "@@.green;Aroused by men">>
 		<<elseif $args[0].attrXX > 95>>
+			<<set _stats = 0, _comma = 0>>
 			<<if $args[0].energy <= 95>>
-				<<set _stats = 0, _comma = 0>>
 				<<set $args[0].summary += "@@.green;Omnisexual!">>
 			<<else>>
-				<<set _stats = 0, _comma = 0>>
+				<<set _drive = 0>>
 				<<set $args[0].summary += "@@.green;Omnisexual nymphomaniac!">>
 			<</if>>
 		<<else>>
@@ -2228,7 +2225,6 @@ will
 			<<set $args[0].summary += "@@ ">>
 		<</if>>
 		
-		<<set _comma = 1>>
 		<<if $args[0].attrXX <= 5>>
 			<<set $args[0].summary += "@@.red;disgusted by women">>
 		<<elseif $args[0].attrXX <= 15>>
@@ -2253,10 +2249,10 @@ will
 			<<set $args[0].summary += ".@@ ">>
 		<</if>>
 		
-		<<set _stats = $summaryStats>>
+		<<set _comma = _drive>>
 		<<if $args[0].energy > 95>>
 			<<if ($args[0].attrXY <= 95) || ($args[0].attrXX <= 95)>>
-				<<set _stats = 0, _comma = 0>>
+				<<set _drive = 0, _comma = 0>>
 				<<set $args[0].summary += "@@.green;Nymphomaniac!">>
 			<</if>>
 		<<elseif $args[0].energy > 80>>
@@ -2270,13 +2266,11 @@ will
 		<<else>>
 			<<set $args[0].summary += "@@.red;No sex drive">>
 		<</if>>
-		<<if _stats == 1>>
+		<<if _drive == 1>>
 			<<set $args[0].summary += " ["+$args[0].energy+"]">>
 		<</if>>
 		<<if _comma == 1>>
 			<<set $args[0].summary += ".@@ ">>
-		<<else>>
-			<<set $args[0].summary += "@@ ">>
 		<</if>>
 	<</if>>
 	

--- a/src/utility/summaryWidgets.tw
+++ b/src/utility/summaryWidgets.tw
@@ -1861,6 +1861,7 @@ will
 		<<set $args[0].summary += "@@ ">>
 	<</if>>
 	
+	<<set _comma = 1>>
 	<<if $args[0].attrXX <= 5>>
 		<<set $args[0].summary += "@@.red;XX---">>
 	<<elseif $args[0].attrXX <= 15>>
@@ -1875,12 +1876,16 @@ will
 		<<set $args[0].summary += "@@.green;XX++">>
 	<<elseif $args[0].attrXY <= 95>>
 		<<set $args[0].summary += "@@.green;XX+++">>
-	<</if>>
-	<<if $summaryStats>>
-		<<set $args[0].summary += "["+$args[0].attrXX+"]@@ ">>
 	<<else>>
+		<<set _comma = 0>>
+	<</if>>
+	<<if _stats == 1>>
+		<<set $args[0].summary += "["+$args[0].attrXX+"]">>
+	<</if>>
+	<<if _comma == 1>>
 		<<set $args[0].summary += "@@ ">>
 	<</if>>
+	
 	<<set _stats = $summaryStats>>
 	<<if $args[0].energy > 95>>
 		<<set _stats = 0>>
@@ -1899,7 +1904,7 @@ will
 		<<set $args[0].summary += "@@.red;SD--">>
 	<</if>>
 	<<if _stats == 1>>
-		<<set $args[0].summary += "["+$args[0].attrXY+"]@@ ">>
+		<<set $args[0].summary += "["+$args[0].energy+"]@@ ">>
 	<<else>>
 		<<set $args[0].summary += "@@ ">>
 	<</if>>
@@ -2214,15 +2219,16 @@ will
 		<<else>>
 			<<set $args[0].summary += "@@.green;Passionate about men">>
 		<</if>>
-		<<if _stats>>
+		<<if _stats == 1>>
 			<<set $args[0].summary += " ["+$args[0].attrXY+"]">>
 		<</if>>
-		<<if _comma>>
+		<<if _comma == 1>>
 			<<set $args[0].summary += ",@@ ">>
 		<<else>>
 			<<set $args[0].summary += "@@ ">>
 		<</if>>
-		<<set _stats = $summaryStats, _comma = 1>>
+		
+		<<set _comma = 1>>
 		<<if $args[0].attrXX <= 5>>
 			<<set $args[0].summary += "@@.red;disgusted by women">>
 		<<elseif $args[0].attrXX <= 15>>
@@ -2237,13 +2243,17 @@ will
 			<<set $args[0].summary += "@@.green;aroused by women">>
 		<<elseif $args[0].attrXY <= 95>>
 			<<set $args[0].summary += "@@.green;passionate about women">>
-		<</if>>
-		<<if _stats>>
-			<<set $args[0].summary += " ["+$args[0].attrXX+"].@@ ">>
 		<<else>>
+			<<set _comma = 0>>
+		<</if>>
+		<<if _stats == 1>>
+			<<set $args[0].summary += " ["+$args[0].attrXX+"]">>
+		<</if>>
+		<<if _comma == 1>>
 			<<set $args[0].summary += ".@@ ">>
 		<</if>>
 		
+		<<set _stats = $summaryStats>>
 		<<if $args[0].energy > 95>>
 			<<if ($args[0].attrXY <= 95) || ($args[0].attrXX <= 95)>>
 				<<set _stats = 0, _comma = 0>>
@@ -2260,10 +2270,10 @@ will
 		<<else>>
 			<<set $args[0].summary += "@@.red;No sex drive">>
 		<</if>>
-		<<if _stats>>
+		<<if _stats == 1>>
 			<<set $args[0].summary += " ["+$args[0].energy+"]">>
 		<</if>>
-		<<if _comma>>
+		<<if _comma == 1>>
 			<<set $args[0].summary += ".@@ ">>
 		<<else>>
 			<<set $args[0].summary += "@@ ">>


### PR DESCRIPTION
Fixes errors related to the display of sexuality and sex drive in the summary.
Fixes some punctuation errors and extraneously displayed stats related to Nymphomaniacs.

Note:  It is possible for errors in the persistent summary to last through save & load.  Visiting the "Summary Options" (you don't have to change any settings) is the easiest way to force a refresh.