### PR TITLE
slaveSurname Tweak

### DIFF
--- a/src/uncategorized/randomNonindividualEvent.tw
+++ b/src/uncategorized/randomNonindividualEvent.tw
@@ -542,6 +542,7 @@
 		<<set $j = $slavesOriginal.findIndex(function(o) { return o.ID == $recruiterSlave.ID; })>>
 		<<if $j != -1>>
 			<<set $events.push("RE relative recruiter")>>
+			<<break>>
 		<<else>> /* no matching slave object in the slavesOriginal array -- bug? */
 			<<set $i = $slaves.findIndex(function(o) { return o.ID == $recruiterSlave.ID; })>>
 			<<set $slaves[$i].recruiter = 0>>

--- a/src/uncategorized/randomNonindividualEvent.tw
+++ b/src/uncategorized/randomNonindividualEvent.tw
@@ -542,7 +542,6 @@
 		<<set $j = $slavesOriginal.findIndex(function(o) { return o.ID == $recruiterSlave.ID; })>>
 		<<if $j != -1>>
 			<<set $events.push("RE relative recruiter")>>
-			<<break>>
 		<<else>> /* no matching slave object in the slavesOriginal array -- bug? */
 			<<set $i = $slaves.findIndex(function(o) { return o.ID == $recruiterSlave.ID; })>>
 			<<set $slaves[$i].recruiter = 0>>

--- a/src/uncategorized/slaveGenerationWidgets.tw
+++ b/src/uncategorized/slaveGenerationWidgets.tw
@@ -381,7 +381,7 @@
 	<<set $args[0].birthName = setup.whiteAmericanSlaveNames.random(), $args[0].birthSurname = setup.whiteAmericanSlaveSurnames.random()>>
 <</switch>>
 
-<<set $args[0].slaveName = $args[0].birthName, $args[0].slaveSurname = $args[0].birthSurname>>>
+<<set $args[0].slaveName = $args[0].birthName, $args[0].slaveSurname = $args[0].birthSurname>>
 <<if $useFSNames == 1>>
 <<if $arcologies[0].FSRomanRevivalist > 20>>
 	<<set $args[0].slaveName = setup.romanSlaveNames.random(), $args[0].slaveSurname = setup.romanSlaveSurnames.random()>>

--- a/src/uncategorized/slaveGenerationWidgets.tw
+++ b/src/uncategorized/slaveGenerationWidgets.tw
@@ -381,7 +381,7 @@
 	<<set $args[0].birthName = setup.whiteAmericanSlaveNames.random(), $args[0].birthSurname = setup.whiteAmericanSlaveSurnames.random()>>
 <</switch>>
 
-<<set $args[0].slaveName = $args[0].birthName>>
+<<set $args[0].slaveName = $args[0].birthName, $args[0].slaveSurname = $args[0].birthSurname>>>
 <<if $useFSNames == 1>>
 <<if $arcologies[0].FSRomanRevivalist > 20>>
 	<<set $args[0].slaveName = setup.romanSlaveNames.random(), $args[0].slaveSurname = setup.romanSlaveSurnames.random()>>
@@ -394,8 +394,6 @@
 <<elseif $arcologies[0].FSDegradationist != "unset">>
 	<<DegradingName $args[0]>>
 <</if>>
-<<else>>
-	<<set $args[0].slaveName = $args[0].birthName, $args[0].slaveSurname = $args[0].birthSurname>>
 <</if>>
 
 <</widget>>


### PR DESCRIPTION
Another tweak to another commit I made a little while back.

I feel I may have misunderstood the original intent of how slaveSurname was supposed to be assigned. This tweak will make it so the default setting is for slaves to have a surname regardless of whether $useFSNames is toggled to 0 or 1. If it was intended for the default to be that slaves automatically get no slaveSurname, or if was supposed to depend on $useFSNames for some reason, I can make another small tweak before this gets merged.

Perhaps we should make an independent setting for whether or not slaves get stripped of their surname upon enslavement? Edit: Or perhaps a policy?