### PR TITLE
Better Bovine Tat descriptions, removed special/universal bovine tat …

### DIFF
--- a/src/uncategorized/bodyModification.tw
+++ b/src/uncategorized/bodyModification.tw
@@ -1289,7 +1289,8 @@ Choose a tattoo style:
 
 Branding: 
 <<if $activeSlave.brand != 0>>
-	$pronounCap has $activeSlave.brand branded into the flesh of $possessive $activeSlave.brandLocation. [[Remove Brand|Body Modification][$brandApplied = 0, $activeSlave.brand = 0,$cash -= $modCost,$degradation -= 10]]
+	<<brandDescription>>
+	[[Remove Brand|Body Modification][$brandApplied = 0, $activeSlave.brand = 0,$cash -= $modCost,$degradation -= 10]]
 <<else>>
 	Her skin is unmarked.
 <</if>>

--- a/src/uncategorized/bodyModification.tw
+++ b/src/uncategorized/bodyModification.tw
@@ -1224,7 +1224,6 @@ Choose a tattoo style:
 <</if>>
 
 <<if $tattooChoice == 0>>
-	<<if $activeSlave.shouldersTat != "bovine patterns">>
 		<<if $activeSlave.shouldersTat != $tattooChoice>> | [[Shoulders|Body Modification][$activeSlave.shouldersTat = $tattooChoice,$cash -= $modCost]]<</if>>
 		<<if $activeSlave.lipsTat != $tattooChoice>> | [[Face|Body Modification][$activeSlave.lipsTat = $tattooChoice,$cash -= $modCost]]<</if>>
 		<<if $activeSlave.boobsTat != $tattooChoice>> | [[Boobs|Body Modification][$activeSlave.boobsTat = $tattooChoice,$cash -= $modCost]]<</if>>
@@ -1242,12 +1241,10 @@ Choose a tattoo style:
 		<<if $activeSlave.amp == 0>>
 			<<if $activeSlave.legsTat != $tattooChoice>> | [[Legs|Body Modification][$activeSlave.legsTat = $tattooChoice,$cash -= $modCost]]<</if>>
 		<</if>>
-	<</if>>
 <<elseif $tattooChoice == "permanent makeup">>
 	[[Face|Body Modification][$activeSlave.lipsTat = $tattooChoice,$cash -= $modCost]]
 <<elseif $tattooChoice == "bleached">>
 	[[Asshole|Body Modification][$activeSlave.anusTat = $tattooChoice,$cash -= $modCost]]
-<<elseif $tattooChoice == "bovine patterns">>
 <<else>>
 	<<if $activeSlave.shouldersTat != $tattooChoice>> | [[Shoulders|Body Modification][$activeSlave.shouldersTat = $tattooChoice,$cash -= $modCost]]<</if>>
 	<<if $activeSlave.lipsTat != $tattooChoice>> | [[Face|Body Modification][$activeSlave.lipsTat = $tattooChoice,$cash -= $modCost]]<</if>>

--- a/src/uncategorized/longSlaveDescription.tw
+++ b/src/uncategorized/longSlaveDescription.tw
@@ -1725,13 +1725,9 @@ $pronounCap is
 <<if $activeSlave.fuckdoll == 0>>
 <<nailsDescription>>
 <<if $showBodyMods == 1>>
-	<<if ($activeSlave.armsTat == "bovine patterns") && ($activeSlave.legsTat == "bovine patterns") && ($activeSlave.shouldersTat == "bovine patterns") && ($activeSlave.backTat == "bovine patterns")>>
-		<<bovineTatDescription>>
-	<<else>>
-		<<backTatDescription>>
-		<<shouldersTatDescription>>
-		<<armsTatDescription>>
-	<</if>>
+	<<backTatDescription>>
+	<<shouldersTatDescription>>
+	<<armsTatDescription>>
 <</if>>
 <</if>>
 

--- a/src/uncategorized/longSlaveDescription.tw
+++ b/src/uncategorized/longSlaveDescription.tw
@@ -1106,7 +1106,7 @@ when a dick is pushed inside <<if $activeSlave.vagina >= -1>>either of its lower
 <<if $showBodyMods == 1>>
   <<if ($activeSlave.brand != 0)>>
 	<<if ($activeSlave.brandLocation == "neck") || ($activeSlave.brandLocation == "left cheek") || ($activeSlave.brandLocation == "right cheek") || ($activeSlave.brandLocation == "cheeks") || ($activeSlave.brandLocation == "left ears") || ($activeSlave.brandLocation == "right ears") || ($activeSlave.brandLocation == "ears")>>
-	  She has $activeSlave.brand branded into the flesh of her $activeSlave.brandLocation.
+	  <<brandDescription>>
 	<</if>>
   <</if>>
 <</if>>
@@ -1524,7 +1524,7 @@ $pronounCap is
 <<if $showBodyMods == 1>>
   <<if ($activeSlave.brand != 0)>>
 	<<if ($activeSlave.brandLocation == "back") || ($activeSlave.brandLocation == "chest") || ($activeSlave.brandLocation == "right shoulder") || ($activeSlave.brandLocation == "left shoulder") || ($activeSlave.brandLocation == "shoulders") || ($activeSlave.brandLocation == "right upper arm") || ($activeSlave.brandLocation == "left upper arm") || ($activeSlave.brandLocation == "upper arms") || ($activeSlave.brandLocation == "right lower arm") || ($activeSlave.brandLocation == "left lower arm") || ($activeSlave.brandLocation == "lower arms") || ($activeSlave.brandLocation == "right wrist") || ($activeSlave.brandLocation == "left wrist") || ($activeSlave.brandLocation == "wrists") || ($activeSlave.brandLocation == "right hand") || ($activeSlave.brandLocation == "left hand") || ($activeSlave.brandLocation == "hands") || ($activeSlave.brandLocation == "left ankle") || ($activeSlave.brandLocation == "right ankle") || ($activeSlave.brandLocation == "ankles") || ($activeSlave.brandLocation == "right calf") || ($activeSlave.brandLocation == "left calf") || ($activeSlave.brandLocation == "calves") || ($activeSlave.brandLocation == "right foot") || ($activeSlave.brandLocation == "left foot") || ($activeSlave.brandLocation == "feet")>>
-	  She has $activeSlave.brand branded into the flesh of her $activeSlave.brandLocation.
+	  <<brandDescription>>
 	<</if>>
   <</if>>
 <</if>>

--- a/src/utility/descriptionWidgets.tw
+++ b/src/utility/descriptionWidgets.tw
@@ -214,3 +214,16 @@
 
 <</widget>>
 
+<<widget "brandDescription">>
+
+<<if ($activeSlave.brand != 0)>>
+	<<set $bellyAccessory = $activeSlave.bellyAccessory>>
+	<<if setup.fakeBellies.includes($bellyAccessory) && ($activeSlave.brandLocation == "belly")>>
+		$possessiveCap fake belly has $activeSlave.brand branded on it.
+	<<else>>
+		$pronounCap has $activeSlave.brand branded into the flesh of $possessive $activeSlave.brandLocation.
+	<</if>>
+<</if>>
+
+<</widget>>
+	

--- a/src/utility/descriptionWidgetsFlesh.tw
+++ b/src/utility/descriptionWidgetsFlesh.tw
@@ -967,11 +967,10 @@ $possessiveCap
 
 <<nipplesPiercingDescription>>
 <<boobsTatDescription>>
-<<if $activeSlave.fuckdoll != 0>>
+<<if $activeSlave.fuckdoll == 0>>
 	<<if ($activeSlave.brand != 0) && (($activeSlave.brandLocation == "left breast") || ($activeSlave.brandLocation == "right breast") || ($activeSlave.brandLocation == "breasts"))>>
-		$pronounCap has $activeSlave.brand branded into the flesh of one of $possessive $activeSlave.brandLocation.
-	<</if>>
-	
+		<<brandDescription>>
+	<</if>>	
 <</if>>
 <</if>>
 
@@ -2638,7 +2637,7 @@ $pronounCap's got a
 <<if $showBodyMods == 1>>
 	<<if ($activeSlave.brand != 0)>>
 	<<if ($activeSlave.brandLocation == "pubic mound")>>
-		$pronounCap has $activeSlave.brand branded into the flesh of $possessive $activeSlave.brandLocation.
+		<<brandDescription>>
 	<</if>>
 	<</if>>
 <</if>>
@@ -4024,18 +4023,9 @@ $pronounCap has
 		<<case "a small empathy belly">>
 			$pronounCap is wearing a carefully sculpted silicone belly modeled after a pregnant woman in $possessive first trimester.
 		<</switch>>
-		<<if $showBodyMods == 1>>
+		<<if ($showBodyMods == 1) && ($activeSlave.brandLocation == "belly")>>
 			<<navelPiercingDescription>>
-			<<if ($activeSlave.brand != 0) && ($activeSlave.brandLocation == "belly")>>
-				$possessiveCap fake belly has $activeSlave.brand branded on it.
-			<</if>>
-		<</if>>
-	<<else>>
-		<<if $showBodyMods == 1>>
-			<<navelPiercingDescription>>
-			<<if ($activeSlave.brand != 0) && ($activeSlave.brandLocation == "belly")>>
-				$pronounCap has $activeSlave.brand branded into the flesh of $possessive $activeSlave.brandLocation.
-			<</if>>
+			<<brandDescription>>
 		<</if>>
 	<</if>>
 <<elseif $showBodyMods == 1>>

--- a/src/utility/descriptionWidgetsTattoos.tw
+++ b/src/utility/descriptionWidgetsTattoos.tw
@@ -24,7 +24,7 @@
   <<elseif $activeSlave.shouldersTat == "counting">>
 	¤ tattoo counting her earnings and acquirements cover her shoulders.
   <<elseif $activeSlave.shouldersTat == "bovine patterns">>
-	Bovine tattoos cover her shoulders.
+	Her shoulders are flecked with tattoos of bovine blotches.
   <<elseif $activeSlave.shouldersTat == "possessive">>
 	A rendition of your face inside a heart is tattooed onto her left shoulder, and the words 'I love my <<if $PC.title == 1>>Master<<else>>Mistress<</if>>' inside an identical heart are tattooed on her right.
   <<elseif $activeSlave.shouldersTat == "sacrament">>
@@ -191,7 +191,7 @@
 		  Tiny dick, pussy, and anus symbols are tattooed all over both her arms, one for each organ she's manually pleasured.
 		<</if>>
 	<<elseif $activeSlave.armsTat == "bovine patterns">>
-		Cow-like spots go down her arms, but stop short of each of her elbows.
+		Tattoos of cow-like spots cover her arms, but stop short of each of her elbows.
 	<</if>>
   <</if>>
 <</widget>>
@@ -262,7 +262,7 @@
 			here: $seed of them.
 		<</if>>
 	<<elseif $activeSlave.shouldersTat == "bovine patterns">>
-		$possessiveCap back is covered in a large saddle-like blotch.
+		$possessiveCap back is tattooed to resemble the dappled flank of a cow.
 <</if>>
 <</widget>>
 
@@ -306,7 +306,7 @@
 		<<case "paternalist">>
 			$pronounCap has a tramp stamp which reads 'Fuck me slowly' with an arrow pointing downward.
 		<<case "bovine patterns">>
-			Spots run right down to where her tail would be.
+			$pronounCap has an identifying barcode tattooed across $possessive lower back.
 	<</switch>>
 	<</if>>
 	<</if>>
@@ -556,12 +556,6 @@
 	<<case "paternalist">>
 		$possessiveCap left thigh reads 'I Love My Life,' and the right 'It's All I'm Good For.'
 	<<case "bovine patterns">>
-		$possessiveCap legs are completely colored to look like a cow, from her hips to the tops of her feet.
+		$possessiveCap legs are covered in tattoos of spots, giving $possessive a noticeably bovine appearance.
 	<</switch>>
-<</widget>>
-
-
-/* Special tats */
-<<widget "bovineTatDescription">> /* For fully bovinated.  Not used for the more technical bodyMod, but useful for longSlaveDescriptions */
-	Bovine tattoos cover her back and shoulders, and go down her arms, but stop short of each of her elbows.  Her legs, too, have splotches that reach down to her ankles.
 <</widget>>

--- a/src/utility/descriptionWidgetsTattoos.tw
+++ b/src/utility/descriptionWidgetsTattoos.tw
@@ -369,7 +369,7 @@
 		'Treat it' is tattooed across $possessive left buttock; 'Gently' is tattooed across $possessive right.
 	<</switch>>
 	<<if ($activeSlave.brand != 0) && (($activeSlave.brandLocation == "left buttock") || ($activeSlave.brandLocation == "right buttock") || ($activeSlave.brandLocation == "buttocks") || ($activeSlave.brandLocation == "left thigh") || ($activeSlave.brandLocation == "right thigh") || ($activeSlave.brandLocation == "thighs"))>>
-		$pronounCap has $activeSlave.brand branded into the flesh of $possessive $activeSlave.brandLocation.
+		<<brandDescription>>
 	<</if>>
 <</widget>>
 


### PR DESCRIPTION
…descriptions (edit: and now Create brandDescription widget, bug fix)

Bovine tats now have enough descriptions to stand on their own, and no longer need weird kludges.  In particular under the older code, a slave with a "shoulder" bovine tat would have her arms and back described with bovine tats, as well as whatever tats they actually had. Unfortunately, slaves could look like they had "two" tats on their arm this way.  I recently tried a few fixes, but thanks to the creative descriptions of @freecitiesbandit in #892, this is no longer needed.  This branch replaces #892 completely.

This commit also allows bovine tats to be applied piecemeal just like other tats and still be described accurately, so I partically reversed my commit in #883.

TL;DR Bovine tats are now as boring as tribal tats.