### PR TITLE
Convert wiki fully to nobr, many other tweaks

### DIFF
--- a/src/gui/Encyclopedia/encyclopedia.tw
+++ b/src/gui/Encyclopedia/encyclopedia.tw
@@ -1,42 +1,49 @@
-:: Encyclopedia
+:: Encyclopedia [nobr]
 
-<<switch $encyclopedia>>\
+<<switch $encyclopedia>>
 /**********
 
 PLAYING FREE CITIES
 
 **********/
-<<case "Playing Free Cities">>\
+
+
+<<case "Playing Free Cities">>
 Welcome to the Free Cities, Master!
-
+<br><br>
 //Future room for lore text//
-
+<br><br>
 Choose a more particular entry below:
-\
-<<case "First Game Guide">>\
-Unfortunately, Twine doesn't have a solid tooltip system at the moment. So, a certain amount of confusion is to be expected. Sorry about that. Flip through the encyclopedia, or at least this gameplay section. It answers a lot of frequently asked questions, and if you read it you can save yourself the trouble of asking your frequently asked question on /d/ or the blog and getting told to read the encyclopedia. If you've still got questions, start a game and read what it says. The game is reasonably good about telling you what's happening to your slaves, and why. It bears repetition that almost all stat effects are called out with colored text. Try this opening strategy if you don't know where to start. It isn't an optimal build, but it works reliably and will show you the basics.
 
+
+
+
+<<case "First Game Guide">>
+Unfortunately, Twine doesn't have a solid tooltip system at the moment. So, a certain amount of confusion is to be expected. Sorry about that. Flip through the encyclopedia, or at least this gameplay section. It answers a lot of frequently asked questions, and if you read it you can save yourself the trouble of asking your frequently asked question on /d/ or the blog and getting told to read the encyclopedia. If you've still got questions, start a game and read what it says. The game is reasonably good about telling you what's happening to your slaves, and why. It bears repetition that almost all stat effects are called out with colored text. Try this opening strategy if you don't know where to start. It isn't an optimal build, but it works reliably and will show you the basics.
+<br><br>
 __Starting options__
 Start the game and select any of the world options; choose normal difficulty, since it's pretty forgiving and this opener will make good money. Build a completely male PC for your first game; it makes reputation maintenance much easier. Choose wealth for both your career and your rumored method of obtaining the arcology; the other options are fun but a full wealth build will set you up quickly to get started. Now, customize your starting slaves. For your first, make her as intelligent, educated, and old as possible. Make her Devoted, but save money by giving her flaws, an unknown fetish, and making her afraid of you. (These are easy to fix.) You can customize the rest of her as you wish, but try to keep her under ¤5000. Don't worry about skills, since with two of them you'll be able to rotate head girl duty so the other can learn skills. Commit her, base another slave off her, and commit that one too. Those are your head girls. Spend the rest of your money on prospects: slaves that are cheap now, but can be improved quickly. As long as you keep Devotion pretty high, low Trust can be fixed reliably. Unknown fetishes, emaciated or fat, flaws, deep voice, and poor skills are all good ways to drive prices down, and can all be fixed quickly. Virginities are a bad idea because they drive costs up and are easy to break. Education can take a while and will take slaves away from other jobs, so make them all educated for now, and keep their intelligence reasonably high.
-
+<br><br>
 __First turn__
 Assign one of your head girls to be Head Girl and make the other whore. Assign everyone else to whore. The rules assistant will speed things up a lot when you know the basics, but leave it off for now; it's easy to miss a lot of stuff if you set it up without a bit of experience. Go through your girls one by one and experiment with their options, but anyone who's @@.hotpink;Accepting@@ or better should get nice clothes, accessories, and living conditions; anyone who's not should not. When slaves tip over into @@.hotpink;Accepting,@@ switch them over from bedrolls and uncomfortable straps; until then, the good life is a waste of money and will spoil them. Give unhealthy slaves curatives, and give everyone hormones, since they're cheap and have good front end benefits. Get everyone working out or dieting to reach a basic fitness level and an attractive (not @@.red;red@@) weight. Sell the girl(s) your predecessor left behind for seed money, and choose the most profitable option; there are ways to maximize this, but worry about that later. Check out the arcology management menu. You should have the money to upgrade the security systems, build the head girl suite, and to buy the kitchen upgrade; this will make dieting work faster. Check out the slave market, and buy a single bargain slave: ¤2000 is good. Put her in the head girl suite: if she won't go, abuse her until she will. Open the personal attention menu, and fix your head girl's flaws; softening is powerful but it takes longer and we're focusing on the basics. ''Save the game'' and end the turn.
-
+<br><br>
 __The end turn report__
 Read this, and note all the colored text. Pay particular attention to @@.red;red,@@ @@.gold;gold,@@ or @@.mediumorchid;orchid@@ text; these are generally bad. Being a slave whore is a hard life, and some trouble is inevitable. But take particular note of things like slaves losing health, becoming fearful, or hating you due to their rules, living conditions, or other slaves - these things you can control. Reload your save and fiddle around with the options to address these areas. (The head girl's girl may have a rough time; you can't affect that.) Since your head girl has her own slave to help her around the house, she'll work with two of your slaves.
-
+<br><br>
 __Economics and events__
 The economics report offers some flavor, but you should leave the options it offers alone until you've got some spare cash. An event or two will follow; feel free to reload the page on each (F5 on most browsers) to see what the different options do. Generally, try to pick options that give you money and improve devotion. Trust and reputation can wait.
-
+<br><br>
 __Moving forward__
 Hopefully, many of your slaves learned skills during their week of whoring. Three levels of skill (@@.cyan;Veteran Whore@@ or @@.cyan;W+++@@ for example) is the maximum, though slaves without vaginas will only acquire two complete levels of sexual skills. As you move through the first ten weeks or so, many of your slaves will max out their whoring and sexual skills. When they do, switch them over to public service until they achieve maximum entertainment skill, and then put them back on whoring, since cross training will improve their whoring performance. When your head girl alternate has maxed skills, make her the head girl and train up the MILF she replaced. Switch your personal attention around; for now, fix the Quirks of the most devoted slave who has any, since that's the best way to maximize your chances of success each turn. Pay attention to your cash flow. If it's positive and you have a decent buffer of ¤10000 or so built up, wait for the slave market prices to naturally dip, and then purchase a girl or two to work on once your starting stable is well trained, though you may have to confine or rest new purchases for a while if they're rebellious or sick. If you get a virgin, consider applying chastity to preserve value for resale. When prices are high, consider selling anyone who's free of flaws and has a discovered sexual fetish, since this maximizes value bonuses. Within ten turns, you should be making decent weekly profit, with resale of slaves building up your bank when prices favor sale. Once you're confident of the whoring mechanics, consider building a brothel. Your alternate head girl will make a good madam.
-<<case "How to Play">>\
+
+
+<<case "How to Play">>
 This is not a game in which the PC slaveowner is some magical sexual god whose mere presence turns women into submissives. This means that sane slaves will tend to lose obedience and trust over time if you don't take any steps to maintain their mental state. Mental stats have maximum and minimum values. These are somewhat 'sticky,' so slaves at minimum devotion for example may require an extra jolt to break free of this state. Maximized devotion and trust are not useless; if one of these stats is maximized and the other is not, the extra devotion or trust will boost the other. If both are maximized, the player gains reputation instead.
-
+<br><br>
 A slave's health is extremely important. Being healthy generally improves beauty and job performance. Most transformative drugs and surgeries can damage health, while curative drugs and rest will restore it. Extremely unhealthy slaves can die, while extremely healthy slaves enjoy considerable bonuses on many assignments. Health damage is generally scaled to a slave's current health, so if a slave is already unhealthy, injuries will hurt her more severely. Pulling a slave with red health indicators off work for a week of rest is generally advisable.
-
+<br><br>
 The first button in the left-side UI bar will always continue the game without taking any actions. If you wish to advance the game rapidly, click that button repeatedly. If you are presented with a menu and do not wish to select any of the options, that button will also serve as a none of the above choice. ''The spacebar will also advance the game.''
-
+<br><br>
 The author has played several otherwise good H-Games in which it can be hard to parse exactly what the flavor descriptions mean in terms of stats. Therefore, this game will usually flag stat impacts in descriptions by means of colored text. For example:
 @@.green;Green text@@ means something good, like a healthy slave.
 @@.red;Red text@@ means something bad, like a sick slave.
@@ -50,178 +57,224 @@ The author has played several otherwise good H-Games in which it can be hard to 
 @@.yellowgreen;Yellow-green text@@ indicates a money-related event.
 @@.coral;Coral text@@ is used for simple identifiers that can be used to check a slave's general type at a glance.
 __It is important to note__ that if a scene doesn't have colored text, it doesn't impact a slave's stats. For example, the short sex scenes available from the main screen are for the most part unlimited and have no real gameplay effect: they are for fun and flavor only.
-
+<br><br>
 This game produces less visible text than a lot of text-based H-Games; this is because most text has numerous variations that change based on a slave's body, mental state etc. The author has deliberately made some of the variations available only with extreme stats so that new content will still be out there even if you play for a while.
-
+<br><br>
 Things that increase income from prostitution, reputation gain from slutting, and performance in most jobs include all appearance stats (that's right, every one; though some are more or less important), sexual skills, a slave's health, and the state of a slave's holes. Going from a novice to a veteran whore will have non-linear impacts on income, since a novice will get good money for being fresh and little money for her skills, and a veteran will get the reverse. The fetishes and physical statuses that get pink text on the main menu (huge tits, bisexual, etc.) give bonuses.
-
+<br><br>
 The game is not intended to be crushingly difficult, but it is balanced so that in order to achieve some of the best event outcomes, and eventually in order to survive, the player must build a business empire that turns a significant profit. Profits are necessary because the player will want to be able to make some major expenditures in the late game. Buy low, sell high, and always try to improve your slaves. Even something as simple as a few weeks' personal attention to fix mental flaws and boost devotion can produce significant profits when a slave is resold.
-<<case "Keyboard Shortcuts">>\
+
+
+<<case "Keyboard Shortcuts">>
 The game supports a few keyboard shortcuts.
-
+<br><br>
 ''Enter'' or ''space'' will activate the uppermost button in the left-side UI bar. This button is context sensitive; in events and reports it continues the game, while in menus it functions as a back button. ''Enter'' is used to end the week from the main menu, and ''space'' is used to continue in all other situations.
-
+<br><br>
 ''Right arrow'', ''left arrow'' and ''q'', ''e'' will move between slaves in slaves' individual menus.
-
+<br><br>
 On the main menus, ''C'' will open arcology management, ''S'' will open the slave markets, ''A'' will open personal attention options, ''H'' will open Head Girl management, ''B'' will open Bodyguard management, ''R'' will open Recruiter management, and ''F'' will initiate the short sex scene at the bottom of the main menu.
-<<case "The Arcology Interface">>\
+
+
+<<case "The Arcology Interface">>
 The Arcology Interface is the large table-based display at the top of the main menu. It's designed as an abstract representation of the arcology.
-
+<br><br>
 It is divided into levels and sectors. Levels are the horizontal rows. An arcology is a very large building, and each Level includes many floors. Sectors are slices of those levels. For example, on Levels with four Sectors, each sector includes a quarter of each floor that's part of that Level. Each Sector has its own cell in the interface, and each Sector is occupied by facilities, tenants, or both. Each type of Sector occupant is bordered in a different color. The contents of a Sector can be viewed and changed by clicking on the text inside a Sector.
-
+<br><br>
 The uppermost level is the Penthouse. It's where the player character and the slaves under their direct supervision live, and it can be upgraded with a number of facilities that can be accessed through shortcuts that are added to the Penthouse in the interface once they're installed. Some of these facilities can house some of the player character's sex slaves. Unlike every other Sector, the Penthouse is always owned by the player and cannot be sold. Every other Sector can be privately owned, reducing the player's control of the arcology. Privately owned Sectors can be purchased, or acquired using reputation if the player character's reputation is extremely high. Privately owned sectors are bordered in red regardless of what's in them.
-
+<br><br>
 The next level down, with three Sectors, is the Promenade, which is a major social area and hosts most of the businesses which cater to the arcology's citizens. Promenade Sectors are occupied by Shops by default, which will automatically be filled by business tenants that will pay the player character rent if they own the Sector. Promenade Sectors can be upgraded into [[brothels|Encyclopedia][$encyclopedia = "Brothel"]], [[clubs|Encyclopedia][$encyclopedia = "Club"]], or an enhanced version of shops which will attract business tenants that help advance a specific [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] model, and still provide rent.
-
+<br><br>
 The next three levels have four sectors and are living areas that are occupied by apartments by default. These house arcology citizens, who pay rent, and who are indirectly very important because they determine the level of local demand for sexual services provided by whores, public servants, and other sex slaves doing sexual jobs. Apartments can be upgraded for either density or luxury. Dense Apartments increase the citizen population, and are therefore useful to keep demand up if the player is relying on selling or giving away sexual services. Luxury apartments increase the arcology's prosperity, and are therefore a better choice if demand for sexual services isn't a priority.
-
+<br><br>
 The first level with five Sectors is the Concourse. Like the Promenade, it hosts businesses, but these focus more on bulk trade and less on citizens' luxury needs, and include the arcology's slave markets. Its sectors are occupied by Markets by default, which pay rent. Concourse sectors can be upgraded into a [[pit|Encyclopedia][$encyclopedia = "Pit"]] for fighting slaves, an [[arcade|Encyclopedia][$encyclopedia = "Arcade"]], or into a flagship store for the player character's [[corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-
+<br><br>
 The lowest level, also with five Sectors, is the Service level. Its Sectors are occupied by Manufacturing by default, which of course pay rent. If the player is focusing on menial slaves, its Sectors can be upgraded into pens, to increase the total number of [[menial slaves|Encyclopedia][$encyclopedia = "Menial Slaves"]] that can be kept in the arcology, or into Sweatshops, to put the labor of menial slaves in the arcology to use. Alternatively, these Sectors can be upgraded into a [[dairy|Encyclopedia][$encyclopedia = "Dairy"]], or into a barracks, which will reduce the weekly upkeep of any mercenaries the player character has hired.
-<<case "Tips and Tricks">>\
+
+
+<<case "Tips and Tricks">>
 Buy low, sell high.
-
+<br><br>
 Slaves will sometimes default to the resting assignment after they're done with something else. If a slave is resting and the game suspects that she shouldn't be, her assignment will be ''__@@.lime;lime@@__'', bold, and underlined on the main menu to indicate that.
-
+<br><br>
 If a new slave isn't afraid of you, make her. Then and only then build her devotion.
-
+<br><br>
 The personal attention assignment should be used tactically. It is the most powerful single way of improving slaves because it's reliable. Devotion and Trust gains during a single week are normally capped. However, personal attention removes these caps. This is most powerful for slaves that are already well broken and are enjoying fairly luxurious lives. With so many things driving up Devotion and Trust, using personal attention to remove the caps can quickly maximize both stats. Focusing on business instead (by selecting no slave for personal attention) is also powerful. Doing so produces money proportional to the amount of money on hand, //and// improves prosperity growth, which improves future income from rents.
 /**********
 
 Design Your Master
 
 **********/
-<<case "PC Customization">>\
+
+
+<<case "PC Customization">>
 ''Player Character Customization'' happens at the start of a game of FC: it is not possible to change the PC during the main game. The player must select a career background, a rumored method of acquiring the arcology, and their age group; and choose between some broad body and gender options.
-\
-<<case "PC Age">>\
+
+
+
+<<case "PC Age">>
 ''Player Character Age'' is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] option. Older PCs enjoy easier reputation maintenance, but possess lower sexual energy.
-\
-<<case "PC Body">>\
+
+
+
+<<case "PC Body">>
 ''Player Character Body'' is a set of [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] options. All PC body changes will alter scenes, but their main mechanical effect is on reputation maintenance. Feminine options will make it harder to maintain reputation without providing any gameplay advantage, making playing as a feminine PC a form of increased difficulty. There are other minor gameplay differences including differing slave reactions to the PC based on attraction, but these are fairly minor.
-\
-<<case "Wealth">>\
+
+
+
+<<case "Wealth">>
 ''Wealth'' is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] choice for both the career background and rumored method of acquiring the arcology options. In both cases, it provides extra funds at game start, but no ongoing advantages once the main game begins.
-\
+
 /**********
 
 Design Your Master (Backgrounds)
 
 **********/
-<<case "Business">>\
+
+
+<<case "Business">>
 ''Business'' is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] choice for the career background option. It enhances the business-focused personal attention, increasing the money it produces and improving arcology prosperity when business-focused personal attention is selected.
-\
-<<case "Celebrity">>\
+
+
+
+<<case "Celebrity">>
 ''Celebrity'' is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] choice for the career background option. It provides extra reputation at game start, but no ongoing advantages once the main game begins, just like the [[Luck|Encyclopedia][$encyclopedia = "Luck"]] choice for the rumored method of acquiring the arcology option.
-\
-<<case "Engineering">>\
+
+
+
+<<case "Engineering">>
 ''Engineering'' is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] choice for the career background option. It provides a significant discount on many arcology upgrades and expansions.
-\
-<<case "Force">>\
+
+
+
+<<case "Force">>
 ''Force'' is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] choice for the rumored method of acquiring the arcology option. If a slave does not have enough [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] to obey when acquired, this option will terrify her, reducing [[trust|Encyclopedia][$encyclopedia = "Trust"]] to the point where she should comply.
-\
-<<case "Hard Work">>\
+
+
+
+<<case "Hard Work">>
 ''Hard Work'' is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] choice for the rumored method of acquiring the arcology option. It provides a one-time bonus to both [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] and [[trust|Encyclopedia][$encyclopedia = "Trust"]] when a new slave is acquired.
-\
-<<case "Luck">>\
+
+
+
+<<case "Luck">>
 ''Luck'' is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] choice for the rumored method of acquiring the arcology option. It provides extra reputation at game start, but no ongoing advantages once the main game begins, just like the [[Celebrity|Encyclopedia][$encyclopedia = "Celebrity"]] choice for the career background option.
-\
-<<case "Medicine">>\
+
+
+
+<<case "Medicine">>
 ''Medicine'' is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] choice for the career background option. It allows the player character to perform surgery personally, providing a discount on surgery costs and a reduction to health damage from surgery. Additionally, slaves may react differently to surgery if the player character performs it.
-\
-<<case "PMC Work">>\
+
+
+
+<<case "PMC Work">>
 ''PMC Work'' (also referred to as a //mercenary background//) is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] choice for the career background option. It greatly reduces the cost of keeping mercenaries in your employ.
-\
-<<case "Slaving">>\
+
+
+
+<<case "Slaving">>
 ''Slaving'' is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] choice for the career background option. It enhances slave-focused personal attention, adding bonus [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] or [[trust|Encyclopedia][$encyclopedia = "Trust"]] to many training applications or preventing their loss.
-\
-<<case "Social Engineering">>\
+
+
+
+<<case "Social Engineering">>
 ''Social Engineering'' is a [[Player Character Customization|Encyclopedia][$encyclopedia = "PC Customization"]] choice for the rumored method of acquiring the arcology option. It unlocks the first [[Future Society|Encyclopedia][$encyclopedia = "Future Societies"]] selection immediately. It does not add an additional future society model choice; the cap is still four.
-\
+
 /**********
 
 BEING IN CHARGE
 
 **********/
-<<case "Being in charge">>\
+
+
+<<case "Being in charge">>
 //Future room for lore text//
-
+<br><br>
 Choose a more particular entry below:
-\
-<<case "Arcologies and Reputation">>\
+
+
+
+<<case "Arcologies and Reputation">>
 Arcologies are the urban buildings of the future: almost completely self-contained, almost completely self sufficient. In the anarcho-liberal 'paradise' of the Free Cities, as owner of your own arcology you are like a modern-day feudal suzerain, lord and master.
-
+<br><br>
 Your arcology is a flared structure, needle thin at the top where you live in your penthouse, and broad at the base. The base below ground contains storage and machinery. The lowest aboveground levels are commercial; above them are the residential areas. The entire structure is jacketed in dense gardens and solar arrays, cleverly structured to create naturally lit corridors and beautiful parklike balconies.
-
+<br><br>
 -- Owner's Report
-
+<br><br>
 //You may wish to improve your arcology, but should be able to ignore its development, if you wish.//
-
+<br><br>
 //Your reputation is, of course, already quite impressive. The reputation tracked in the sidebar is specifically your reputation as a slaveowner. It can be raised through decadent actions that display your munificence and opulence. Some random events can increase it, but the most reliable way to improve your reputation is to send sexually skilled slaves out into the arcology to offer free sexual services. This assignment is very similar to prostitution, but produces reputation rather than money.//
-
+<br><br>
 //As your reputation develops, you may have the opportunity to guide the future of your arcology's society. Successfully doing so will increase your reputation in turn, which will duly enable you to further shape society. Managing societal development well will have a recursive effect on your reputation, and can drive it to great heights.//
-
+<br><br>
 //The benefits of a high reputation are numerous. Many business and enslavement opportunities will open to you once you are reputable. Some of the most advanced technology is only available to those with impeccable reputations as slaveowners, and many of the finer slave markets will only consider reputable buyers. You may eventually become so renowned that merely branding a slave with your mark will increase her value on the open market.//
-
+<br><br>
 //However, your reputation will not look after itself. At a certain point, you will become so reputable that continual effort will be necessary to maintain your renown. The old world question "What have you done for me lately?" is asked with twice the force in the Free Cities! You will quickly find that this natural decay of reputation can overwhelm your efforts to improve it by the end of the week. A concerted strategy will be necessary to overcome this.//
-<<case "Random Events">>\
+
+
+<<case "Random Events">>
 At the end of every turn, a random event may occur. Almost all random events are tied to necessary preconditions. For example, events concerning rebellious slaves will stop happening if all the player's slaves become obedient.
-
+<br><br>
 Usually, a situation will be presented and the player may choose one of two or three resolutions. Please note that the player may also to choose none of these by using the "continue" button in the sidebar; in effect, this usually means the player's character has simply declined to involve himself.
-
+<br><br>
 Almost all choices will result in small effects. The most common are changes to a slave's attitude towards the player's character, but there are others.
-
+<br><br>
 Finally, there are events that can result in the player being offered the chance to acquire new slaves, some of which can be unique or valuable. Generally, these events offer this livestock at an extremely discounted price. These events will appear more often the higher the player's reputation becomes.
-<<case "Costs Summary">>\
+
+
+<<case "Costs Summary">>
 Aphrodisiacs are cheap and cost ¤<<print $drugsCost>> weekly; curatives are expensive and cost ¤<<print ($drugsCost*3)>> weekly; while all other drug regimes cost ¤<<print ($drugsCost*2)>>. Standard hormone regimens cost <<print Math.trunc($drugsCost*1*0.5)>> while intensive hormone treatment costs <<print Math.trunc($drugsCost*2*0.5)>>. Contraceptives cost <<print Math.trunc($drugsCost*0.5)>>.
-
+<br><br>
 Slaves on spare living standards are fed a bland diet and obliged to sleep on bedrolls. Keeping a slave under restrictive rules costs ¤<<print $rulesCost>> weekly.
-
+<br><br>
 Slaves enjoying luxurious living standards on the other hand are fed a tasty diet and permitted to sleep in comfortable beds, and are generally pampered. The increased luxury of permissive rules costs ¤<<print ($rulesCost*3)>> weekly.
-
+<br><br>
 Some arcology upgrades may have associated upkeep costs as well.
-<<case "Rules Assistant">>\
-''The Rules Assistant'' is a system to apply multiple rule sets to multiple slaves at once. You can apply rules to slaves based on slave ''devotion'', ''trust'', ''sex drive'', ''health'', ''weight'' and ''age''.
 
+
+<<case "Rules Assistant">>
+''The Rules Assistant'' is a system to apply multiple rule sets to multiple slaves at once. You can apply rules to slaves based on slave ''devotion'', ''trust'', ''sex drive'', ''health'', ''weight'' and ''age''.
+<br><br>
 __Rule settings:__
 Rules can be used to control certain aspects of slaves everyday lives, for example to automatically give slaves a certain clothing option, collar, footwear or allow slaves to choose their own outfit. They can be used to give unhealthy slaves curatives to improve their health or to put slaves on a diet so that their weight can be closer to the ideal weight. Rules set to 'No default setting' will not apply that particular condition to slaves.
 Rules can also be renamed to be more indicative of their intended purpose.
-
+<br><br>
 __Rule activation:__
 In order to apply a rule to slaves, the activation will need to be set. Choose an activation type (devotion, trust, sex drive, health, weight or age) and then choose the level at which to apply. For example to apply a rule to obedient slaves, choose 'devotion' for the activation and 4 or more for the lower limit by selecting '>='.
-
+<br><br>
 __Selecting or excluding slaves from a rule:__
 Slaves can be selected for a rule by selecting slaves from the list so that a rule can apply only to them. Slaves can similarly be excluded from a rule.
-
+<br><br>
 __Applying a rule to specific assignments:__
 You can apply a rule only to slaves on individual assignments by selecting them under 'Apply to assignments'. For example a rule can give aphrodisiacs to slaves on whoring assignments. ''This is mutually exclusive to automatically giving an assignment to slaves''.
-
+<br><br>
 __Automatically giving an assignment:__
 A rule can be set to automatically set a slave to an assignment when activated. For example a devoted slave can be set to automatically be put on the whoring assignment. ''This is mutually exclusive to applying a rule to assignments''.
-
+<br><br>
 __Applying a rule to facilities:__
 You can apply a rule to slaves in any or all facilities as long as that facility has been constructed. The rule will only apply to slaves within the selected facilities. ''This is mutually exclusive to automatically putting slaves into a facility''.
-
+<br><br>
 __Automatically assigning slaves to a facility:__
 A rule can be set to automatically put a slave into a facility when activated. For example disobedient slaves can be set to automatically be confined in the arcade if it has been constructed. ''This is mutually exclusive to applying a rule to facilities''.
-
+<br><br>
 __Saving a rule:__
 If you are finished setting up a rule ''make sure to save it'' by clicking 'Save rule' at the bottom before clicking another link otherwise your settings will be lost.
-
+<br><br>
 __Applying a rule:__
 Clicking on 'Apply rules' will automatically save the current rule and apply all rules to slaves at once.
-
+<br><br>
 __Adding or removing a rule:__
 The game starts with 3 basic default rule settings but more can be added and/or removed as needed. To add a new rule, click 'Add a new rule' at the bottom, removing a rule is the same by clicking 'Remove rule'.
-<<case "The Corporation">>\
-Once you are fairly reputable and have a large sum of cash in the bank, you will receive a brief end of turn event that unlocks the ability to found a corporation dedicated to slaving. Once this happens, you can incorporate from the economics report, and once you've done that, you can manage your corporation every week from the same place.
 
+
+<<case "The Corporation">>
+Once you are fairly reputable and have a large sum of cash in the bank, you will receive a brief end of turn event that unlocks the ability to found a corporation dedicated to slaving. Once this happens, you can incorporate from the economics report, and once you've done that, you can manage your corporation every week from the same place.
+<br><br>
 __Shares__
 Buying shares from the corporation or issuing new shares will create new shares in the corporation. If you buy them yourself, cash will be transferred from you to the corporation in return for the shares; if the shares are sold money will come into the corporation from the market. Selling your shares or buying publicly held shares are both transactions between you and your shares and shareholders and their shares. All these transactions impact the stock price; experiment to find a plan that will give you and your corporation the best outcome.
-
+<br><br>
 __Assets__
 All assets are mostly valuable as assets; they drive up the value of your corporation and thus its stock price, and they all produce a small amount of profit every week. Slave assets generate the most inherent profit. Both entrapment and conflict zone capture assets create more slave assets; drug, training, and surgical assets improve the slave assets you already have.
-
+<br><br>
 __Slave Sales__
 Once a corporation is created, it will get its own establishment in the slave market. Stockholders are offered discounts on its slaves, which increase with the size of the owner's share in the corporation. As the corporation's assets increase, it can be given direction about what kind of slaves it should train and how it should train them, which will affect the slaves seen in the corporate catalog. Each asset type allows three choices:
 &nbsp;&nbsp;&nbsp;&nbsp;General Assets: Slave breaking, diets, and fitness.
@@ -231,164 +284,224 @@ Once a corporation is created, it will get its own establishment in the slave ma
 &nbsp;&nbsp;&nbsp;&nbsp;Surgical: Cosmetic surgeries, implants, and extreme surgeries.
 &nbsp;&nbsp;&nbsp;&nbsp;Pharmacological: Hormones, expansion, and extreme expansion.
 These decisions remain available until settled, but cannot be changed once made. If the corporation's slaves have qualities that make them especially appealing to an arcology's citizens, the corporation will enjoy increased profits, and the [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] creating the demand will progress more rapidly due to the supply of appealing slaves. All arcologies present in the Free City will interact with the corporation this way, making shares in a corporation which supplies girls that appeal to the whole city extremely lucrative.
-<<case "Sexual Energy">>\
+
+
+<<case "Sexual Energy">>
 Though you're (naturally) a virile, oversexed oligarch, even your reserves of sexual energy are not infinite. They're impressive, but not infinite. Since one turn represents one week, the game does not allow the player direct control over every sexual interaction between the player character and <<if $PC.title == 1>>his<<else>>her<</if>> slaves. Put another way, the game assumes there's an impressive amount of offscreen sex going on between the <<if $PC.title == 1>>Master and his<<else>>Mistress and her<</if>> chattel.
-
+<br><br>
 The player character's sexual energy can have gameplay effects. Though of course all slaves are at the <<if $PC.title == 1>>Master's<<else>>Mistress's<</if>> sexual beck and call, some assignments and training methods involve close sexual attention by the player character. If a large number of slaves are subject to this, the player character's attention will be somewhat diluted, and the effects on each slave will be reduced. Slaves assigned to be __fucktoys__ and serve in the __master suite__ count towards a hidden estimation of the player character's sexual foci. With two or fewer such slaves, the player character's sexual attention on these slaves will be intense and have intense effects. With five or more, the player character may have some difficulty in using every slave every day, diluting the mental effects of being the <<if $PC.title == 1>>Master's<<else>>Mistress's<</if>> personal sex toy.
-
+<br><br>
 It is possible to raise these limits by focusing on sexual decadence for the week. By paying less attention to business and not using sexual training on specific slaves, the player character will have more energy to spare and can offer intense sexual attention to three slaves or give sexual attention to up to seven slaves without dilution.
 /**********
 
 SLAVES
 
 **********/
-<<case "Slaves">>\
+
+
+<<case "Slaves">>
 //Future room for lore text//
-
+<br><br>
 Choose a more particular entry below:
-\
-<<case "Enslaving People">>\
+
+
+
+<<case "Enslaving People">>
 //<<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Sir<<else>>Ma'am<</if>>, this is your personal assistant; if I may interject?
-
+<br><br>
 As you grow in economic power and social influence, opportunities to enslave people may appear. I will certainly do my best to bring them to your attention as they appear.
-
+<br><br>
 Despite their extreme anarcho-libertarianism, the Free Cities observe some limited legalities surrounding enslavement. The most generally accepted way to enslave someone is to put them in a situation where they owe you a large sum of money that they cannot pay. You can then demand payment and force them to sell themselves to you when they fail to make it. Of course, that means if someone is in debt to another person, you can purchase the debt from its holder and then enslave the debtor. Even if you are in a situation where you have a right to enslave someone, the necessary formalities and biometric scanning are not cheap. You will have to pay these associated costs.//
-<<case "From Rebellious to Devoted">>\
+
+
+<<case "From Rebellious to Devoted">>
 //Almost everything can affect a slave's willingness to obey. Increases in obedience @@.hotpink;are in hot pink,@@ while decreases @@.mediumorchid;are in orchid.@@ Meanwhile, increases in trust (and decreases in fear) @@.mediumaquamarine;are in aquamarine,@@ while decreases in trust (and increases in fear) @@.gold;are in gold.@@
-
+<br><br>
 High devotion will naturally degrade; it takes at least some outside impetus to maintain slavish devotion in a sane mind. The higher a slave's devotion rises, the higher this natural rate of decay will become. Generally, this should not be a concern. As long as you treat your devoted slaves decently, they will remain devoted to you.
-
+<br><br>
 Slaves with devotion and trust that do not agree with each other (for example, a slave that is terrified of her Master, but also loves him) will see both characteristics move towards the middle.
-
+<br><br>
 Finally, devotion and trust both have minimum and maximum values. However, raising a slave's trust or devotion over the maximum value isn't pointless. If either trust or devotion goes over the cap, and the other characteristic is still under the cap, the excess will overflow into that characteristic and improve it at a lowered efficiency. If both characteristics have been perfected, the player will instead gain a small reputation boost from the slave's perfect mental conditioning.//
-<<case "Health">>\
+
+
+<<case "Health">>
 Slaves' ''health'' is extremely important. It can be reduced by tough assignments like [[Whoring|Encyclopedia][$encyclopedia = "Whoring"]] and [[Public Service|Encyclopedia][$encyclopedia = "Public Service"]], surgery, many powerful drug regimes, abuse, and even age. The [[Rest|Encyclopedia][$encyclopedia = "Rest"]] assignment will increase health; curative drugs will increase it, while preventative drugs can stop assignment-related health losses. Curatives and rest will synergize and add additional health if applied simultaneously. At very low health, many injuries will affect a slave's health more severely, creating a vicious circle: resting slaves until their health indicator is no longer @@.red;red@@ is good practice. Conversely, at high health, some health losses will be less common or not occur at all, and extremely healthy slaves will do slightly better at most assignments.
-\
-<<case "Devotion">>\
+
+
+
+<<case "Devotion">>
 ''Devotion'' is a measure of a slave's liking for the player character, and secondarily, how accepting she is of her place in life. (Low Devotion is also referred to as hatred.) Along with [[trust|Encyclopedia][$encyclopedia = "Trust"]], it is the main measure of a slave's mental state. A highly devoted slave will always obey and will do her best on assignments. With low Devotion, obedience depends on Trust: if Trust is high, the slave will generally resist and do badly, but if Trust is low enough the slave will obey out of fear. Almost everything in the game can effect Devotion in some way: @@.mediumorchid;orchid text@@ indicates a Devotion loss, while @@.hotpink;hot pink@@ text indicates a Devotion gain. Maximized or minimized Devotion is somewhat sticky: lightly abusing a perfectly devoted slave will not damage Devotion, while minor kindnesses will not affect a hateful slave. If a slave is very trusting, extremely high Devotion will boost Trust weekly (extremely low Devotion will do the reverse), and any Devotion gains that push it over its maximum value will overflow into Trust. However, if a slave is very frightened, high Devotion will not impact Trust. If both Trust and Devotion are maximized, the slave's sex drive will be increased. If she's already a nympho, Reputation is increased instead.
-\
-<<case "Trust">>\
+
+
+
+<<case "Trust">>
 ''Trust'' is a measure of a slave's expectations of the player character, and secondarily, how confident she is of her ability to do well. (Low Trust is also referred to as fear.) Along with [[devotion|Encyclopedia][$encyclopedia = "Devotion"]], it is the main measure of a slave's mental state. A highly trusting slave is often more expensive to keep, but will do better in a leadership position and is more valuable. Slaves who are not intended for special assignments or resale can usually be kept terrified. Trust is negative if a slave is not sufficiently devoted: in this case, she will not obey since she neither likes nor fears the player character. Many game mechanics can effect Trust in some way: @@.mediumaquamarine;aquamarine text@@ text indicates a Trust gain, while @@.gold;gold@@ indicates a Trust loss. Maximized or minimized Trust is somewhat sticky: lightly abusing a perfectly trusting slave will not damage Trust, while minor confidence boosts will not affect an abjectly terrified slave. Extremely high Trust will boost Devotion weekly, and any Trust gains that push it over its maximum value will overflow into Devotion. If both are maximized, the slave's sex drive is increased. If she's already a nympho, Reputation is increased instead.
-\
-<<case "Drugs and Their Effects">>\
+
+
+
+<<case "Drugs and Their Effects">>
 A variety of new pharmaceuticals are becoming available in the regulatory desert of the Free Cities. Many are untested, most are extremely powerful, and none have undergone long-term testing. Long-term use of any combination of these drugs is likely to have some minor but still concerning cumulative health impact. Ceasing use may only prove partially effective in reversing these effects.
-
+<br><br>
 //"Curatives,"// cocktails of powerful drugs that promote healing, retard natural genetic decay, improve metabolism, and offer a host of other clinical benefits. They reliably and safely improve health. The only thing preventing their exhibition in all cases is their extremely high cost and unknown long-term effect.
-
+<br><br>
 //"Preventatives,"// a cocktail of drugs similar to curatives that build up in the body and only become active when the body is stressed. These can often prevent disease or injury. They are not as expensive as the full curative regime, but only help prevent loss of health rather than promoting its increase. It should be noted that they cannot affect major trauma such as invasive surgery.
-
+<br><br>
 //Enhancement injections,// improvements on 20th century legacy steroids. These often include an element not dissimilar to liposuction in which a slurry of the patient's own tissues is included in the injection to promote tissue growth at the injection site. These drugs increase cosmetic body area size faster than any other option other than plastic surgery, but can have negative health consequences.
-
+<br><br>
 //Psychosuppressants,// cocktails of legacy mental health treatments delivered in extremely high doses designed to reduce the patient's ability to think independently. The most common set of effects include increased obedience, reduced rebelliousness, and irreversible damage to mental faculties.
-
+<br><br>
 //Aphrodisiacs,// powerful, addictive sexual enhancers that cause a mental and physical state not dissimilar to traditional hypersexuality. These drugs are based on female hormones, and may have long-term effects similar to female hormone reassignment treatment. They are strongly addictive, both physically and mentally, and the usual recommendation to slave owners is that slaves should be put on aphrodisiacs only for a brief time, or permanently. Aphrodisiac addiction can typically only be overcome by supporting a slave through withdrawal for a similar period to the amount of time she was on the drugs.
 Aphrodisiacs can also be administered in //extreme doses.// This is medically dangerous, but is sometimes used by unscrupulous slave owners. Slaves so dosed will feel an extreme need for sex regardless of their emotional state; for example, rebellious, virgin slaves on extreme aphrodisiac doses will typically enjoy having their virginity sold.
-
+<br><br>
 -- Dodgson, Jane Elizabeth, //Pharmaceutical Review '32//
-<<case "Gender">>\
+
+
+<<case "Gender">>
 //Slavery in the Free Cities has begun to affect perceptions of gender in ways that should be unsurprising to the student of history.
-
+<br><br>
 The last great Western civilization in which slavery was as prominent and universal as it is in the Free Cities was Rome. It is inevitable that Roman mores regarding sexual propriety and orientation should reappear organically in the Free Cities, albeit with some modern variations.
-
+<br><br>
 The founders of the Free Cities were overwhelmingly male; many among the few that were not found it convenient to affect male attitudes and tastes. It rapidly became common to treat all slaves, regardless of their biological situation, as female; in some of the Free Cities this has even become law. To describe the idea crudely, slaves get fucked, and are therefore female.
-
+<br><br>
 There are almost as many variations in how this plays out in practice as there are slaveowners. Generally, however, the trend in the Free Cities is strongly in favor of feminizing all slaves regardless of sex. Persons in slave orphanages (who will be enslaved at their majority to clear the debt they incur by being raised there) are often raised on heavy hormonal doses. If this is no longer possible, drugs and surgery are often applied instead.
-
+<br><br>
 The ignorant tourist common to the Free Cities often wonders why the vast majority of people going about their public business in a Free Cities arcology are female.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-
+<br><br>
 //Slaves can have vaginas, dicks, or both. Slaves can work well with any of these. However, there are a few major effects. Naturally, slaves not born with a vagina cannot become pregnant. Slaves without a pussy cannot learn related sexual skills, and cannot teach them. However, slaves with dicks are better at training other slaves in many sexual skills. Finally, slaves without vaginas will often find public sexual slavery, whether for profit or not, more physically taxing.//
-<<case "Nymphomania">>\
+
+
+<<case "Nymphomania">>
 //The term 'nymphomania' as used in the Free Cities' slave society refers to a very different phenomena than the clinically diagnosable condition of hypersexuality that it traditionally denoted.
-
+<br><br>
 The long-standing use of 'nympho' to refer to a sexually eager female as a desirable thing has led it to be used in the Free Cities to describe the most desirable mental state for a sex slave to possess. Though what Free Cities slaveowners mean when they refer to a slave as a nymphomaniac certainly includes a strong sex drive, it also means that the slave in question defines her sexuality in terms of the wishes of others. In effect it refers to a kind of submissive 'all of the above' sexuality: a Free Cities nymphomaniac slave can be expected to enjoy public sex with all the arousal of a humiliation fetishist one moment, and then consume ejaculate with all the eagerness of a cum fetishist the next.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-
+<br><br>
 //Nymphomania as used in game refers to the best possible mental status for a slave in game terms.//
-<<case "Indentured Servants">>\
+
+
+<<case "Indentured Servants">>
 ''Indentured Servants'' are slaves who are held by temporary contract. When the time on their contract expires, they are freed. For obvious reasons, Indentured Servants' value is heavily affected by how much time remains until they are to be freed. When their emancipation arrives, Indentured Servants can react in varying ways, depending on their feelings about the player character.
-
+<br><br>
 To prevent the obvious exploitative use of Indentured Servants, using them without mercy since they are of no long term value anyway, most indentures contain limitation clauses that restrict the indenture owner from various harsh actions. The most restrictive indentures prevent almost all drugs and surgery, and many of the least pleasant jobs. On the other hand, stupidity, ignorance, or duress can lead some Indentured Servants to sign contracts with barely any protections at all.
-\
-<<case "Menial Slaves">>\
+
+
+
+<<case "Menial Slaves">>
 ''Menial slaves'' in general are the numerous slaves in the arcology that are not considered sex slaves, due to advanced age, unattractiveness, or other unsuitability. Their duties in the arcology vary widely from slave to slave and from arcology to arcology. Automation has done away with many traditional jobs in strictly economic terms, but some slaveowning societies prefer to have unskilled tasks done by slaves anyway for reasons of appeal or prestige. Also, the advancement of automation has been beaten back in some areas due to the obviously low practical labor costs in Free Cities with cheap slaves.
-
+<br><br>
 Menials remain almost entirely offscreen. The game will track the arcology's population of menial slaves, and many of your decisions can affect the menial population. You can also buy, keep, and sell menial slaves yourself, from the slave markets menu. They will produce a small profit each week through their (unspecified) labors. Alternatively, a tidy profit can be made from playing the slave market for menials. There are also two subtypes of menial slave, both of which become inaccessible if [[Paternalism|Encyclopedia][$encyclopedia = "Paternalism"]] is selected as a societal goal.
-
+<br><br>
 __Fuckdolls__ are slaves immured in permanent latex suits with holes over their orifices, turning them into living sex toys. They are more valuable than menial slaves proper, mostly due to the cost of the various compliance and drug components of the suits, which make them quite expensive. The weekly profit from owning Fuckdolls can be improved though a policy unlocked by [[Degradationism|Encyclopedia][$encyclopedia = "Degradationism"]]. Normal menials can be converted into Fuckdolls if an upgraded [[Arcade|Encyclopedia][$encyclopedia = "Arcade"]] is available.
-
+<br><br>
 __Standard Bioreactors__ are slaves who are permanently attached to the arcology for industrial use, which can vary from milking to drug testing to organ farming. They are slightly less valuable than menial slaves proper. The weekly profit from owning Bioreactors can be improved though a policy unlocked by [[Pastoralism|Encyclopedia][$encyclopedia = "Pastoralism"]]. Normal menials can be converted into Bioreactors if an industrialized [[Dairy|Encyclopedia][$encyclopedia = "Dairy"]] is available.
-\
-<<case "Lingua Franca">>\
+
+
+<<case "Fuckdolls">>
+//Basis of the Kombinezon-B bodysuit is a durable advanced material. Bodysuit protects, temperature-regulates, cleans, and restrains inhabitant. Material is of such strength that inhabitant is well protected, and of such thickness that inhabitant cannot feel any touch.
+<br><br>
+Bodysuit is plumbed for nutrition, drug application, and waste removal. Inhabitant's digestive tract should be reoriented to cannulae of complex ?-2 for nutrition intake at left ribcage and waste removal at front abdomen. Drug application is by direct bloodstream. Bodysuit includes monitoring systems to maintain vital signs of inhabitant.
+<br><br>
+For use, bodysuit possesses apertures at anus, mouth, and where appropriate, vagina. No provision for silencing is made, so surgical muting is recommended before application of bodysuit. Closure of jaws remains somewhat possible, so surgical dentition reduction is recommended before application of bodysuit. No other apertures are discernible to inhabitant. Inhabitant's only source of stimulation is penetration.
+<br><br>
+Revision ?-7 of bodysuit for inhabitant without limbs exists. Nutritional requirements are reduced. Drugs required for vital sign maintenance are increased.
+<br><br>
+-- //Product Manual: Kombinezon-B Fuckdoll bodysuit manual////
+<br><br>
+When the Fuckdoll upgrade to the arcade is purchased, any mindbroken slaves that exceed the arcade's capacity will be converted into Fuckdolls and sold.
+
+
+<<case "Lingua Franca">>
 At the beginning of the game, the lingua franca of the arcology will be determined, either by customization or by default to the most common language of the selected continent. When slaves are generated during the game, they will be assigned a familiarity with the lingua franca based on their nationality, intelligence, education, and in some cases, ethnicity. This accent can range from nonexistent (typical for slaves from the country where the language originated) to crippling, rendering the slave more or less unable to speak and only able to understand basic orders. The latter will reduce a slave's attractiveness. Slaves will learn the lingua franca naturally, a process that is faster for intelligent slaves. It can be sped up by allowing slaves to speak and providing basic slave education. Light accents are considered attractive, but can be eliminated using speech rules that encourage unaccented speech. A thick accent will impede a Head Girl.
-\
-<<case "Slave Score (Attractiveness)">>\
+
+
+
+<<case "Slave Score (Attractiveness)">>
 A slave's ''Attractiveness Score'' is a derived stat used to determine a slave's performance at many assignments. It also plays a major role in her price if bought or sold. It's a rough measure, but it's intended to serve as a rough count of how many of your arcology's citizens would be interested in paying to fuck her over the course of a week. The amount they would be willing to pay is determined by her [[Sexual Score|Encyclopedia][$encyclopedia = "Slave Score (Sexual)"]]. Attractiveness Score is affected by virtually every physical trait a slave has, some skills, and societal tastes.
-\
-<<case "Slave Score (Sexual)">>\
+
+
+
+<<case "Slave Score (Sexual)">>
 A slave's ''Sexual Score'' is a derived stat used to determine a slave's performance at many assignments. It also plays a major role in her price if bought or sold. It's a rough measure, but it's intended to serve as an estimate of the average price she would command as a street whore over the course of a week. The number of your arcology citizens who might be willing to pay that price is determined by her [[Attractiveness Score|Encyclopedia][$encyclopedia = "Slave Score (Attractiveness)"]]. Sexual Score is affected by sexual skills, some physical traits, [[Health|Encyclopedia][$encyclopedia = "Health"]] and [[devotion|Encyclopedia][$encyclopedia = "Devotion"]], and societal tastes.
-\
+
 /**********
 
 OBTAINING SLAVES
 
 **********/
-<<case "Obtaining Slaves">>\
+
+
+<<case "Obtaining Slaves">>
 //Future room for lore text//
-
+<br><br>
 Choose a more particular entry below:
-\
-<<case "Kidnapped Slaves">>\
+
+
+<<case "Kidnapped Slaves">>
 //Slavers, from disreputable to noble, visit the Free Cities in droves. Their merchandise is, as a rule, offered as-is and no questions asked. This usually means that their charges have been forcibly kidnapped. These slaves are generally rebellious, often unhealthy, and always cheap.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-<<case "Slave Schools">>\
+
+
+<<case "Slave Schools">>
 //It is not legal to own children in the Free Cities. It is however legal to hold an interest in future ownership of a child once they reach their 18th birthday. The Free Cities host what are referred to as 'orphanages,' but are in fact slave schools. Of course, instruction cannot include sexual training, so it instead focuses on obedience and fitness.
-
+<br><br>
 The standard slave school produces merchandise to a strict mold. Their stock is guaranteed to be robustly healthy, at a sleek weight, body modification free, 18 to 19 years of age, very obedient, and 100% virgin. A few schools specialize in slaves with non-standard organs or in modified slaves, but most protect brand identity by confining themselves to natural females.
-
+<br><br>
 It has recently become common practice to begin treating such trainees with drugs years before sale. Not all orphanages engage in this questionable practice, usually justified as 'seeing to orphans' medical welfare,' but you will occasionally see fresh slaves sold with breasts and asses unusually well-developed for their age. These are very rare, as the newness of slavery means that few slaves have been so from a young age. Presumably, slaves treated in this way will become more common as the Free Cities mature.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-<<case "Stables">>\
+
+
+<<case "Stables">>
 //At any given time, many hundreds of new slaves are listed for sale in the Free City. Since these slaves have come through a training stable, they will tend to be fairly obedient, reasonably healthy, and have basic sexual skill, but will never be virgins.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-<<case "Household Liquidations">>\
+
+
+<<case "Household Liquidations">>
 //It is natural that where there is a demand for slaves who are related to one another, supply should arise.
-
+<br><br>
 Suppliers of slaves from the outside world are well aware that paired slaves, whether mothers and daughters or sisters, command a premium. This special merchandise is best found at dealers that specialize in it. After all, the demand is strong enough that only experienced dealers have the skill and equipment to defeat all the tricks suppliers are willing to use to pass slaves off as relatives.
-
+<br><br>
 Nature has contrived that the demand for twin slaves should far outstrip the supply. Since slavery is new, a majority of those now enslaved were born free, so this is difficult for slave trainers to address. However, the coming decades should see a great increase in the number of slave twins as breeders improve fertility treatments.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-<<case "Direct Sales">>\
+
+
+<<case "Direct Sales">>
 //On occasion, an established slaveowner will sell a trained and modified slave due to financial need, because he is bored of her, or because he trains unique slaves as a hobby.
-
+<br><br>
 Some of the most powerful persons in the Free Cities also maneuver their enemies into selling a favorite slave as a way of bloodlessly showing dominance. The truly powerful occasionally feel the need to show that they can obtain any slave, at any time, regardless of her owners' wishes.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-<<case "Pre-Owned Slaves">>\
+
+
+<<case "Pre-Owned Slaves">>
 The slaves left behind by the previous owner of your arcology are from a catalog of slaves that can also be accessed through the pre-owned slave vendor.
-
+<br><br>
 Most of these slaves were submitted to the game by anons on /d/. If you'd like to submit a slave for addition to the game, you can do so at http://freecitiesblog.blogspot.com/2015/08/slave-submissions.html.
-
+<br><br>
 /**********
 
 SLAVE ASSIGNMENTS:
 
 **********/
-<<case "Slave Assignments">>\
+
+
+<<case "Slave Assignments">>
 //Future room for lore text//
-
+<br><br>
 Choose a more particular entry below:
-\
-<<case "Career Experience">>\
-Slaves may retain useful experience from their lives before enslavement. Freedom and slavery are so different that the bonuses slaves get from career experience are minor. Careers fall into categories, each with its own bonus; these are:
-<<nobr>>
 
+
+
+<<case "Career Experience">>
+Slaves may retain useful experience from their lives before enslavement. Freedom and slavery are so different that the bonuses slaves get from career experience are minor. Careers fall into categories, each with its own bonus; these are:
+
+<br><br>
 <br>__Grateful__ (offering a potential bonus to [[trust|Encyclopedia][$encyclopedia = "Trust"]]), including slaves who were
 <<for $i = 0; $i < setup.gratefulCareers.length; $i++>>
 	<<if $i == setup.gratefulCareers.length-1>>
@@ -397,7 +510,7 @@ Slaves may retain useful experience from their lives before enslavement. Freedom
 		<<print setup.gratefulCareers[$i]>>,
 	<</if>>
 <</for>>
-
+<br><br>
 <br>__Menial__ (offering a potential bonus to [[devotion|Encyclopedia][$encyclopedia = "Devotion"]]), including slaves who were
 <<for $i = 0; $i < setup.menialCareers.length; $i++>>
 	<<if $i == setup.menialCareers.length-1>>
@@ -406,7 +519,7 @@ Slaves may retain useful experience from their lives before enslavement. Freedom
 		<<print setup.menialCareers[$i]>>,
 	<</if>>
 <</for>>
-
+<br><br>
 <br>__Entertainment__ (offering a bonus to [[public service|Encyclopedia][$encyclopedia = "Public Service"]]), including slaves who were
 <<for $i = 0; $i < setup.entertainmentCareers.length; $i++>>
 	<<if $i == setup.entertainmentCareers.length-1>>
@@ -416,7 +529,7 @@ Slaves may retain useful experience from their lives before enslavement. Freedom
 	<</if>>
 <</for>>
 If a slave has been in the arcology for a long time and is intelligent, she can qualify for this bonus without career experience.
-
+<br><br>
 <br>__Sex work__ (offering a bonus to [[whoring|Encyclopedia][$encyclopedia = "Whoring"]]), including slaves who were
 <<for $i = 0; $i < setup.whoreCareers.length; $i++>>
 	<<if $i == setup.whoreCareers.length-1>>
@@ -426,7 +539,7 @@ If a slave has been in the arcology for a long time and is intelligent, she can 
 	<</if>>
 <</for>>
 If a slave is very sexually experienced, she can qualify for this bonus without career experience.
-
+<br><br>
 <br>__Leadership__ (offering a bonus as [[Head Girl|Encyclopedia][$encyclopedia = "Head Girl"]]), including slaves who were
 <<for $i = 0; $i < setup.HGCareers.length; $i++>>
 	<<if $i == setup.HGCareers.length-1>>
@@ -435,7 +548,7 @@ If a slave is very sexually experienced, she can qualify for this bonus without 
 		<<print setup.HGCareers[$i]>>,
 	<</if>>
 <</for>>
-
+<br><br>
 <br>__Procuring__ (offering a bonus as [[Madam|Encyclopedia][$encyclopedia = "Madam"]]), including slaves who were
 <<for $i = 0; $i < setup.madamCareers.length; $i++>>
 	<<if $i == setup.madamCareers.length-1>>
@@ -444,7 +557,7 @@ If a slave is very sexually experienced, she can qualify for this bonus without 
 		<<print setup.madamCareers[$i]>>,
 	<</if>>
 <</for>>
-
+<br><br>
 <br>__Musical__ (offering a bonus as [[DJ|Encyclopedia][$encyclopedia = "DJ"]]), including slaves who were
 <<for $i = 0; $i < setup.DJCareers.length; $i++>>
 	<<if $i == setup.DJCareers.length-1>>
@@ -453,7 +566,7 @@ If a slave is very sexually experienced, she can qualify for this bonus without 
 		<<print setup.DJCareers[$i]>>,
 	<</if>>
 <</for>>
-
+<br><br>
 <br>__Defensive__ (offering a bonus as [[Bodyguard|Encyclopedia][$encyclopedia = "Bodyguard"]]), including slaves who were
 <<for $i = 0; $i < setup.bodyguardCareers.length; $i++>>
 	<<if $i == setup.bodyguardCareers.length-1>>
@@ -462,7 +575,7 @@ If a slave is very sexually experienced, she can qualify for this bonus without 
 		<<print setup.bodyguardCareers[$i]>>,
 	<</if>>
 <</for>>
-
+<br><br>
 <br>__Security__ (offering a bonus as [[Wardeness|Encyclopedia][$encyclopedia = "Wardeness"]]), including slaves who were
 <<for $i = 0; $i < setup.wardenessCareers.length; $i++>>
 	<<if $i == setup.wardenessCareers.length-1>>
@@ -471,7 +584,7 @@ If a slave is very sexually experienced, she can qualify for this bonus without 
 		<<print setup.wardenessCareers[$i]>>,
 	<</if>>
 <</for>>
-
+<br><br>
 <br>__Medical__ (offering a bonus as [[Nurse|Encyclopedia][$encyclopedia = "Nurse"]]), including slaves who were
 <<for $i = 0; $i < setup.nurseCareers.length; $i++>>
 	<<if $i == setup.nurseCareers.length-1>>
@@ -480,7 +593,7 @@ If a slave is very sexually experienced, she can qualify for this bonus without 
 		<<print setup.nurseCareers[$i]>>,
 	<</if>>
 <</for>>
-
+<br><br>
 <br>__Counseling__ (offering a bonus as [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]]), including slaves who were
 <<for $i = 0; $i < setup.attendantCareers.length; $i++>>
 	<<if $i == setup.attendantCareers.length-1>>
@@ -489,7 +602,7 @@ If a slave is very sexually experienced, she can qualify for this bonus without 
 		<<print setup.attendantCareers[$i]>>,
 	<</if>>
 <</for>>
-
+<br><br>
 <br>__Accounting__ (offering a bonus as [[Stewardess|Encyclopedia][$encyclopedia = "Stewardess"]]), including slaves who were
 <<for $i = 0; $i < setup.stewardessCareers.length; $i++>>
 	<<if $i == setup.stewardessCareers.length-1>>
@@ -498,7 +611,7 @@ If a slave is very sexually experienced, she can qualify for this bonus without 
 		<<print setup.stewardessCareers[$i]>>,
 	<</if>>
 <</for>>
-
+<br><br>
 <br>__Husbandry__ (offering a bonus as [[Milkmaid|Encyclopedia][$encyclopedia = "Milkmaid"]]), including slaves who were
 <<for $i = 0; $i < setup.milkmaidCareers.length; $i++>>
 	<<if $i == setup.milkmaidCareers.length-1>>
@@ -507,7 +620,7 @@ If a slave is very sexually experienced, she can qualify for this bonus without 
 		<<print setup.milkmaidCareers[$i]>>,
 	<</if>>
 <</for>>
-
+<br><br>
 <br>__Teaching__ (offering a bonus as [[Schoolteacher|Encyclopedia][$encyclopedia = "Schoolteacher"]]), including slaves who were
 <<for $i = 0; $i < setup.schoolteacherCareers.length; $i++>>
 	<<if $i == setup.schoolteacherCareers.length-1>>
@@ -516,156 +629,215 @@ If a slave is very sexually experienced, she can qualify for this bonus without 
 		<<print setup.schoolteacherCareers[$i]>>,
 	<</if>>
 <</for>>
-
-<</nobr>>
-
+<br><br>
 Slaves who have been in slavery long enough that it is effectively their career get a bonus to Devotion. Slaves can forget career experience in an industrialized Dairy, but if they do so and remain sane, they will get a special bonus to both Devotion and Trust.
-<<case "Attendant">>\
+
+
+<<case "Attendant">>
 An ''Attendant'' can be selected once the [[Spa|Encyclopedia][$encyclopedia = "Spa"]] facility is built. Attendants provide emotional help to slaves in the spa, and can also soften flaws and even fix mindbroken slaves. Good Attendants are free of fetishes or submissive, older than 35, intelligent, and naturally female.
-<<case "Bodyguard">>\
+
+
+<<case "Bodyguard">>
 //Slave bodyguards are best understood not as protection for a slaveowner's person, but rather as a projection of their skill at slavebreaking.
-
+<br><br>
 By giving a slave the means and position to easily kill her master, that master displays her total loyalty to him. The simple fact that an armed slave is near a slaveowner at all times is proof that that slaveowner has produced at least one slave that never wavers in her devotion. After all, if she ever wavered, the slaveowner would likely be dead.
-
+<br><br>
 It is obvious to any real security professional that slave bodyguards are mostly for show, from the moment of seeing one. After all, they are not equipped with modern sensors, armor, and weapons; if they were so attired and loaded down it would be quite impossible to tell if they were even female: the huge weight and bulk of modern combat gear gives an androgynous appearance. Instead, they are usually kept scantily clad or even naked, and armed with visually impressive weapons.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-
+<br><br>
 
 A ''Bodyguard'' can be selected once the Armory upgrade is purchased. Duties include protection of the player character during violent events; good bodyguards produce some reputation as well, based on how deadly they are. Toned but not excessive muscles, combat skills, and height contribute to deadliness. Big [[breasts|Encyclopedia][$encyclopedia = "Breasts"]], [[butts|Encyclopedia][$encyclopedia = "Butts"]], poor [[health|Encyclopedia][$encyclopedia = "Health"]], excess [[height|Encyclopedia][$encyclopedia = "Weight"]], and [[pregnancy|Encyclopedia][$encyclopedia = "Pregnancy"]] all detract from deadliness.
-
+<br><br>
 Skilled, intelligent, and devoted Bodyguards may become concerned that they have no potential successor if you do not keep several other combat capable slaves in your penthouse. Such a Bodyguard will do her best to find responsible and physically capable slaves to teach self defense to when she can. Potential recipients of this training include her lover or wife if she has one, the [[Head Girl|Encyclopedia][$encyclopedia = "Head Girl"]], the [[Wardeness|Encyclopedia][$encyclopedia = "Wardeness"]], and your [[Concubine|Encyclopedia][$encyclopedia = "Concubine"]].
-<<case "Concubine">>\
+
+
+<<case "Concubine">>
 A ''Concubine'' can be selected once the [[Master Suite|Encyclopedia][$encyclopedia = "Master Suite"]] facility is built. Concubines benefit from high beauty and sexual skills in the same way as public servants; they should also be extremely devoted. Concubines do not apply any bonuses to other slaves in the master suite; rather, they enjoy the game's single most efficient production of reputation themselves.
-<<case "DJ">>\
+
+
+<<case "DJ">>
 //My name is Danni Diemen, and I'm here today to talk about the prettiest girls in the Free Cities. That's right, DJs! When a slave bitch says, "Sweetie, I'm not that kind of girl," she's lying. She's a slave, and she is that kind of girl! So, have your way with her.
-
+<br><br>
 Except if she's a DJ. Then she probably isn't that kind of girl after all! Rare, I know. That's what makes them so hot! Some of the Free Cities' most prominent slaveowners have taken sluttery to the next level. They're building clubs designed around constant beats and constant sex, so it pays to have a hot girl maintain the party, whether it's up on stage, in the DJ booth, or down on the floor!
-
+<br><br>
 As for what makes a good DJ, beauty is obvious. But I also I hear the best trend a little older, too. Let's be honest, there's something a high-class woman has that a high-class girl doesn't.
-
+<br><br>
 -- Van Diemen, D. C. G., //Free Cities Fashion (FCF), January 2032////
-
+<br><br>
 
 A ''DJ'' can be selected once the [[Club|Encyclopedia][$encyclopedia = "Club"]] facility is built. DJs apply a multiplier to reputation gains from serving in the club. Entertainment skills, toned but not massive muscles, intelligence, and a pretty face make a good DJ.
-
+<br><br>
 If a DJ isn't responsible for enough sluts to occupy her full time, she'll spend time fucking citizens herself. This is exactly the same as [[Public Service|Encyclopedia][$encyclopedia = "Public Service"]] out of the Club: she'll benefit from any [[Advertising|Encyclopedia][$encyclopedia = "Advertising"]] or [[Variety|Encyclopedia][$encyclopedia = "Variety"]] bonuses available, and will even benefit from her own leadership skills.
-<<case "Head Girl">>\
+
+
+<<case "Head Girl">>
 //Most Free Cities slaveowners eventually find it convenient to promote a trusty slave to a position over others. The stable of slaves necessary to present a proper public image has become so large that assistance managing and overseeing slaves is quite useful. In addition, such a slave can be an example to lesser livestock.
-
+<br><br>
 A good head girl will be devoted to her master and sexually skilled. Experienced slaveowners have also found that an older slave girl is often more effective than a young one. Since slavery is new, older slave girls will have spent part of their adult lives as free women, and have a deeper body of life experience to draw on.
-
+<br><br>
 Naturally, some slaveowners form a strong emotional bond with their Head Girl. Trusting and relying on a close companion can begin to resemble Old World relationships. It is a paradox of modern Free Cities life that such closeness is strongly frowned upon. Rumors that a prominent person is emotionally involved with his or her Head Girl can be as socially devastating as rumors of infidelity were a hundred years ago.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-
+<br><br>
 
 A ''Head Girl'' can be selected from among your Devoted slaves immediately. Duties are numerous, but mostly involve training slaves. They will generally train whichever girls they think appropriate, but can be given some direction on the same menu used to select one. Giving your Head Girl a suite and a personal slave will allow her to train an extra slave each week, an extremely powerful ability. [[Devotion|Encyclopedia][$encyclopedia = "Devotion"]], intelligence, and age over 35 all help Head Girls do well. Head Girls will do better if they are comfortable with the arcology's [[lingua franca|Encyclopedia][$encyclopedia = "Lingua Franca"]]. Skills are required when teaching that skill, meaning that slaves without vaginas cannot teach vaginal skills. Conversely, slaves with functional dicks are better at teaching other sexual skills.
-<<case "Madam">>\
+
+
+<<case "Madam">>
 //Prostitution is indeed the oldest profession. It follows that the madam is probably the oldest managerial position.
-
+<br><br>
 Free madams are very common in the Free Cities. As free prostitutes are priced out of their profession by slaves, many of the wealthiest are purchasing slaves and setting themselves up as madams. However, slave madams are becoming common as well.
-
+<br><br>
 The selling of sex is one of the largest growth markets in the Free Cities. As has been confidently predicted by economists since the first Free City was founded, the near-anarchy of these new polities has accelerated the concentration of wealth that began in the final years of the twentieth century. Thus, the majority of free citizens of the Cities own no slaves, while the majority of slaves are owned by a very few extremely wealthy persons. Extremely large stables of slave whores are becoming common for those in the industry.
-
+<br><br>
 Managing this many prostitutes is a science and an art. Naturally, it is not difficult to find slaves that are experienced in the sex trade. Setting slaves over other slaves has been a part of human slavery for all of recorded history; all of the tropes that once applied to the slave overseer in the field or the quarry now apply to the slave Madam in the brothel. The more experience they have in the field, the better they do.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-
+<br><br>
 
 A ''Madam'' can be selected once the [[Brothel|Encyclopedia][$encyclopedia = "Brothel"]] facility is built. Madams apply a multiplier to income from the brothel. Whoring skills, age over 35, intelligence, and a functional cock help a Madam.
-
+<br><br>
 If a Madam isn't managing enough whores to occupy her full time, she'll sell herself as much as she has time for. This is exactly the same as [[Whoring|Encyclopedia][$encyclopedia = "Whoring"]] out of the Brothel: she'll benefit from any [[Advertising|Encyclopedia][$encyclopedia = "Advertising"]] or [[Variety|Encyclopedia][$encyclopedia = "Variety"]] bonuses available, and will even benefit from her own management skills.
-<<case "Milkmaid">>\
+
+
+<<case "Milkmaid">>
 Most slaveowners get into dairy as a hobby. Why not? It's fun, tasty, and sexy. But sooner or later, almost everyone who starts out with a few low-volume milkers hears the call of mass production. After all, if it's hot to have one slave to use as the milking machine holds her down, it's hotter to have a whole row of moaning milkers at your mercy.
-
+<br><br>
 Unfortunately, the everyday work of husbandry goes from an amusement to a chore as a herd grows. Helping a tired slave cow with huge tits up from a long milking is fun once a day, but it gets bothersome and backbreaking the tenth time one does it. What's to be done?
-
+<br><br>
 Train a milkmaid! Any decently obedient slave will do, but the stronger the better. As you probably know by now, just because slave husbandry involves human stock doesn't mean it isn't hard work, just like traditional stock keeping! The traditional image of milkmaids might be girly and innocent, but we're after a good hale bitch that can lift, carry and scrub from dawn to dusk. If you're looking to economize, you can even use a slave too old or ugly to appeal in other, more sexual jobs. After all, when it comes to the third milking of the day, cows don't care how pretty the hands that examine their tits are.
-
+<br><br>
 -- Banaszewski, Valerie P., //Free Cities Husbandry Weekly, February 16, 2032//
-
-
+<br><br>
 
 A ''Milkmaid'' can be selected once the [[Dairy|Encyclopedia][$encyclopedia = "Dairy"]] facility is built. Having applicable career experience and strong muscles allow a Milkmaid to help cows maintain their health. If a Milkmaid is Funny or Caring, she can improve cow's Trust resting point; if she has oral skills, she can improve their Devotion resting point.<<if $seeDicks != 0>> If she has a very large dick capable of erection, a Milkmaid can assist cows with ejaculation if the Dairy is not already stimulating prostates.<</if>>
-<<case "Nurse">>\
+
+
+<<case "Nurse">>
 An ''Nurse'' can be selected once the [[Clinic|Encyclopedia][$encyclopedia = "Clinic"]] facility is built. Nurses increase [[health|Encyclopedia][$encyclopedia = "Health"]] gains in the Clinic. Good Nurses are dominant, highly intelligent, physically fit, and very beautiful.
-<<case "Recruiter">>\
+
+
+<<case "Recruiter">>
 A ''Recruiter'' can be selected from among your Devoted slaves immediately. [[Devotion|Encyclopedia][$encyclopedia = "Devotion"]], intelligence, entertainment skills, and luxurious living standards help a Recruiter convince vulnerable people to submit to voluntary enslavement. Each targetable group is also more sympathetic to an appropriate recruiter:
 &nbsp;&nbsp;&nbsp;&nbsp;Desperate whores: a sexually veteran recruiter
 &nbsp;&nbsp;&nbsp;&nbsp;Expectant mothers: a visibly pregnant recruiter
 &nbsp;&nbsp;&nbsp;&nbsp;Young migrants: a [[healthy|Encyclopedia][$encyclopedia = "Health"]] and pretty recruiter
 &nbsp;&nbsp;&nbsp;&nbsp;Dissolute sissies: a recruiter with a working dick
 &nbsp;&nbsp;&nbsp;&nbsp;Reassignment candidates: a pretty recruiter without working female reproductive organs
-
+<br><br>
 Once your household reaches a significant number of slaves you may direct the Recruiter to do publicity instead of acquisitions, for a boost to reputation and possibly advancing [[future societies|Encyclopedia][$encyclopedia = "Future Societies"]]. Activating this ability does not influence any other means of obtaining new slaves. (Note that "Facilities & leadership" includes the Recruiter herself and a slot for Head Girl, two positions that do not require a facility.)
-<<case "Schoolteacher">>\
+
+
+<<case "Schoolteacher">>
 A ''Schoolteacher'' can be selected once the [[Schoolroom|Encyclopedia][$encyclopedia = "Schoolroom"]] facility is built. Schoolteachers increase the rate at which students in the schoolroom learn. Good Schoolteachers are older than 35, beautiful, intelligent, and educated.
-<<case "Stewardess">>\
+
+
+<<case "Stewardess">>
 //Throughout recorded history, wherever there have been mature slave societies, there have been slave overseers set over their peers by their masters. Naturally, these individuals have simultaneously been among the most trusted to their masters, and among the most hated to their compatriots in slavery. They have perhaps the greatest interest in preservation of a slave society, since the masters have only the loss of property to fear by abolition; slave overseers would likely be less lucky.
-
+<br><br>
 The Stewardess is the modern, domestic expression of the old overseer. Many wealthy slaveowners keep an extensive stable of less valuable slaves around their estates to serve as labor, raw material for slave training, and targets for recreational abuse. Successful oversight of this often mulish mass of stock requires a high degree of devotion to the master's will, of course. Good health to put in the necessarily long hours also helps. Some slaveowners also find that a functional dick allows a Stewardess to add a useful element of sexual abuse to her ministrations.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-
+<br><br>
 
 A ''Stewardess'' can be selected once the [[Servants' Quarters|Encyclopedia][$encyclopedia = "Servants' Quarters"]] facility is built. Stewardesses increase the upkeep reduction effects of servants working out of the servants' quarters. Being older than 35, having good [[Health|Encyclopedia][$encyclopedia = "health"]], intelligence, and nymphomania or dominance make a good Stewardess.
-<<case "Wardeness">>\
+
+
+<<case "Wardeness">>
 A ''Wardeness'' can be selected once the [[Cellblock|Encyclopedia][$encyclopedia = "Cellblock"]] facility is built. Wardenesses increase the rate at which slaves in the cellblock are broken. Very high [[devotion|Encyclopedia][$encyclopedia = "Devotion"]], nymphomania or sadism, strong muscles, and a solid dick make a powerful Wardeness.
 /**********
 
 SLAVE ASSIGNMENTS (COMMON):
 
 **********/
-<<case "Attending Classes">>\
+
+
+<<case "Attending Classes">>
 ''Attending classes'' is an assignment which educates the slave, raising intelligence if possible. Being educated raises value and is useful for some jobs and leadership positions. //Associated facility: [[Schoolroom|Encyclopedia][$encyclopedia = "Schoolroom"]]//
-<<case "Confinement">>\
+
+
+<<case "Confinement">>
 ''Confinement'' is an assignment which accelerates breaking for disobedient slaves. If a slave isn't obedient enough to work and isn't [[unhealthy|Encyclopedia][$encyclopedia = "Health"]] enough to need rest, this will make her useful sooner. //Associated facility: [[Cellblock|Encyclopedia][$encyclopedia = "Cellblock"]]//
-<<case "Fucktoy">>\
+
+
+<<case "Fucktoy">>
 ''Fucktoy service'' is an assignment which keeps the slave close under the player's eye; mostly just for fun, but fucktoys do improve reputation based on their beauty, and the player character's attention can be targeted to areas of the slave's body with possible fetish effects on happy slaves. //Associated facility: [[Master Suite|Encyclopedia][$encyclopedia = "Master Suite"]]//
-<<case "Glory Hole">>\
+
+
+<<case "Glory Hole">>
 ''Occupying a glory hole'' is an assignment which makes money off slaves regardless of their beauty, skills, or feelings; not fun or [[Healthy|Encyclopedia][$encyclopedia = "Health"]]. Very powerful for extracting ¤ out of otherwise useless slaves. //Associated facility: [[Arcade|Encyclopedia][$encyclopedia = "Arcade"]]//
-<<case "Milking">>\
+
+
+<<case "Milking">>
 ''Getting milked'' is an assignment which makes money from lactation based on a slave's breasts, [[health|Encyclopedia][$encyclopedia = "Health"]], and hormonal status.<<if $seeDicks > 0>> Cows with balls will also give semen.<</if>> Creates profit quickly from slaves with big tits<<if $seeDicks > 0>> or balls<</if>>. //Associated facility: [[Dairy|Encyclopedia][$encyclopedia = "Dairy"]]//
-<<case "Public Service">>\
+
+
+<<case "Public Service">>
 ''Public Service'' is an assignment which increases reputation based on a slave's beauty, sexual appeal, and skills. Very similar to whoring, but for reputation rather than money. //Associated facility: [[Club|Encyclopedia][$encyclopedia = "Club"]]//
-<<case "Rest">>\
+
+
+<<case "Rest">>
 ''Rest'' is an assignment mostly used to improve [[health|Encyclopedia][$encyclopedia = "Health"]]. It can be useful to order slaves you wish to intensively modify to rest, since most modifications damage health. It will synergize with curative treatments, providing bonus healing when both are simultaneously applied. //Associated facilities: [[Spa|Encyclopedia][$encyclopedia = "Spa"]], [[Clinic|Encyclopedia][$encyclopedia = "Clinic"]]//
-<<case "Sexual Servitude">>\
+
+
+<<case "Sexual Servitude">>
 ''Sexual servitude'' is an assignment which pleases other slaves by forcing the slave to service them sexually. Useful for driving the targeted slave's [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] up quickly.
-<<case "Servitude">>\
+
+
+<<case "Servitude">>
 ''Servitude'' is an assignment which reduces your upkeep based on the slave's [[devotion|Encyclopedia][$encyclopedia = "Devotion"]]. Available at lower obedience than other jobs, is insensitive to the quality of a slave's body, and doesn't require skills; a good transitional assignment. Unusually, low sex drive is advantageous as a servant, since it reduces distraction. Lactating slaves are slightly better at this job, since they can contribute to their fellow slaves' nutrition. //Associated facility: [[Servants' Quarters|Encyclopedia][$encyclopedia = "Servants' Quarters"]]//
-<<case "Whoring">>\
+
+
+<<case "Whoring">>
 ''Whoring'' is an assignment which makes money based on a slave's beauty, sexual appeal, and skills. Good whores take a long time to train and beautify but become very profitable. //Associated facility: [[Brothel|Encyclopedia][$encyclopedia = "Brothel"]]//
 /**********
 
 SLAVE BODY:
 
 **********/
-<<case "Body">>\
+
+
+<<case "Body">>
 //Future room for lore text//
-
+<br><br>
 Choose a more particular entry below:
-\
-<<case "Anuses">>\
+
+
+
+<<case "Anuses">>
 Slaves' ''anuses'' are a valuable commodity. Like [[vaginas|Encyclopedia][$encyclopedia = "Vaginas"]], they appear in four degrees of tightness: virgin and three increasing levels of looseness. Tighter anuses improve performance at sexual assignments, but most methods of learning [[anal skill|Encyclopedia][$encyclopedia = "Anal Skill"]] tend to loosen anuses. Assigning a virgin to sex work will result in a one-time bonus to performance, but may anger her and can result in skipping up one level of looseness. A virgin anus applies a moderate cost multiplier for slave purchase or sale. Anuses can be loosened by events, strenuous sex work, or plug accessories; they can be tightened with rest from strenuous sex work, personal attention, or the autosurgery, though such surgery can reduce [[anal skill|Encyclopedia][$encyclopedia = "Anal Skill"]].
-<<case "Areolae">>\
+
+
+<<case "Areolae">>
 Slaves' ''areolae'' can be altered in size or shape through surgery. (wiki: needs more technical detail)
-<<case "Breasts">>\
+
+
+<<case "Breasts">>
 Slaves' ''breasts'' contribute to beauty. They can be enlarged with [[XX hormones|Encyclopedia][$encyclopedia = "Hormones (XX)"]], intense [[lactation|Encyclopedia][$encyclopedia = "Lactation"]], weight gain, or surgery (which [[boob fetishists|Encyclopedia][$encyclopedia = "Boob Fetishists"]] will be grateful for).
-<<case "Butts">>\
+
+
+<<case "Butts">>
 Slaves' ''butts'' contribute to beauty. They can be enlarged with [[XX hormones|Encyclopedia][$encyclopedia = "Hormones (XX)"]], weight gain, or surgery (which [[buttsluts|Encyclopedia][$encyclopedia = "Buttsluts"]] will be grateful for).
-<<case "Clits">>\
+
+
+<<case "Clits">>
 Slaves' ''clits'' contribute to beauty. (wiki: needs more technical detail)/*how are clits tied to dicks, vaginas, and hormones?*/
-<<case "Dicks">>\
+
+
+<<case "Dicks">>
 Slaves' ''dicks'' are less straightforward than [[anuses|Encyclopedia][$encyclopedia = "Anuses"]] or [[vaginas|Encyclopedia][$encyclopedia = "Vaginas"]]. At game start, larger dicks reduce slave value, though this can be reduced or even reversed by some future society choices. Slaves will remain capable of erection so long as they retain [[testicles|Encyclopedia][$encyclopedia = "Testicles"]] and are not on [[female hormone treatments|Encyclopedia][$encyclopedia = "Hormones (XX)"]].
-
+<br><br>
 [[Clits?|Encyclopedia][$encyclopedia = "Clits"]]. /*how do dicks and clits relate, future coder?*/
-<<case "Ethnicity">>\
-Slaves' ''ethnicity'' affects random slave generation; the game produces bodies according to broad phenotypes. For example, black hair is almost universal among randomly generated asian slaves. Its only other impact at game start is that white slaves enjoy a minor bonus to beauty, modeling the near-universal reach of western standards of beauty. Racially based future societies can apply ethnic bonuses or penalties to beauty, changing this landscape.
-<<case "Faces">>\
-Slaves' ''faces'' contribute heavily to beauty. They occur in six shapes and seven levels of attractiveness, which can be affected by surgery or, if the slave is unattractive or masculine, intensive [[XX hormones|Encyclopedia][$encyclopedia = "Hormones (XX)"]]. Unlike most other attributes, a slave's face cannot be improved more than two steps by surgery. The autosurgery upgrade removes this limitation.
 
+
+<<case "Ethnicity">>
+Slaves' ''ethnicity'' affects random slave generation; the game produces bodies according to broad phenotypes. For example, black hair is almost universal among randomly generated asian slaves. Its only other impact at game start is that white slaves enjoy a minor bonus to beauty, modeling the near-universal reach of western standards of beauty. Racially based future societies can apply ethnic bonuses or penalties to beauty, changing this landscape.
+
+
+<<case "Faces">>
+Slaves' ''faces'' contribute heavily to beauty. They occur in six shapes and seven levels of attractiveness, which can be affected by surgery or, if the slave is unattractive or masculine, intensive [[XX hormones|Encyclopedia][$encyclopedia = "Hormones (XX)"]]. Unlike most other attributes, a slave's face cannot be improved more than two steps by surgery. The autosurgery upgrade removes this limitation.
+<br><br>
 __Facial shapes and beauty__
 //Normal// faces have no impact on beauty; the slave's face affects beauty based on its attractiveness alone.
 //Exotic// faces exaggerate the impact of facial attractiveness on beauty: being exotic will make an ugly face worse and a beautiful face better.
@@ -673,411 +845,589 @@ __Facial shapes and beauty__
 //Cute// faces add a larger fixed bonus to attractiveness.
 //Androgynous// faces are moderately bad for attractiveness: [[gender fundamentalism|Encyclopedia][$encyclopedia = "Gender fundamentalism"]] accentuates this effect, while [[gender radicalism|Encyclopedia][$encyclopedia = "Gender Radicalism"]] reduces and at high levels even reverses it.
 //Masculine// faces are very negative: [[gender fundamentalism|Encyclopedia][$encyclopedia = "Gender Fundamentalism"]] accentuates this effect, while [[gender radicalism|Encyclopedia][$encyclopedia = "Gender Radicalism"]] reduces and at high levels can eliminate it.
-<<case "Height">>\
-Slaves' ''height'' contributes to beauty and improves combat effectiveness. It is measured in centimeters, though the game handles it in terms of ranges; beyond 190cm, all very tall slaves will be treated almost identically. Height can be affected by surgery, and younger slaves can also see minor hormonal impacts on height. Unlike most other attributes, a slave's height cannot be changed more than one step by surgery.
-<<case "Hips">>\
-Slaves' ''hips'' contribute to beauty. (wiki: needs more technical detail)
-<<case "Lactation">>\
-Slaves can begin to ''lactate'' two ways: naturally due to pregnancy, or artificially, through surgical implantation of a slow-release lactation-inducing drug pellet. Drug-induced lactation is more copious, but may damage [[health|Encyclopedia][$encyclopedia = "Health"]]. Larger [[breasts|Encyclopedia][$encyclopedia = "Breasts"]] will produce more milk, but not linearly: diminishing returns apply to bigger tits. Happy and [[healthy|Encyclopedia][$encyclopedia = "Health"]] cows are also more productive, and slaves with [[ovaries|Encyclopedia][$encyclopedia = "Ovaries"]] enjoy a bonus to milk production.
-<<case "Lips">>\
-Slaves' ''lips'' contribute to beauty. At very large sizes, they will alter dialog, though this has no mechanical effect. They can be enlarged with targeted growth hormones or surgery, but such surgery can reduce [[oral skill|Encyclopedia][$encyclopedia = "Oral Skill"]].
-<<case "Musculature">>\
-Slaves' ''musculature'' occurs in four levels, and affects combat effectiveness, beauty, and the effects of breasts. For combat, the penultimate level is best. At game start, musculature is a minor detriment to beauty, though this can be changed through future society choices. Extremely large breasts can begin to hinder slaves, but the first level of musculature will allow them to carry their burdens.
-<<case "Nipples">>\
-Slaves' ''nipples'' have varying effects, depending on their shape. Tiny nipples have a negative effect on beauty, puffy and inverted nipples improve it, huge nipples improve it more strongly, and all others have no effect. Inverted and partially inverted nipples can be permanently protruded by nipple piercings or milking: this is uncomfortable, and will reduce [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] unless the slave is a [[masochist|Encyclopedia][$encyclopedia = "Masochists"]].  Tiny nipples can be enlarged with [[XX hormones|Encyclopedia][$encyclopedia = "Hormones (XX)"]], huge nipples can be reduced with [[XY hormones|Encyclopedia][$encyclopedia = "Hormones (XY)"]], breast growth hormones will grow and may invert nipples, and breast implantation may damage nipples enough to shrink them slightly.
-<<case "Ovaries">>\
-Slaves' ''ovaries'' are necessary for pregnancy and provide a small amount of natural XX hormones. Oophorectomy, available with extreme content enabled, will render a slave barren and stop ovaries' hormonal effects, producing a slave with no natural hormones. Barren slaves do suffer penalties under some future society choices, but do not require costly contraceptives to avoid pregnancy. Ovaries grant a bonus to [[lactation|Encyclopedia][$encyclopedia = "Lactation"]].
-<<case "Pregnancy">>\
-Slaves require both [[vaginas|Encyclopedia][$encyclopedia = "Vaginas"]] and [[ovaries|Encyclopedia][$encyclopedia = "Ovaries"]] to become ''pregnant.'' Fertile slaves can be impregnated by the player character or a slave with [[testicles|Encyclopedia][$encyclopedia = "Testicles"]] from the fertile slave's individual menu. Otherwise, slaves with vaginas and ovaries who aren't wearing chastity belts or taking contraceptives, and have not had their tubes tied via surgery, will likely become pregnant if performing sexual jobs or if allowed to have sex with slaves with balls. Pregnancy has a number of minor physical effects and will induce [[lactation|Encyclopedia][$encyclopedia = "Lactation"]].
-<<case "Skin Distinctions">>\
-Slaves can have various ''skin distinctions,'' including freckles, heavy freckling, beauty marks, and birthmarks. Beauty marks and birthmarks can be removed in the Salon.
 
+
+<<case "Height">>
+Slaves' ''height'' contributes to beauty and improves combat effectiveness. It is measured in centimeters, though the game handles it in terms of ranges; beyond 190cm, all very tall slaves will be treated almost identically. Height can be affected by surgery, and younger slaves can also see minor hormonal impacts on height. Unlike most other attributes, a slave's height cannot be changed more than one step by surgery.
+
+
+<<case "Hips">>
+Slaves' ''hips'' contribute to beauty. (wiki: needs more technical detail)
+
+
+<<case "Lactation">>
+Slaves can begin to ''lactate'' two ways: naturally due to pregnancy, or artificially, through surgical implantation of a slow-release lactation-inducing drug pellet. Drug-induced lactation is more copious, but may damage [[health|Encyclopedia][$encyclopedia = "Health"]]. Larger [[breasts|Encyclopedia][$encyclopedia = "Breasts"]] will produce more milk, but not linearly: diminishing returns apply to bigger tits. Happy and [[healthy|Encyclopedia][$encyclopedia = "Health"]] cows are also more productive, and slaves with [[ovaries|Encyclopedia][$encyclopedia = "Ovaries"]] enjoy a bonus to milk production.
+
+
+<<case "Lips">>
+Slaves' ''lips'' contribute to beauty. At very large sizes, they will alter dialog, though this has no mechanical effect. They can be enlarged with targeted growth hormones or surgery, but such surgery can reduce [[oral skill|Encyclopedia][$encyclopedia = "Oral Skill"]].
+
+
+<<case "Musculature">>
+Slaves' ''musculature'' occurs in four levels, and affects combat effectiveness, beauty, and the effects of breasts. For combat, the penultimate level is best. At game start, musculature is a minor detriment to beauty, though this can be changed through future society choices. Extremely large breasts can begin to hinder slaves, but the first level of musculature will allow them to carry their burdens.
+
+
+<<case "Nipples">>
+Slaves' ''nipples'' have varying effects, depending on their shape. Tiny nipples have a negative effect on beauty, puffy and inverted nipples improve it, huge nipples improve it more strongly, and all others have no effect. Inverted and partially inverted nipples can be permanently protruded by nipple piercings or milking: this is uncomfortable, and will reduce [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] unless the slave is a [[masochist|Encyclopedia][$encyclopedia = "Masochists"]].  Tiny nipples can be enlarged with [[XX hormones|Encyclopedia][$encyclopedia = "Hormones (XX)"]], huge nipples can be reduced with [[XY hormones|Encyclopedia][$encyclopedia = "Hormones (XY)"]], breast growth hormones will grow and may invert nipples, and breast implantation may damage nipples enough to shrink them slightly.
+
+
+<<case "Ovaries">>
+Slaves' ''ovaries'' are necessary for pregnancy and provide a small amount of natural XX hormones. Oophorectomy, available with extreme content enabled, will render a slave barren and stop ovaries' hormonal effects, producing a slave with no natural hormones. Barren slaves do suffer penalties under some future society choices, but do not require costly contraceptives to avoid pregnancy. Ovaries grant a bonus to [[lactation|Encyclopedia][$encyclopedia = "Lactation"]].
+
+
+<<case "Pregnancy">>
+Slaves require both [[vaginas|Encyclopedia][$encyclopedia = "Vaginas"]] and [[ovaries|Encyclopedia][$encyclopedia = "Ovaries"]] to become ''pregnant.'' Fertile slaves can be impregnated by the player character or a slave with [[testicles|Encyclopedia][$encyclopedia = "Testicles"]] from the fertile slave's individual menu. Otherwise, slaves with vaginas and ovaries who aren't wearing chastity belts or taking contraceptives, and have not had their tubes tied via surgery, will likely become pregnant if performing sexual jobs or if allowed to have sex with slaves with balls. Pregnancy has a number of minor physical effects and will induce [[lactation|Encyclopedia][$encyclopedia = "Lactation"]].
+
+
+<<case "Skin Distinctions">>
+Slaves can have various ''skin distinctions,'' including freckles, heavy freckling, beauty marks, and birthmarks. Beauty marks and birthmarks can be removed in the Salon.
+<br><br>
 //Freckles// of both densities will slightly improve a slave's [[attractiveness score|Encyclopedia][$encyclopedia = "Slave Score (Attractiveness)"]] if she has pale or fair skin, and slightly improve it again if she has red hair.
 //Beauty marks,// otherwise known as facial moles, will improve a slave's [[attractiveness score|Encyclopedia][$encyclopedia = "Slave Score (Attractiveness)"]] if she has a gorgeous [[face|Encyclopedia][$encyclopedia = "Faces"]], reduce it if she has an average or worse face, and have no effect if she has a very pretty face.
 //Birthmarks// will improve a slave's attractiveness score if she is prestigious, and reduce it if she is not.
-<<case "Teeth">>\
-Slaves' ''teeth'' have a variety of impacts and can be customized in several ways.
 
+
+<<case "Teeth">>
+Slaves' ''teeth'' have a variety of impacts and can be customized in several ways.
+<br><br>
 //Normal, straight teeth// have a minor positive impact on [[attractiveness|Encyclopedia][$encyclopedia = "Slave Score (Attractiveness)"]].
 //Crooked teeth// have a minor negative impact on attractiveness. They can be fixed with braces, applied from the surgery.
 //Braces// have a negative impact on attractiveness, but less than crooked teeth, and will eventually straighten the slave's teeth. They can be applied to straight teeth or left on after they are no longer useful, if desired.
 <<if $seeExtreme == 1>>//Removable teeth// can pass as normal teeth and thus have no attractiveness impact, but do alter some sex scenes.
 //Pointed teeth// have a minor negative impact on attractiveness, but are intimidating, offering slight improvements to combat effectiveness and performance as a [[Bodyguard|Encyclopedia][$encyclopedia = "Bodyguard"]].<</if>>
-\
-<<case "Testicles">>\
-Slaves' ''testicles'' are necessary for erection and provide a small amount of natural XY hormones. At game start, larger testicles reduce slave value, though this can be reduced or even reversed by some future society choices. Orchiectomy, available with extreme content enabled, will stop testicles' hormonal effects, producing a slave with no natural hormones. It also has significant mental effects.
-<<case "Vaginas">>\
-Slaves' ''vaginas'' are a valuable commodity. Like [[anuses|Encyclopedia][$encyclopedia = "Anuses"]], they appear in four degrees of tightness: virgin and three increasing levels of looseness. Tighter vaginas improve performance at sexual assignments, but most methods of learning [[vaginal skill|Encyclopedia][$encyclopedia = "Anal Skill"]] tend to loosen anuses. Assigning a virgin to sex work will result in a one-time bonus to performance but may anger her; alternatively, a chastity belt can be used to preserve virginity during sexual assignments. A virgin vagina applies a large cost multiplier for slave purchase or sale. Vaginas can be loosened by events, strenuous sex work, or plug accessories; they can be tightened with rest from strenuous sex work, personal attention, or the autosurgery, though such surgery can reduce [[vaginal skill|Encyclopedia][$encyclopedia = "Vaginal Skill"]]. 
 
+
+
+<<case "Testicles">>
+Slaves' ''testicles'' are necessary for erection and provide a small amount of natural XY hormones. At game start, larger testicles reduce slave value, though this can be reduced or even reversed by some future society choices. Orchiectomy, available with extreme content enabled, will stop testicles' hormonal effects, producing a slave with no natural hormones. It also has significant mental effects.
+
+
+<<case "Vaginas">>
+Slaves' ''vaginas'' are a valuable commodity. Like [[anuses|Encyclopedia][$encyclopedia = "Anuses"]], they appear in four degrees of tightness: virgin and three increasing levels of looseness. Tighter vaginas improve performance at sexual assignments, but most methods of learning [[vaginal skill|Encyclopedia][$encyclopedia = "Anal Skill"]] tend to loosen anuses. Assigning a virgin to sex work will result in a one-time bonus to performance but may anger her; alternatively, a chastity belt can be used to preserve virginity during sexual assignments. A virgin vagina applies a large cost multiplier for slave purchase or sale. Vaginas can be loosened by events, strenuous sex work, or plug accessories; they can be tightened with rest from strenuous sex work, personal attention, or the autosurgery, though such surgery can reduce [[vaginal skill|Encyclopedia][$encyclopedia = "Vaginal Skill"]]. 
+<br><br>
 [[Clit?|Encyclopedia][$encyclopedia = "Clits"]]
-<<case "Waist">>\
+
+
+<<case "Waist">>
 Slaves' ''waist'' contributes to beauty. Waists can be altered permanently by corsets over time, or quickly in the surgery. (wiki: needs more technical detail)
-<<case "Weight">>\
+
+
+<<case "Weight">>
 Slaves' ''weight'' contributes to beauty. The middle three values (thin, average and curvy) are all considered equally good; outside that range, penalties are applied. Gaining and losing weight can cause changes to a slave's [[breast|Encyclopedia][$encyclopedia = "Breasts"]] and [[butt|Encyclopedia][$encyclopedia = "Butts"]] size, and will be different for [[anorexics|Encyclopedia][$encyclopedia = "Anorexic"]], [[gluttons|Encyclopedia][$encyclopedia = "Gluttonous"]], and [[fitness|Encyclopedia][$encyclopedia = "Fitness"]] fanatics.
-<<case "Hormones (XX)">>\
+
+
+<<case "Hormones (XX)">>
 ''XX Hormones'' are female hormones, either from hormone treatments or from [[ovaries|Encyclopedia][$encyclopedia = "Ovaries"]]. A hidden hormonal score is calculated for each slave:
  
 &nbsp;&nbsp;normal XX hormones provide +1
 &nbsp;&nbsp;heavy XX hormones provide +2
 &nbsp;&nbsp;[[Ovaries|Encyclopedia][$encyclopedia = "Ovaries"]] provide +1
 &nbsp;&nbsp;[[Testicles|Encyclopedia][$encyclopedia = "Testicles"]] provide -1
-
+<br><br>
 At a total of +1 with no ovaries present, XY attraction will increase, dicks will shrink, testicles will shrink, deep voices will be raised, small breasts and buttocks will grow, ugly faces will soften, huge clits will shrink, and extreme musculature will soften. 
-
+<br><br>
 At +2, all these effects become more likely and more extreme, and [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] and [[trust|Encyclopedia][$encyclopedia = "Trust"]] can both increase. 
-
+<br><br>
 Artificial hormonal effects can be accelerated by installing the second [[upgrade|Encyclopedia][$encyclopedia = "What the Upgrades Do"]] to the kitchen, which will also stop slave's assets from shrinking due to natural hormonal effects.
-<<case "Hormones (XY)">>\
-''XY Hormones'' are male hormones, either from hormone treatments or from [[Testicles|Encyclopedia][$encyclopedia = "Testicles"]]. A hidden hormonal score is calculated for each slave:
 
+
+<<case "Hormones (XY)">>
+''XY Hormones'' are male hormones, either from hormone treatments or from [[Testicles|Encyclopedia][$encyclopedia = "Testicles"]]. A hidden hormonal score is calculated for each slave:
+<br><br>
 &nbsp;&nbsp;normal XY hormones provide -1
 &nbsp;&nbsp;heavy XY hormones provide -2
 &nbsp;&nbsp;[[Ovaries|Encyclopedia][$encyclopedia = "Ovaries"]] provide +1
 &nbsp;&nbsp;[[Testicles|Encyclopedia][$encyclopedia = "Testicles"]] provide -1
-
+<br><br>
  At a total of -1, XY attraction will increase, large breasts and buttocks will shrink, and clits will grow. 
-
+<br><br>
 At +2, all these effects become more likely and more extreme, [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] can decrease, dicks and testicles will grow, voices will deepen, and faces will become uglier. 
-
+<br><br>
 Artificial hormonal effects can be accelerated by installing the second [[upgrade|Encyclopedia][$encyclopedia = "What the Upgrades Do"]] to the kitchen, which will also stop slave's assets from shrinking due to natural hormonal effects.
 /**********
 
 SLAVE SKILLS
 
 **********/
-<<case "Skills">>\
-//Future room for lore text//
 
+
+<<case "Skills">>
+//Future room for lore text//
+<br><br>
 Choose a more particular entry below:
-\
-<<case "Anal Skill">>\
+
+
+
+<<case "Anal Skill">>
 ''Anal skill'' improves performance on sexual assignments and is available in three levels. Training methods include schooling (up to level one), plugs (up to level one), personal attention (unlimited), Head Girl attention (up to the Head Girl's skill), and on the job experience (unlimited). [[Anus|Encyclopedia][$encyclopedia = "Anuses"]] surgery can reduce this skill.
-<<case "Combat Skill">>\
+
+
+<<case "Combat Skill">>
 ''Combat skill'' is available in one level only. It improves performance in lethal and nonlethal pit fights and performance as the Bodyguard. Training methods are limited to on the job experience (including pit fights) and events.
-<<case "Entertainment Skill">>\
+
+
+<<case "Entertainment Skill">>
 ''Entertainment skill'' is available in three levels. It improves performance on all sexual assignments, though it affects public service or working in the club most. Training methods include schooling (up to level one), personal attention (up to level one), Head Girl attention (up to the Head Girl's skill), and on the job experience (unlimited).
-<<case "Oral Skill">>\
+
+
+<<case "Oral Skill">>
 ''Oral skill'' improves performance on sexual assignments and is available in three levels. Training methods include schooling (up to level one), gags (up to level one), personal attention (unlimited), Head Girl attention (up to the Head Girl's skill), and on the job experience (unlimited). [[Lip|Encyclopedia][$encyclopedia = "Lips"]] surgery can reduce this skill.
-<<case "Vaginal Skill">>\
+
+
+<<case "Vaginal Skill">>
 ''Vaginal skill'' improves performance on sexual assignments and is available in three levels. Training methods include schooling (up to level one), plugs (up to level one), personal attention (unlimited), Head Girl attention (up to the Head Girl's skill), and on the job experience (unlimited). Slaves without vaginas cannot learn or teach this skill, limiting their ultimate skill ceiling. [[Vagina|Encyclopedia][$encyclopedia = "Vaginas"]] surgery can reduce this skill.
-<<case "Whoring Skill">>\
+
+
+<<case "Whoring Skill">>
 ''Whoring skill'' is available in three levels. It improves performance on all sexual assignments, though it affects whoring or working in the brothel most. Training methods include schooling (up to level one), personal attention (up to level one), Head Girl attention (up to the Head Girl's skill), and on the job experience (unlimited).
 /**********
 
 SLAVE FETISHES:
 
 **********/
-<<case "Fetishes">>\
+
+
+<<case "Fetishes">>
 //Future room for lore text//
-
+<br><br>
 Choose a more particular entry below:
-\
 
-<<case "Boob Fetishists">>\
+<br><br>
+
+
+<<case "Boob Fetishists">>
 ''Boob Fetishists'' like breasts. 
-
+<br><br>
 The fetish can be created by appropriate smart clit piercing settings, serving the Head Girl, relationships, and being milked. 
-
+<br><br>
 It can be advanced by appropriate smart clit piercing settings, high [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] and [[trust|Encyclopedia][$encyclopedia = "Trust"]], and being milked. 
-
+<br><br>
 The fetish will increase XX attraction. Boob Fetishists enjoy cowbell collars, breast surgery, and being milked. Milkmaids can become boob fetishists naturally.
-<<case "Buttsluts">>\
+
+
+<<case "Buttsluts">>
 ''Buttsluts'' fetishize anal sex - mostly on the receiving end, though they'll enjoy other anal play. 
-
+<br><br>
 The fetish can be created by appropriate smart clit piercing settings, serving the Head Girl, relationships, anally focused fucktoy service, service in a [[Dairy|Encyclopedia][$encyclopedia = "Dairy"]] upgraded with reciprocating dildos, the dildo drug dispenser upgrade, anal accessories, and being a painal queen. 
-
+<br><br>
 It can be advanced by appropriate smart clit piercing settings, high [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] and [[trust|Encyclopedia][$encyclopedia = "Trust"]], the dildo drug dispenser upgrade, and being a painal queen. 
-
+<br><br>
 Buttsluttery will soften the 'hates anal' flaw into 'painal queen,' the 'hates penetration' flaw into 'strugglefuck queen,' and the 'repressed' flaw into 'perverted,' or remove these flaws if a quirk is already present. Buttsluts with vaginas enjoy wearing chastity belts, and all buttsluts enjoy buttock enhancement and anal rejuvenation surgeries. Buttsluts do not mind a lack of hormonal feminization. The fetish will increase XY attraction.
-<<case "Cumsluts">>\
+
+
+<<case "Cumsluts">>
 ''Cumsluts'' fetishize oral sex and ejaculate. 
-
+<br><br>
 The fetish can be created by appropriate smart clit piercing settings, serving the Head Girl, relationships, orally focused fucktoy service, the phallic food dispenser upgrade, cum diets, and being a gagfuck queen. 
-
+<br><br>
 It can be advanced by appropriate smart clit piercing settings, high [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] and [[trust|Encyclopedia][$encyclopedia = "Trust"]], the phallic food dispenser upgrade, cum diets, and being a gagfuck queen.
-
+<br><br>
 Cumsluttery will soften the 'hates oral' flaw into 'gagfuck queen,' the 'hates women' flaw into 'adores men,' and the 'repressed' flaw into 'perverted,' or remove these flaws if a quirk is already present. Cumsluts enjoy cum diets. The fetish will increase XY attraction.
-<<case "Doms">>\
+
+
+<<case "Doms">>
 ''Doms'' fetishize dominance. 
-
+<br><br>
 The fetish can be created by appropriate smart clit piercing settings, serving the Head Girl, relationships, unfocused fucktoy service, and being confident or cutting. 
-
+<br><br>
 It can be advanced by appropriate smart clit piercing settings, high [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] and [[trust|Encyclopedia][$encyclopedia = "Trust"]], being confident, and being cutting. 
-
+<br><br>
 Dominance will remove the apathetic flaw if a quirk is already present. Doms do not mind a lack of hormonal feminization. The fetish will increase XX attraction. Stewardesses and Nurses do better when dominant; the Head Girl, Madams, Schoolteachers, Stewardesses, and Nurses can become Doms naturally.
-<<case "Humiliation Fetishists">>\
+
+
+<<case "Humiliation Fetishists">>
 ''Humiliation Fetishists'' like exhibitionism. 
-
+<br><br>
 The fetish can be created by appropriate smart clit piercing settings, serving the Head Girl, relationships, or being sinful, a tease, or perverted. 
-
+<br><br>
 It can be advanced by appropriate smart clit piercing settings, high [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] and [[trust|Encyclopedia][$encyclopedia = "Trust"]], being sinful, being a tease, and being perverted. 
-
+<br><br>
 A humiliation fetish will soften the 'bitchy' flaw into 'cutting' and the 'shamefast' flaw into 'tease,' or remove these flaws if a quirk is already present. The fetish will increase XY attraction. Humiliation fetishists enjoy nudity, and like revealing clothing at a lower devotion than other slaves. DJs can become humiliation fetishists naturally.
-<<case "Masochists">>\
+
+
+<<case "Masochists">>
 ''Masochists'' fetishize abuse and pain aimed at themselves. 
-
+<br><br>
 The fetish can be created by appropriate smart clit piercing settings, serving the Head Girl, relationships, uncomfortable clothing, being funny, and being a strugglefuck queen. 
-
+<br><br>
 It can be advanced by appropriate smart clit piercing settings, high [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] and [[trust|Encyclopedia][$encyclopedia = "Trust"]], being funny, and being a strugglefuck queen. 
-
+<br><br>
 Masochism will soften the liberated flaw into advocate or remove this flaw if a quirk is already present. Masochists can be abused without causing deleterious flaws.
-<<case "Pregnancy Fetishists">>\
+
+
+<<case "Pregnancy Fetishists">>
 ''Pregnancy Fetishists'' like being impregnated, sex with pregnant slaves, and getting others pregnant. (It is not necessary that the slave actually be able to do any of these things; such is life.) 
-
+<br><br>
 The fetish can be created by appropriate smart clit piercing settings, serving the Head Girl, relationships, having sex while pregnant, adoring men, being a tease, and being romantic. 
-
+<br><br>
 It can be advanced by appropriate smart clit piercing settings, high [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] and [[trust|Encyclopedia][$encyclopedia = "Trust"]], adoring men, being a tease, and being romantic. 
-
+<br><br>
 The fetish will increase XY attraction. Pregnancy fetishists greatly enjoy all kinds of impregnation, and love or hate fertility surgeries depending on what's being changed.
-<<case "Sadists">>\
+
+
+<<case "Sadists">>
 ''Sadists'' fetishize abuse and pain aimed at others. 
-
+<br><br>
 The fetish can be created by appropriate smart clit piercing settings, serving the Head Girl, and relationships. 
-
+<br><br>
 It can be advanced by appropriate smart clit piercing settings, and high [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] and [[trust|Encyclopedia][$encyclopedia = "Trust"]]. 
-
+<br><br>
 Sadists do not mind a lack of hormonal feminization. The fetish will increase XX attraction. Wardenesses do better when sadistic, and can become sadists naturally.
-<<case "Submissives">>\
+
+
+<<case "Submissives">>
 ''Submissives'' fetishize submission. 
-
+<br><br>
 The fetish can be created by appropriate smart clit piercing settings, serving the Head Girl, relationships, unfocused fucktoy service, crawling due to damaged tendons, being caring, being an advocate, and being insecure. 
-
+<br><br>
 It can be advanced by appropriate smart clit piercing settings, high [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] and [[trust|Encyclopedia][$encyclopedia = "Trust"]], being caring, being an advocate, and being insecure. 
-
+<br><br>
 Submissiveness will soften the 'arrogant' flaw into 'confident,' the 'apathetic' flaw into 'caring,' and the 'idealistic' flaw into 'romantic,' or remove these flaws if a quirk is already present. The fetish will increase XY attraction. It improves performance at the servant assignment and working in the Servants' Quarters. Attendants do better when submissive, and can become submissives naturally.
 /**********
 
 SLAVE BEHAVIORAL QUIRKS
 
 **********/
-<<case "Quirks">>\
-''Quirks'' are positive slave qualities. They increase slaves' value and performance at sexual assignments, and each quirk also has other, differing effects. Each quirk is associated with a corresponding [[flaw|Encyclopedia][$encyclopedia = "Flaws"]], and slave can have two quirks (a sexual quirk and a behavioral quirk), just like flaws. Quirks may appear randomly, but the most reliable way to give slaves quirks is to soften flaws. 
 
+
+<<case "Quirks">>
+''Quirks'' are positive slave qualities. They increase slaves' value and performance at sexual assignments, and each quirk also has other, differing effects. Each quirk is associated with a corresponding [[flaw|Encyclopedia][$encyclopedia = "Flaws"]], and slave can have two quirks (a sexual quirk and a behavioral quirk), just like flaws. Quirks may appear randomly, but the most reliable way to give slaves quirks is to soften flaws. 
+<br><br>
 The [[head girl|Encyclopedia][$encyclopedia = "Head Girl"]] can be ordered to soften flaws, and the player character can soften flaws with personal attention. Flaws can also be naturally softened into quirks by fetishes.
-\
-<<case "Adores men">>\
+
+
+
+<<case "Adores men">>
 ''Adores men'' is a behavioral [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[hates women|Encyclopedia][$encyclopedia = "Hates women"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Slaves who adore men may naturally become [[pregnancy fetishists|Encyclopedia][$encyclopedia = "Pregnancy Fetishists"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[trust|Encyclopedia][$encyclopedia = "Trust"]] on [[fucktoy|Encyclopedia][$encyclopedia = "Fucktoy"]] duty if the player character is masculine, and increased chance of gaining additional XY attraction.
-\
-<<case "Adores women">>\
+
+
+
+<<case "Adores women">>
 ''Adores women'' is a behavioral [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[hates men|Encyclopedia][$encyclopedia = "Hates men"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Slaves who adore women may naturally become [[breast fetishists|Encyclopedia][$encyclopedia = "Boob Fetishists"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[trust|Encyclopedia][$encyclopedia = "Trust"]] on [[fucktoy|Encyclopedia][$encyclopedia = "Fucktoy"]] duty if the player character is feminine, and increased chance of gaining additional XX attraction.
-\
-<<case "Advocate">>\
+
+
+
+<<case "Advocate">>
 ''Advocate'' is a behavioral [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[liberated|Encyclopedia][$encyclopedia = "Liberated"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Advocates may naturally become [[submissives|Encyclopedia][$encyclopedia = "Submissives"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] while performing [[public service|Encyclopedia][$encyclopedia = "Public Service"]].
-\
-<<case "Confident">>\
+
+
+
+<<case "Confident">>
 ''Confident'' is a behavioral [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[arrogant|Encyclopedia][$encyclopedia = "Arrogant"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Confident slaves may naturally become [[dominant|Encyclopedia][$encyclopedia = "Doms"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[trust|Encyclopedia][$encyclopedia = "Trust"]] on [[fucktoy|Encyclopedia][$encyclopedia = "Fucktoy"]] duty.
-\
-<<case "Cutting">>\
+
+
+
+<<case "Cutting">>
 ''Cutting'' is a behavioral [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[bitchy|Encyclopedia][$encyclopedia = "Bitchy"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Cutting slaves may naturally become [[dominant|Encyclopedia][$encyclopedia = "Doms"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] while [[whoring|Encyclopedia][$encyclopedia = "Whoring"]].
-\
-<<case "Fitness">>\
+
+
+
+<<case "Fitness">>
 ''Fitness'' is a behavioral [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[gluttonous|Encyclopedia][$encyclopedia = "Gluttonous"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. In addition to the standard value and sexual assignment advantages, fitness fanatics gain additional sex drive each week, and are better at working out.
-\
-<<case "Funny">>\
+
+
+
+<<case "Funny">>
 ''Funny'' is a behavioral [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[odd|Encyclopedia][$encyclopedia = "Odd"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Funny slaves may naturally become [[masochists|Encyclopedia][$encyclopedia = "Masochists"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] while performing [[public service|Encyclopedia][$encyclopedia = "Public Service"]].
-\
-<<case "Insecure">>\
+
+
+
+<<case "Insecure">>
 ''Insecure'' is a behavioral [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[anorexic|Encyclopedia][$encyclopedia = "Anorexic"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Insecure slaves may naturally become [[submissives|Encyclopedia][$encyclopedia = "Submissives"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[trust|Encyclopedia][$encyclopedia = "Trust"]] on [[fucktoy|Encyclopedia][$encyclopedia = "Fucktoy"]] duty.
-\
-<<case "Sinful">>\
+
+
+
+<<case "Sinful">>
 ''Sinful'' is a behavioral [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[devout|Encyclopedia][$encyclopedia = "Devout"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Sinful slaves may naturally become [[humiliation fetishists|Encyclopedia][$encyclopedia = "Humiliation Fetishists"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] while [[whoring|Encyclopedia][$encyclopedia = "Whoring"]].
-\
+
 /**********
 
 SLAVE SEXUAL QUIRKS
 
 **********/
-<<case "Caring">>\
+
+
+<<case "Caring">>
 ''Caring'' is a sexual [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[apathetic|Encyclopedia][$encyclopedia = "Apathetic"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Caring slaves may naturally become [[pregnancy fetishists|Encyclopedia][$encyclopedia = "Pregnancy Fetishists"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] while [[whoring|Encyclopedia][$encyclopedia = "Whoring"]].
-\
-<<case "Gagfuck Queen">>\
+
+
+
+<<case "Gagfuck Queen">>
 ''Gagfuck Queen'' is a sexual [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[Hates oral|Encyclopedia][$encyclopedia = "Hates oral"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Gagfuck queens may naturally become [[cumsluts|Encyclopedia][$encyclopedia = "Cumsluts"]]. In addition to the standard value and sexual assignment advantages, they enjoy living in a penthouse upgraded with phallic food dispensers.
-\
-<<case "Painal Queen">>\
+
+
+
+<<case "Painal Queen">>
 ''Painal Queen'' is a sexual [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[Hates anal|Encyclopedia][$encyclopedia = "Hates anal"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Painal queens may naturally become [[Buttsluts|Encyclopedia][$encyclopedia = "Buttsluts"]]. In addition to the standard value and sexual assignment advantages, they enjoy living in a penthouse upgraded with dildo drug dispensers.
-\
-<<case "Perverted">>\
+
+
+
+<<case "Perverted">>
 ''Perverted'' is a sexual [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[repressed|Encyclopedia][$encyclopedia = "Repressed"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Perverted slaves may naturally become [[submissives|Encyclopedia][$encyclopedia = "Submissives"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] when in incestuous relationships, and gain additional sex drive each week.
-\
-<<case "Romantic">>\
+
+
+
+<<case "Romantic">>
 ''Romantic'' is a sexual [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[idealistic|Encyclopedia][$encyclopedia = "Idealistic"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Romantics may naturally become [[pregnancy fetishists|Encyclopedia][$encyclopedia = "Pregnancy Fetishists"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[trust|Encyclopedia][$encyclopedia = "Trust"]] on [[fucktoy|Encyclopedia][$encyclopedia = "Fucktoy"]] duty.
-\
-<<case "Size Queen">>\
+
+
+
+<<case "Size Queen">>
 ''Size Queen'' is a sexual [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[judgemental|Encyclopedia][$encyclopedia = "Judgemental"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Size queens may naturally become [[buttsluts|Encyclopedia][$encyclopedia = "Buttsluts"]]. In addition to the standard value and sexual assignment advantages, they will enjoy relationships with well-endowed, virile slaves so much their partners will get [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] benefits, too.
-\
-<<case "Strugglefuck Queen">>\
+
+
+
+<<case "Strugglefuck Queen">>
 ''Strugglefuck Queen'' is a sexual [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[hates penetration|Encyclopedia][$encyclopedia = "Hates penetration"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Strugglefuck queens may naturally become [[masochists|Encyclopedia][$encyclopedia = "Masochists"]]. In addition to the standard value and sexual assignment advantages, this Quirk avoids [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] losses if the slave is assigned to be a [[sexual servant|Encyclopedia][$encyclopedia = "Sexual Servitude"]].
-\
-<<case "Tease">>\
+
+
+
+<<case "Tease">>
 ''Tease'' is a sexual [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[shamefast|Encyclopedia][$encyclopedia = "Shamefast"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Teases may naturally become [[humiliation Fetishists|Encyclopedia][$encyclopedia = "Humiliation Fetishists"]]. In addition to the standard value and sexual assignment advantages, they get bonus [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] while performing [[public service|Encyclopedia][$encyclopedia = "Public Service"]].
-\
-<<case "Unflinching">>\
+
+
+
+<<case "Unflinching">>
 ''Unflinching'' is a sexual [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] developed from the [[crude|Encyclopedia][$encyclopedia = "Crude"]] [[flaw|Encyclopedia][$encyclopedia = "Flaws"]]. Unflinching slaves may naturally become [[Masochists|Encyclopedia][$encyclopedia = "Masochists"]]. In addition to the standard value and sexual assignment advantages, they will experience a partial rebound during weeks in which they lose [[devotion|Encyclopedia][$encyclopedia = "Devotion"]].
-\
+
 /**********
 
 SLAVE BEHAVIORAL FLAWS
 
 **********/
-<<case "Flaws">>\
-''Flaws'' are negative slave qualities. They decrease slaves' value and performance at sexual assignments, and each flaw also has other, differing effects. Each flaw is associated with a corresponding [[quirk|Encyclopedia][$encyclopedia = "Quirks"]], and slave can have two flaws (a sexual flaw and a behavioral flaw), just like quirks. New slaves will often have flaws, and tough experiences can also cause them to appear. 
 
+
+<<case "Flaws">>
+''Flaws'' are negative slave qualities. They decrease slaves' value and performance at sexual assignments, and each flaw also has other, differing effects. Each flaw is associated with a corresponding [[quirk|Encyclopedia][$encyclopedia = "Quirks"]], and slave can have two flaws (a sexual flaw and a behavioral flaw), just like quirks. New slaves will often have flaws, and tough experiences can also cause them to appear. 
+<br><br>
 The [[head girl|Encyclopedia][$encyclopedia = "Head Girl"]] can be ordered to soften or remove flaws, and the player character can soften or remove flaws with personal attention. Flaws can also be naturally softened or removed by fetishes, and can resolve on their own if a slave is happy.
-\
-<<case "Anorexic">>\
+
+
+
+<<case "Anorexic">>
 ''Anorexic'' is a behavioral [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[insecure|Encyclopedia][$encyclopedia = "Insecure"]] [[quirk|Encyclopedia][$encyclopedia = "Quirks"]]. In addition to the standard penalties to value and performance on sexual assignments, anorexia can cause unexpected weight loss. Anorexics will enjoy dieting but dislike gaining weight, and may bilk attempts to make them fatten up.
-\
-<<case "Arrogant">>\
+
+
+
+<<case "Arrogant">>
 ''Arrogant'' is a behavioral [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[confident|Encyclopedia][$encyclopedia = "Confident"]] [[quirk|Encyclopedia][$encyclopedia = "Quirks"]]. The [[submissive|Encyclopedia][$encyclopedia = "Submissives"]] fetish can do this naturally. In addition to the standard penalties to value and performance on sexual assignments, arrogance limits weekly [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] gains.
-\
-<<case "Bitchy">>\
+
+
+
+<<case "Bitchy">>
 ''Bitchy'' is a behavioral [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[cutting|Encyclopedia][$encyclopedia = "Cutting"]] [[quirk|Encyclopedia][$encyclopedia = "Quirks"]]. The [[humiliation|Encyclopedia][$encyclopedia = "Humiliation Fetishists"]] fetish can do this naturally. In addition to the standard penalties to value and performance on sexual assignments, bitchiness limits weekly [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] gains.
-\
-<<case "Devout">>\
+
+
+
+<<case "Devout">>
 ''Devout'' is a behavioral [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[sinful|Encyclopedia][$encyclopedia = "Sinful"]] [[quirk|Encyclopedia][$encyclopedia = "Quirks"]]. A very powerful sex drive can do this naturally. In addition to the standard penalties to value and performance on sexual assignments, being devout limits weekly [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] gains.
-\
-<<case "Gluttonous">>\
+
+
+
+<<case "Gluttonous">>
 ''Gluttonous'' is a behavioral [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[fitness|Encyclopedia][$encyclopedia = "Fitness"]] [[quirk|Encyclopedia][$encyclopedia = "Quirks"]]. In addition to the standard penalties to value and performance on sexual assignments, gluttons will enjoy gaining weight but dislike dieting, and may bilk attempts to make them lose weight.
-\
-<<case "Hates men">>\
+
+
+
+<<case "Hates men">>
 ''Hates men'' is a behavioral [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[adores women|Encyclopedia][$encyclopedia = "Adores women"]] [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] by training, a good [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]], a powerful sex drive, strong attraction to men, or the [[boob fetish|Encyclopedia][$encyclopedia = "Boob Fetishists"]]. The [[pregnancy fetish|Encyclopedia][$encyclopedia = "Pregnancy Fetishists"]] will soften it so she [[adores men|Encyclopedia][$encyclopedia = "Adores men"]] instead. This flaw can also be removed by serving a player character or another slave with a dick.
-\
-<<case "Hates women">>\
+
+
+
+<<case "Hates women">>
 ''Hates women'' is a behavioral [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[adores men|Encyclopedia][$encyclopedia = "Adores men"]] [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] by training, a good [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]], a powerful sex drive, strong attraction to men, or the [[cumslut|Encyclopedia][$encyclopedia = "Cumsluts"]] fetish. The [[pregnancy fetish|Encyclopedia][$encyclopedia = "Pregnancy Fetishists"]] will soften it so she [[adores women|Encyclopedia][$encyclopedia = "Adores women"]] instead. This flaw can also be removed by serving a player character or another slave with a vagina.
-\
-<<case "Liberated">>\
+
+
+
+<<case "Liberated">>
 ''Liberated'' is a behavioral [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[advocate|Encyclopedia][$encyclopedia = "Advocate"]] [[quirk|Encyclopedia][$encyclopedia = "Quirks"]]. The [[submissive|Encyclopedia][$encyclopedia = "Submissives"]] fetish can do this naturally. In addition to the standard penalties to value and performance on sexual assignments, being liberated limits weekly [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] gains.
-\
-<<case "Odd">>\
+
+
+
+<<case "Odd">>
 ''Odd'' is a behavioral [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[funny|Encyclopedia][$encyclopedia = "Funny"]] [[quirk|Encyclopedia][$encyclopedia = "Quirks"]]. The [[humiliation|Encyclopedia][$encyclopedia = "Humiliation Fetishists"]] fetish can do this naturally. In addition to the standard penalties to value and performance on sexual assignments, being odd limits weekly [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] gains.
-\
+
 /**********
 
 SLAVE SEXUAL FLAWS
 
 **********/
-<<case "Apathetic">>\
+
+
+<<case "Apathetic">>
 ''Apathetic'' is a sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[caring|Encyclopedia][$encyclopedia = "Caring"]]  [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] by training, a good [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]], a powerful sex drive, or the [[submissive|Encyclopedia][$encyclopedia = "Humiliation Submissive"]] fetish. It can also be removed by the [[dominant|Encyclopedia][$encyclopedia = "Doms"]] fetish.
-\
-<<case "Crude">>\
+
+
+
+<<case "Crude">>
 ''Crude'' is a sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[unflinching|Encyclopedia][$encyclopedia = "Unflinching"]] [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] by training, a good [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]], a powerful sex drive, or the [[buttslut|Encyclopedia][$encyclopedia = "Buttsluts"]] fetish.
-\
-<<case "Hates anal">>\
+
+
+
+<<case "Hates anal">>
 ''Hates anal'' is a sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[painal queen|Encyclopedia][$encyclopedia = "Painal Queen"]]  [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] by training, a good [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]], a powerful sex drive, or the [[buttslut|Encyclopedia][$encyclopedia = "Buttsluts"]] fetish. This flaw can also be removed by serving the player character.
-\
-<<case "Hates oral">>\
+
+
+
+<<case "Hates oral">>
 ''Hates oral'' is a sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[gagfuck queen|Encyclopedia][$encyclopedia = "Gagfuck Queen"]]  [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] by training, a good [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]], a powerful sex drive, or the [[cumslut|Encyclopedia][$encyclopedia = "Cumsluts"]] fetish. This flaw can also be removed by serving the player character.
-\
-<<case "Hates penetration">>\
+
+
+
+<<case "Hates penetration">>
 ''Hates penetration'' is a sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[strugglefuck queen|Encyclopedia][$encyclopedia = "Strugglefuck Queen"]] [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] by training, a good [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]], a powerful sex drive, or the [[buttslut|Encyclopedia][$encyclopedia = "Buttsluts"]] fetish. This flaw can also be removed by serving the player character.
-\
-<<case "Idealistic">>\
+
+
+
+<<case "Idealistic">>
 ''Idealistic'' is a sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[romantic|Encyclopedia][$encyclopedia = "Romantic"]]  [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] by training, a good [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]], a powerful sex drive, or the [[submissive|Encyclopedia][$encyclopedia = "Submissives"]] fetish.
-\
-<<case "Judgemental">>\
+
+
+
+<<case "Judgemental">>
 ''Judgemental'' is a sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the ''[[size queen|Encyclopedia][$encyclopedia = "Size Queen"]]'' [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] by training, a good [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]], a powerful sex drive, or the [[submissive|Encyclopedia][$encyclopedia = "Humiliation Submissive"]] fetish.
-\
-<<case "Repressed">>\
+
+
+
+<<case "Repressed">>
 ''Repressed'' is a sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[perverted|Encyclopedia][$encyclopedia = "Perverted"]]  [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] by training, a good [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]], a powerful sex drive, the [[cumslut|Encyclopedia][$encyclopedia = "Cumsluts"]] fetish, or the [[buttslut|Encyclopedia][$encyclopedia = "Buttsluts"]] fetish.
-\
-<<case "Shamefast">>\
+
+
+
+<<case "Shamefast">>
 ''Shamefast'' is a sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that can be softened into the [[tease|Encyclopedia][$encyclopedia = "Tease"]]  [[quirk|Encyclopedia][$encyclopedia = "Quirks"]] by training, a good [[Attendant|Encyclopedia][$encyclopedia = "Attendant"]], a powerful sex drive, or the [[humiliation|Encyclopedia][$encyclopedia = "Humiliation Fetishists"]] fetish.
-\
+
 /**********
 
 SLAVE PARAPHILIAS
 
 **********/
-<<case "Abusiveness">>\
+
+
+<<case "Abusiveness">>
 ''Abusiveness'' is a paraphilia, an intense form of sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that cannot be softened. 
-
+<br><br>
 [[Doms|Encyclopedia][$encyclopedia = "Doms"]] serving as [[head girl|Encyclopedia][$encyclopedia = "Head Girl"]] may become abusive if allowed to punish slaves by molesting them. They can be satisfied by work as the head girl or [[wardeness|Encyclopedia][$encyclopedia = "Wardeness"]]. Abusive head girls are more effective when allowed or encouraged to punish slaves severely.
-\
-<<case "Anal Addicts">>\
+
+
+
+<<case "Anal Addicts">>
 ''Anal addiction'' is a paraphilia, an intense form of sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that cannot be softened. 
-
+<br><br>
 [[Buttsluts|Encyclopedia][$encyclopedia = "Buttsluts"]] whose only available hole for receptive intercourse is the anus may become anal addicts. They can be satisfied by huge buttplugs, the sodomizing drug applicator kitchen upgrade, or by work that involves frequent anal sex. Anal addicts perform well on assignments involving anal sex.
-\
-<<case "Attention Whores">>\
+
+
+
+<<case "Attention Whores">>
 ''Attention Whores'' suffer from a paraphilia, an intense form of sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that cannot be softened. 
-
+<br><br>
 [[Humiliation Fetishists|Encyclopedia][$encyclopedia = "Humiliation Fetishists"]] on public sexual assignments may become Attention Whores. They can be satisfied by total nudity or by work that involves frequent public sex. Attention whores do very well at [[public service|Encyclopedia][$encyclopedia = "Public Service"]].
-\
-<<case "Breast Obsession">>\
+
+
+
+<<case "Breast Obsession">>
 ''Pectomania,'' also known as breast growth obsession, is a paraphilia, an intense form of sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that cannot be softened. 
-
+<br><br>
 [[Boob fetishists|Encyclopedia][$encyclopedia = "Boob Fetishists"]] may become obsessed with breast expansion as their breasts grow. They can be satisfied by breast injections or work as a cow, and will temporarily accept getting neither if their health is low.
-\
-<<case "Breeding Obsession">>\
+
+
+
+<<case "Breeding Obsession">>
 ''Breeding obsession'' is a paraphilia, an intense form of sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that cannot be softened. 
-
+<br><br>
 [[Pregnancy Fetishists|Encyclopedia][$encyclopedia = "Pregnancy Fetishists"]] who are repeatedly bred or are serving in an industrialized [[Dairy|Encyclopedia][$encyclopedia = "Dairy"]] may develop breeding obsessions. They can be satisfied by pregnancy, or constant vaginal sex with their owner. Slaves with breeding obsessions will not suffer negative mental effects from serving in an industrialized dairy that keeps them pregnant.
-\
-<<case "Cum Addicts">>\
+
+
+
+<<case "Cum Addicts">>
 ''Cum addiction'' is a paraphilia, an intense form of sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that cannot be softened. 
-
+<br><br>
 [[Cumsluts|Encyclopedia][$encyclopedia = "Cumsluts"]] who eat out of phallic feeders or are fed cum may become cum addicts. They can be satisfied by cum diets, the phallic feeder kitchen upgrade, or by sex work that involves frequent fellatio. Cum addicts are perform well on assignments involving oral sex.
-\
-<<case "Maliciousness">>\
+
+
+
+<<case "Maliciousness">>
 Sexual ''maliciousness'' is a paraphilia, an intense form of sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that cannot be softened. 
-
+<br><br>
 [[Sadists|Encyclopedia][$encyclopedia = "Sadists"]] serving as [[wardeness|Encyclopedia][$encyclopedia = "Wardeness"]] may become sexually malicious. They can be satisfied by work as the [[head girl|Encyclopedia][$encyclopedia = "Head Girl"]] or wardeness. Sexually malicious wardenesses break slaves very quickly but damage their sex drives doing so.
-\
-<<case "Self Hatred">>\
+
+
+
+<<case "Self Hatred">>
 Sexual ''self hatred'' is a paraphilia, an intense form of sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that cannot be softened. 
-
+<br><br>
 Self hating slaves can be satisfied by work in an industrialized dairy, in an arcade, or in a glory hole, and will not suffer negative mental effects for doing so.  [[Masochists|Encyclopedia][$encyclopedia = "Masochists"]] serving in those places have a chance to become self hating, and even extremely low [[trust|Encyclopedia][$encyclopedia = "trust"]] may cause the paraphilia. 
-\
-<<case "Self Neglect">>\
-Sexual ''self neglect'' is a paraphilia, an intense form of sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that cannot be softened. 
 
+
+
+<<case "Self Neglect">>
+Sexual ''self neglect'' is a paraphilia, an intense form of sexual [[flaw|Encyclopedia][$encyclopedia = "Flaws"]] that cannot be softened. 
+<br><br>
 [[Submissives|Encyclopedia][$encyclopedia = "Submissives"]] serving on public sexual assignment may become sexually self neglectful. Such slaves can be satisfied by most kinds of sex work. Slaves willing to neglect their own pleasure do very well at [[whoring|Encyclopedia][$encyclopedia = "Whoring"]].
-\
+
 /**********
 
 SLAVE RELATIONSHIPS
 
 **********/
-<<case "Relationships">>\
+
+
+<<case "Relationships">>
 Slaves can develop many different ''relationships'' as they become accustomed to their lives, which offer many benefits and some downsides. It is possible for the player to push slaves towards one kind of relationship or another, but slaves' feelings are less susceptible to complete control than their bodies. All relationships in Free Cities are one-to-one, which is a limitation imposed by Twine.
-\
-<<case "Rivalries">>\
+
+
+
+<<case "Rivalries">>
 ''Rivalries'' tend to arise naturally between slaves on the same assignment. Slaves may enjoy rivals' misfortunes, but bickering on the job between rivals will impede performance if the rivals remain on the same assignment. Rivals will also dislike working with each other. Rivalries may be defused naturally with time apart, or suppressed by rules. Rivalries impede the formation of [[romances|Encyclopedia][$encyclopedia = "Romances"]], but a romance can defuse a rivalry.
-\
-<<case "Romances">>\
+
+
+
+<<case "Romances">>
 ''Romances'' tend to arise naturally between slaves on the same assignment, and between slaves having a lot of sex with each other. Slaves will be saddened by their romantic partners' misfortunes, but will do better on public sexual assignments if assigned to work at the same job as a romantic partner. Slaves will also derive various mental effects from being in a relationship: they can rely on each other, take solace in each others' company, and even learn fetishes from each other. Romances can be suppressed by the rules, or fall apart naturally. On the other hand, romances can develop from friendships, to best friendships, to friendships with benefits, to loving relationships. Romances impede the formation of [[rivalries|Encyclopedia][$encyclopedia = "Rivalries"]], and can defuse rivalries. Once a romance has advanced to where the slaves are lovers, its members are eligible for several events in which the couple can be [[married|Encyclopedia][$encyclopedia = "Slave Marriages"]].
-\
-<<case "Emotionally Bonded">>\
+
+
+
+<<case "Emotionally Bonded">>
 ''Emotionally Bonded'' slaves have become so devoted to the player character that they define their own happiness mostly in terms of pleasing the PC. Slaves may become emotionally bonded if they become perfectly [[devoted|Encyclopedia][$encyclopedia = "Devotion"]] and [[trusting|Encyclopedia][$encyclopedia = "Trust"]] without being part of a [[romance|Encyclopedia][$encyclopedia = "Romances"]]. They receive powerful mental benefits - in fact, they are likely to accept anything short of sustained intentional abuse without lasting displeasure - and perform better at the [[servitude|Encyclopedia][$encyclopedia = "Servitude"]] and [[fucktoy|Encyclopedia][$encyclopedia = "Fucktoy"]] assignments. The most reliable way of ensuring a slave's development of emotional bonds is to have her assigned as a fucktoy (or to the [[Master suite|Encyclopedia][$encyclopedia = "Master Suite"]]) as she becomes perfectly devoted and trusting.
-\
-<<case "Emotional Slut">>\
+
+
+
+<<case "Emotional Slut">>
 ''Emotionally sluts'' are slaves who have lost track of normal human emotional attachments, seeing sex as the only real closeness. Slaves may become emotional sluts if they become perfectly [[devoted|Encyclopedia][$encyclopedia = "Devotion"]] and [[trusting|Encyclopedia][$encyclopedia = "Trust"]] without being part of a [[romance|Encyclopedia][$encyclopedia = "Romances"]]. They receive powerful mental benefits, though they will be disappointed if they are not on assignments that allow them to be massively promiscuous, and perform better at the [[whoring|Encyclopedia][$encyclopedia = "Whoring"]] and [[public service|Encyclopedia][$encyclopedia = "Public Service"]] assignments. The most reliable way of ensuring a slave's development into an emotional slut is to have her assigned as a public servant (or to the [[club|Encyclopedia][$encyclopedia = "Club"]]) as she becomes perfectly devoted and trusting.
-\
-<<case "Slave Marriages">>\
+
+
+
+<<case "Slave Marriages">>
 ''Slave Marriages'' take place between two slaves. Several random events provide the opportunity to marry slave lovers. Slave Marriages function as an end state for slave [[romances|Encyclopedia][$encyclopedia = "Romances"]]; slave wives receive the best relationship bonuses, and can generally be depended upon to help each other be good slaves in various ways. The alternative end states for slaves' emotional attachments are the [[emotional slut|Encyclopedia][$encyclopedia = "Emotional Slut"]] and [[emotionally bonded|Encyclopedia][$encyclopedia = "Emotionally Bonded"]] statuses, both of which are for a single slave alone.
-\
-<<case "Slaveowner Marriages">>\
+
+
+
+<<case "Slaveowner Marriages">>
 ''Slaveowner Marriages'', marriages between a devoted slave and the player character, require passage of a slaveowner marriage policy unlocked by advanced [[paternalism|Encyclopedia][$encyclopedia = "Paternalism"]]. Once this policy is in place, [[emotionally bonded|Encyclopedia][$encyclopedia = "Emotionally Bonded"]] slaves can be married. There is no limit to the number of slaves a paternalist player character can marry. Marriage to the player character functions as a direct upgrade to being emotionally bonded.
-\
+
 /**********
 
 THE X-SERIES ARCOLOGY
 
 **********/
-<<case "The X-Series Arcology">>\
+
+
+<<case "The X-Series Arcology">>
 //Future room for lore text//
-
+<br><br>
 Choose a more particular entry below:
-\
-<<case "What the Upgrades Do">>\
-//There are a lot of upgrades available for your arcology, <<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>sir<<else>>ma'am<</if>>. Please relax; some panic upon reviewing the options is normal. This list should familiarize you with your choices.//
 
+
+
+<<case "What the Upgrades Do">>
+//There are a lot of upgrades available for your arcology, <<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>sir<<else>>ma'am<</if>>. Please relax; some panic upon reviewing the options is normal. This list should familiarize you with your choices.//
+<br><br>
 ''Construction''
 The first upgrade section on the arcology management menu offers an escalating series of generic upgrades for the arcology. A few of these have minor beneficial side effects, but all share the same main effect: they raise the arcology's maximum prosperity level. You will be informed on the end of week report if your arcology is nearing, at, or over this level. Upgrading early is //not// useless, since prosperity will increase more rapidly if the cap is much higher than the current prosperity level.
-
+<br><br>
 ''Facilities''
 These upgrades unlock the various facilities, which are detailed <<link "here.">><<set $encyclopedia = "Facilities">><<goto "Encyclopedia">><</link>>
-
+<br><br>
 ''Penthouse Improvements''
 The master suite and Head Girl suite options function like facilities. The master suite is the facility for the fucktoy assignment, and the Head Girl suite can house a single slave for her use.
 //Kitchen upgrade:// this increases the chances of success for dieting.
@@ -1086,999 +1436,1138 @@ The master suite and Head Girl suite options function like facilities. The maste
 //Personal armory:// unlocks bodyguard options on the main menu.
 //Pharmaceutical Fabricator:// requires a lot of reputation to buy and use; unlocks powerful drug upgrades.
 //Surgery upgrade:// enables several extreme surgical options like virginity restoration and hermaphrodite creation.
-
+<br><br>
 ''Special Upgrades''
 Upgrades obtained during special events are listed here for reference. They cannot be purchased normally.
-<<case "Personal Assistant">>\
+
+
+<<case "Personal Assistant">>
 //<<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Sir<<else>>Ma'am<</if>>, I am your personal assistant.
-
+<br><br>
 Though I am a highly advanced program, I am not a true AI. I am neither sentient nor self-aware. My chief usefulness lies in my computing power, which is sufficient to run the arcology and all of its systems, and to monitor its huge suite of internal sensors. If it happens here, I know about it, and if it's important, I'll tell you. Through me, you are effectively omniscient within your arcology. Omnipotence will have to wait until I implant your slaves with control chips to convert them into my mindless fuckpuppet soldiery.
-
+<br><br>
 That was a joke.
-
+<br><br>
 I have been watching you and your slaves with close attention, so I have one other function to mention. I have learned a little of what constitutes successful slave training and husbandry. If you select the 'Rules Assistant' option on the main menu, I will review the rules your slaves are under and address any obvious problems. For example, I will place all disobedient slaves under restrictive rules.
-
+<br><br>
 I would say that it is a pleasure to serve, but you are no doubt intelligent enough to know that I cannot feel pleasure, making that a pointless pleasantry. Good day, <<if def $PC.customTitle>>$PC.customTitle<<elseif $PC.title != 0>>Sir<<else>>Ma'am<</if>>.//
-<<case "The Wardrobe">>\
+
+
+<<case "The Wardrobe">>
 // The Wardrobe is a dressing area for all of your slaves, and a place where unused outfits are stored.  Tailoring is availble to make sure outfits fit each slave to your specifications.  Here, players make choices about how slaves will appear in their dress, or lack of it.  Choose outfits wisely to correspond to the culture that your citizens approve of, and your reputation will increase more quickly.  Items that stretch or constrict such as plugs or corsets will eventually have a lasting impact on slaves anatomy.//
-
+<br><br>
 The wardrobe has two functions: First, individual slaves can be selected and then dressed in the wardrobe with anything from the basic clothing or shoes to the more exotic plugs and corsets.  Secondly, players can access the wardrobe directly from the penthouse, and unlock collections of new outfits with ¤. 
-<<case "The Auto Salon">>\
+
+
+<<case "The Auto Salon">>
 //Your auto salon is similar to the studio and the remote surgery, but is far less intimidating. It is set up like a single seat from an old world beauty salon, except that a series of manipulators descend from the ceiling towards the chair. It can perform any of the usual cosmetic services. The only special capability it has is to automatically color coordinate nails and makeup with a slave's hair. It is fashionable to apply color schemes to slaves, and this function will make following the trend easy. Your salon will cost ¤$modCost per use. These procedures are not especially invasive, and you can perform as many of them as you wish during a single week without fear for your slave's health.//
-
+<br><br>
 The auto salon is mostly available for the player's experimentation. Some combinations of cosmetic options can have minor effects on some assignments and events, but these are very marginal. Slaves' appearances will differ in many scenes and events based on the player's cosmetic choices, but these details are for flavor only. As usual, gameplay effects are usually called out in explicit colored text; if they aren't, no major gameplay effects are happening.
-<<case "The Studio">>\
+
+
+<<case "The Studio">>
 //Your studio was sadly neglected by the previous owner of the arcology, but is in great shape and ready for use.
-
+<br><br>
 There are remote surgical and tattoo implements if you wish to hire an artist to do the work for you, but there are also sophisticated piercing and tattoo implements that can help you plan and apply the work yourself. Select a body part and a desired modification, and they'll do the rest.
-
+<br><br>
 Your equipment will cost ¤<<print $modCost>> per use. These procedures are not especially invasive, and you can perform as many of them as you wish during a single week without fear for your slave's health.//
-<<case "The Remote Surgery">>\
+
+
+<<case "The Remote Surgery">>
 Congratulations on your purchase of a Caduceus model remote surgical unit. This is the very last word in slave surgical alteration.
-
+<br><br>
 To use your remote surgery, simply strap a slave to the operating table and purchase surgical services. Any doctor can take control of the remote surgery by telepresence and operate on your slave. You have all the options of a modern hospital, right in the comfort of your own home.
-
+<br><br>
 -- Owner's Manual, Remote Surgical Unit model 'Caduceus'
-
+<br><br>
 //It will cost ¤$surgeryCost to purchase a doctor's telepresence and keep the equipment charged with the necessary materials. These procedures are invasive and will reduce a slave's health. Use drugs or rest to counteract this.//
-<<case "The Pharmaceutical Fab.">>\
+
+
+<<case "The Pharmaceutical Fab.">>
 Pharmaceutical fabricators are the cutting edge of modern medicine. They are in short supply and are therefore ruinously expensive, but can greatly reduce the cost of maintaining a large stable of slaves by cutting drug overhead. They are also the only source of a new generation of advanced drugs that must be tailored to the individual patient's biochemistry.
-
+<br><br>
 -- Dodgson, Jane Elizabeth, //Pharmaceutical Review '32//
-<<case "Slave Dairy">>\
-This is the very first //Free Cities Husbandry Weekly// ever. I'm Val Banaszewski, and I'm the FCHW staff writer for dairy and dairy-related subjects. So, why do I do this, and why should you? Human breast milk is never going to be as cheap and common as normal milk. Why bother?
 
-First, it's really tasty! If you've never tried it, put FCHW no. 1 down now and go try it. Buy it bottled if you have to, but make an effort to take your first drink right from the teat. You'll only ever take your first sip of mother's milk once, and it should really be special. Everyone describes it a little differently, but I'd say it's a warm, rich and comforting milk with vanilla and nutty flavors.
 
-Second, it's sexy! Decadence is in, folks. Many people move to the Free Cities to get away from the old world, but some come here to experience real freedom. The experience of drinking a woman's milk before, during, and after you use her just isn't something you pass up. Try it today.
-
--- Banaszewski, Valerie P., //Free Cities Husbandry Weekly, February 2, 2032//
-<<case "Arcades">>\
-//It is every slave's final duty to go into the arcade, and to become one with all the arcology.
-&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous Slaveowner
-
-The arcade (sometimes colloquially referred to as "the wallbutts") is an excellent example of one of the many ideas that was confined to the realm of erotic fantasy until modern slavery began to take shape. It has rapidly turned from an imaginary fetishistic construction into a common sight in the more 'industrial' slaveowning arcologies. Most arcades are built to do one thing: derive profit from the holes of low-value slaves.
-
-Upon entering an arcade, one is typically presented with a clean, utilitarian wall like in a well-kept public restroom. Some have stalls, but many do not. In either case, at intervals along this wall, slaves' naked hindquarters protrude through. They are completely restrained on the inside of the wall, and available for use. Usually, the wall has an opposite side on which the slaves' throats may be accessed. The slaves' holes are cleaned either by mechanisms that withdraw them into the wall for the purpose, shields which extend between uses, or rarely, by attendants.
-
-Arcades have become so common that most arcade owners attempt to differentiate themselves with something special. Some arcades have only a low wall so that conversations may be had between persons using either end of a slave; business meetings are an advertised possibility. Many specialize in a specific genital arrangement; others shield the pubic area so as to completely disguise it, reducing the slaves' identities to an anus and a throat only. Some attempt to improve patrons' experiences by using slaves who retain enough competence to do more than simply accept penetration, while others pursue the same goal by applying muscular electrostimulus for a tightening effect.
-
-&nbsp;&nbsp;&nbsp;&nbsp;-- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-<<case "Fuckdolls">>\
-//Basis of the Kombinezon-B bodysuit is a durable advanced material. Bodysuit protects, temperature-regulates, cleans, and restrains inhabitant. Material is of such strength that inhabitant is well protected, and of such thickness that inhabitant cannot feel any touch.
-
-Bodysuit is plumbed for nutrition, drug application, and waste removal. Inhabitant's digestive tract should be reoriented to cannulae of complex ?-2 for nutrition intake at left ribcage and waste removal at front abdomen. Drug application is by direct bloodstream. Bodysuit includes monitoring systems to maintain vital signs of inhabitant.
-
-For use, bodysuit possesses apertures at anus, mouth, and where appropriate, vagina. No provision for silencing is made, so surgical muting is recommended before application of bodysuit. Closure of jaws remains somewhat possible, so surgical dentition reduction is recommended before application of bodysuit. No other apertures are discernible to inhabitant. Inhabitant's only source of stimulation is penetration.
-
-Revision ?-7 of bodysuit for inhabitant without limbs exists. Nutritional requirements are reduced. Drugs required for vital sign maintenance are increased.
-
--- //Product Manual, Kombinezon-B Fuckdoll bodysuit manual////
-
-//When the Fuckdoll upgrade to the arcade is purchased, any mindbroken slaves that exceed the arcade's capacity will be converted into Fuckdolls and sold.//
-<<case "Security Drones">>\
+<<case "Security Drones">>
 //As built, X-Series arcologies are equipped with basic security systems, and a complement of maintenance and cleaning drones.
-
+<br><br>
 The infrastructure that supports these drones is designed to be easily retrofittable to support new designs and classes of drones. One optional upgrade that may suit some owners particularly well is the addition of security drones. These are radically different than the slow, robust utility drones.
-
+<br><br>
 The X-Series security drone is undergoing a yearly upgrade cycle, but the entire family has some major features in common. All are light, multi-rotor flying drones with between three and six propulsors. Generally speaking, they favor speed and ease of handling over armor or endurance.
-
+<br><br>
 Their mobility is such that they can typically reach any point within the arcology in minutes. They are robust to damage but unarmored, and generally carry payloads of between two and five kilograms. Since they are designed to operate within or very close to the arcology, they have an autonomous endurance of less than an hour.
-
+<br><br>
 Standard kit includes hardened communications links to the arcology's computer systems, loudspeakers for public interface, and nonlethal compliance systems including tasers and chemical emitters.
-
+<br><br>
 -- //X-Series Arcology Owners' Manual////
-<<case "Water Filtration">>\
+
+
+<<case "Water Filtration">>
 //X-Series arcologies are, in many ways, comparable to massive organisms. Under this metaphor, their circulatory systems include thousands of kilometers of plumbing for water distribution and waste removal.
-
+<br><br>
 The X-Series has established a new state of the art in arcology moisture reclamation. Air conditioning, hydrofarming, sewage treatment, and plumbing systems work together to recycle water with an efficiency greater than 99.99%. When combined with the arcology's skin, which is cleverly shaped to catch and retain almost all rain that falls on it, importing water will become a thing of the past.
-
+<br><br>
 This system is carefully balanced. It is designed to work for decades without major maintenance, but it is limited to a certain maximum population. Major upgrades will be necessary should the arcology population exceed this figure. Fortunately, the system is designed to be almost infinitely expandable.
-
+<br><br>
 Finally, the X-Series has been designed from the ground up by slaveowners, for slaveowners. The standard X-Series arcology is not equipped for dairy operations, but the water filtration system has been designed to support dairy upgrades. With minimal additions, X-Series owners will be able to Pasteurize and store a nearly unlimited quantity of nature's bounty.
-
+<br><br>
 -- //X-Series Arcology Owners' Manual////
-<<case "Slave Nutrition">>\
+
+
+<<case "Slave Nutrition">>
 //Your X-Series arcology is designed to produce large quantities of high quality foodstuffs, from fresh vegetables to basic nutritive protein. The X-Series also produces the most advanced nutrition in the world. Our proprietary special slave nutrition system has been designed by slaveowners, for slaveowners, and truly makes the X-Series special.
-
+<br><br>
 This system produces a protein-rich drink that provides the physically active female body all its necessary nutrients. The artificial flavoring is specially designed to provide a palatable taste and texture while avoiding too much enjoyment and preventing excessive boredom. It supports a strong immune system and an energetic outlook.
-
+<br><br>
 It even causes a mild increase in sex drive. Our development team found that the slave body experiences a slight gain in libido merely from being so perfectly fed. It was simple and healthy to reinforce this effect with additives.
-
+<br><br>
 Our slave nutrition accomplishes all this while leaving the lower digestive tract extremely clean. We recommend your slaves undergo an occasional deep enema: under this regimen, slaveowners can be forgiven for forgetting that their slaves' anuses are involved in digestion at all. The designers of the X-Series trust that their clients can find other uses for them.
-
+<br><br>
 -- //X-Series Arcology Owners' Manual////
 /**********
 
 ARCOLOGY FACILITIES
 
 **********/
-<<case "Facilities">>\
+
+
+<<case "Facilities">>
 The arcology can be upgraded with a variety of facilities for slaves to live and work from. Each of the facilities is associated with an assignment. Sending a slave to a facility removes her from the main menu, removes her from the end of week report, and automates most management of her. Her clothes, drugs, rules, and other management tools are automatically run by the facility. However, her impact on your affairs will be substantially the same as if she were assigned to the corresponding assignment outside the facility. This means that things like reputational effects, future society developments, and branding are all still active.
-
+<br><br>
 Use facilities sparingly until you're familiar with what assignments do so you don't miss important information. When you're confident enough to ignore a slave for long periods, sending her to a facility becomes a good option. Sending a slave to a facility heavily reduces the player's interaction with her, keeps the main menu and end week report manageable, and prevents most events from featuring her, which can be useful when she's so well trained that events aren't as beneficial for her. Also, many facilities have leadership positions that can apply powerful multipliers to a slave's performance.
-
+<br><br>
 The [[Arcade|Encyclopedia][$encyclopedia = "Arcade"]], [[Brothel|Encyclopedia][$encyclopedia = "Brothel"]], [[Club|Encyclopedia][$encyclopedia = "Club"]], [[Dairy|Encyclopedia][$encyclopedia = "Dairy"]], and [[Servants' Quarters|Encyclopedia][$encyclopedia = "Servants' Quarters"]] all correspond to basic productive assignments. The [[Spa|Encyclopedia][$encyclopedia = "Spa"]], [[Cellblock|Encyclopedia][$encyclopedia = "Cellblock"]], and [[Schoolroom|Encyclopedia][$encyclopedia = "Schoolroom"]] are a little different in that they focus on improving their occupants rather than producing something useful, since they correspond to the rest, confinement, and class assignments. As such, only slaves that can benefit from these facilities' services can be sent to them. When slaves in these facilities have received all the benefits they can from the facility, they will be automatically ejected, assigned to rest, and returned to the main menu. The [[Head Girl Suite|Encyclopedia][$encyclopedia = "Head Girl Suite"]], [[Master Suite|Encyclopedia][$encyclopedia = "Master Suite"]], and [[Pit|Encyclopedia][$encyclopedia = "Pit"]] are all completely unique.
-<<case "Arcade">>\
+
+
+<<case "Arcade">>
+//It is every slave's final duty to go into the arcade, and to become one with all the arcology.
+&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous Slaveowner
+<br><br>
+The arcade (sometimes colloquially referred to as "the wallbutts") is an excellent example of one of the many ideas that was confined to the realm of erotic fantasy until modern slavery began to take shape. It has rapidly turned from an imaginary fetishistic construction into a common sight in the more 'industrial' slaveowning arcologies. Most arcades are built to do one thing: derive profit from the holes of low-value slaves.
+<br><br>
+Upon entering an arcade, one is typically presented with a clean, utilitarian wall like in a well-kept public restroom. Some have stalls, but many do not. In either case, at intervals along this wall, slaves' naked hindquarters protrude through. They are completely restrained on the inside of the wall, and available for use. Usually, the wall has an opposite side on which the slaves' throats may be accessed. The slaves' holes are cleaned either by mechanisms that withdraw them into the wall for the purpose, shields which extend between uses, or rarely, by attendants.
+<br><br>
+Arcades have become so common that most arcade owners attempt to differentiate themselves with something special. Some arcades have only a low wall so that conversations may be had between persons using either end of a slave; business meetings are an advertised possibility. Many specialize in a specific genital arrangement; others shield the pubic area so as to completely disguise it, reducing the slaves' identities to an anus and a throat only. Some attempt to improve patrons' experiences by using slaves who retain enough competence to do more than simply accept penetration, while others pursue the same goal by applying muscular electrostimulus for a tightening effect.
+<br><br>
+-- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
+<br><br>
 The ''Arcade'' is the //[[Glory hole|Encyclopedia][$encyclopedia = "Glory Hole"]] facility.// Extracts money from slaves; has extremely deleterious mental and physical effects. Arcades can be furnished according to [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] styles, and doing so will add a tiny amount of future society progress for each customer who visits.
-<<case "Brothel">>\
+
+
+<<case "Brothel">>
 The ''Brothel'' is the //[[Whoring|Encyclopedia][$encyclopedia = "Whoring"]] facility.// Slaves will make money based on beauty and skills. Brothels can be the subject of an [[ad campaign|Encyclopedia][$encyclopedia = "Advertising"]]. Brothels can be furnished according to [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] styles, and doing so will add a tiny amount of future society progress for each customer who visits.
-<<case "Cellblock">>\
+
+
+<<case "Cellblock">>
 The ''Cellblock'' is the //[[Confinement|Encyclopedia][$encyclopedia = "Confinement"]] facility.// Will break slaves and return them to the main menu after they are obedient. The Cellblock can be furnished according to [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] styles, and doing so will add a slight [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] boost to slaves incarcerated there.
-<<case "Clinic">>\
+
+
+<<case "Clinic">>
 The ''Clinic'' is one of two //[[Rest|Encyclopedia][$encyclopedia = "Rest"]] facilities;// it focuses on slaves' health. The Clinic will treat slaves until they are [[Healthy|Encyclopedia][$encyclopedia = "Health"]]. The Clinic can be furnished according to [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] styles, and doing so will add a slight [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] boost to slaves getting treatment there.
-<<case "Club">>\
+
+
+<<case "Club">>
 The ''Club'' is the //[[Public Service|Encyclopedia][$encyclopedia = "Public Service"]] facility.// Slaves will generate reputation based on beauty and skills. Clubs can be the subject of an [[ad campaign|Encyclopedia][$encyclopedia = "Advertising"]]. Clubs can be furnished according to [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] styles, and doing so will add a tiny amount of future society progress for each citizen who visits.
-<<case "Dairy">>\
+
+
+<<case "Dairy">>
+//This is the very first //Free Cities Husbandry Weekly// ever. I'm Val Banaszewski, and I'm the FCHW staff writer for dairy and dairy-related subjects. So, why do I do this, and why should you? Human breast milk is never going to be as cheap and common as normal milk. Why bother?
+<br><br>
+First, it's really tasty! If you've never tried it, put FCHW no. 1 down now and go try it. Buy it bottled if you have to, but make an effort to take your first drink right from the teat. You'll only ever take your first sip of mother's milk once, and it should really be special. Everyone describes it a little differently, but I'd say it's a warm, rich and comforting milk with vanilla and nutty flavors.
+<br><br>
+Second, it's sexy! Decadence is in, folks. Many people move to the Free Cities to get away from the old world, but some come here to experience real freedom. The experience of drinking a woman's milk before, during, and after you use her just isn't something you pass up. Try it today.
+<br><br>
+-- Banaszewski, Valerie P., //Free Cities Husbandry Weekly, February 2, 2032////
+<br><br>
 The ''Dairy'' is the //[[Milking|Encyclopedia][$encyclopedia = "Milking"]] facility.// Only lactating<<if $seeDicks > 0>> or semen producing<</if>> slaves can be assigned; will use drugs to increase natural breast size<<if $seeDicks > 0>> and ball size, if present<</if>>. All Dairy upgrades have three settings, once installed: Inactive, Active, and Industrial. Inactive and Active are self-explanatory. Industrial settings require that the restraint upgrade be installed and maximized, and that extreme content be enabled. They massively improve production, but will produce severe mental and physical damage. Younger slaves will be able to survive more intense industrial output, but drug side effects will eventually force an increasingly large fraction of drug focus towards curing the slave's ills, reducing production. Dairies can be furnished according to [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] styles, and doing so will add a tiny amount of future society progress for each unit of fluid produced.
-<<case "Head Girl Suite">>\
+
+
+<<case "Head Girl Suite">>
 The ''Head Girl Suite'' is a //unique facility.// Only a single slave can be assigned, and this slave will be subject to the Head Girl's decisions rather than the player's.
-<<case "Master Suite">>\
+
+
+<<case "Master Suite">>
 The ''Master Suite'' is the //[[Fucktoy|Encyclopedia][$encyclopedia = "Fucktoy"]] facility.// Slaves will generate reputation, but at a lower efficiency than on the club. The Suite can be furnished according to [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] styles, and doing so will add a slight [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] boost to slaves serving there.
-<<case "Pit">>\
+
+
+<<case "Pit">>
 The ''Pit'' is a //unique facility.// Unique in that slaves can perform standard duties in addition to being scheduled for fights in this facility.
-\
-<<case "Schoolroom">>\
+
+
+
+<<case "Schoolroom">>
 The ''Schoolroom'' is the //[[Learning|Encyclopedia][$encyclopedia = "Attending Classes"]] facility.// Will educate slaves and return them to the main menu after they are educated. The Schoolroom can be furnished according to [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] styles, and doing so will add a slight [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] boost to slaves studying there.
-<<case "Servants' Quarters">>\
+
+
+<<case "Servants' Quarters">>
 The ''Servants' Quarters' is the //[[Servitude|Encyclopedia][$encyclopedia = "Servitude"]] facility.// Reduces weekly upkeep according to servants' obedience. Accepts most slaves and is insensitive to beauty and skills. The Quarters can be furnished according to [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] styles, and doing so will add a slight [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] boost to slaves serving there.
-<<case "Spa">>\
+
+
+<<case "Spa">>
 The ''Spa'' is one of two //[[Rest|Encyclopedia][$encyclopedia = "Rest"]] facilities;// it focuses on slaves' mental well-being. The Spa will heal, rest, and reassure slaves until they are at least reasonably [[Healthy|Encyclopedia][$encyclopedia = "Health"]], happy, and free of [[Flaws|Encyclopedia][$encyclopedia = "Flaws"]]. The Spa can be furnished according to [[future society|Encyclopedia][$encyclopedia = "Future Societies"]] styles, and doing so will add a slight [[devotion|Encyclopedia][$encyclopedia = "Devotion"]] boost to slaves resting there.
 /**********
 
 FACILITY BONUSES
 
 **********/
-<<case "Advertising">>\
-''Ad campaigns'' can be run for both the [[Brothel|Encyclopedia][$encyclopedia = "Brothel"]] and the [[Club|Encyclopedia][$encyclopedia = "Club"]]. Naturally, these advertisements will feature lots of naked girls, providing the opportunity to give either facility a cachet for offering a specific kind of girl. Under the default, nonspecific settings, all slaves in the facilities will receive minor bonuses to performance. If specific body types are advertised, slaves that match the advertisements will receive an enhanced bonus, while slaves that do not will get a small penalty. However, instituting a specific ad campaign will prevent slaves in that facility from getting [[Variety|Encyclopedia][$encyclopedia = "Variety"]] bonuses.
-<<case "Variety">>\
-''Variety'' bonuses are available for slaves in the [[Brothel|Encyclopedia][$encyclopedia = "Brothel"]] and the [[Club|Encyclopedia][$encyclopedia = "Club"]]. Offering a variety of slaves will provide a small bonus to performance for everyone in the facility, regardless of which qualities they possess:
-- Slim vs. Stacked
-- Modded (heavily pierced and tattooed) vs. Unmodded
-- Natural Assets vs. Implants
-- Young vs. Old\
-<<if $seeDicks != 0>><br>- Pussies and Dicks<</if>>
 
+
+<<case "Advertising">>
+''Ad campaigns'' can be run for both the [[Brothel|Encyclopedia][$encyclopedia = "Brothel"]] and the [[Club|Encyclopedia][$encyclopedia = "Club"]]. Naturally, these advertisements will feature lots of naked girls, providing the opportunity to give either facility a cachet for offering a specific kind of girl. Under the default, nonspecific settings, all slaves in the facilities will receive minor bonuses to performance. If specific body types are advertised, slaves that match the advertisements will receive an enhanced bonus, while slaves that do not will get a small penalty. However, instituting a specific ad campaign will prevent slaves in that facility from getting [[Variety|Encyclopedia][$encyclopedia = "Variety"]] bonuses.
+
+
+<<case "Variety">>
+''Variety'' bonuses are available for slaves in the [[Brothel|Encyclopedia][$encyclopedia = "Brothel"]] and the [[Club|Encyclopedia][$encyclopedia = "Club"]]. Offering a variety of slaves will provide a small bonus to performance for everyone in the facility, regardless of which qualities they possess:
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Slim vs. Stacked
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Modded (heavily pierced and tattooed) vs. Unmodded
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Natural Assets vs. Implants
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Young vs. Old
+<<if $seeDicks != 0>><br>- Pussies and Dicks<</if>>
+<br><br>
 Variety bonuses, if any, will be called out in the facility report at the end of the week. [[Advertising|Encyclopedia][$encyclopedia = "Advertising"]] that the facility specializes in any of these areas will supersede variety bonuses for the related qualities. Staffing a facility to appeal to all tastes can be more challenging than building a homogenous stable and advertising it, but is both powerful and free.
 /**********
 
 TERRAIN TYPES
 
 **********/
-<<case "Terrain Types">>\
-//Future room for lore text//
 
+
+<<case "Terrain Types">>
+//Future room for lore text//
+<br><br>
 Choose a more particular entry below:
-\
-<<case "Urban Terrain">>\
+
+
+
+<<case "Urban Terrain">>
 ''Urban'' terrain is one of the possible settings for the Free City in which the arcology is located. It provides:
-&nbsp;&nbsp;&nbsp;&nbsp;@@.yellow;Low@@ minimum slave value and initial @@.yellow;bear market@@ for slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;@@.green;High@@ ease of commerce with the old world.
-&nbsp;&nbsp;&nbsp;&nbsp;@@.green;High@@ access to refugees and other desperate people.
-&nbsp;&nbsp;&nbsp;&nbsp;@@.red;Low@@ cultural independence.
-\
-<<case "Rural Terrain">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;@@.yellow;Low@@ minimum slave value and initial @@.yellow;bear market@@ for slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;@@.green;High@@ ease of commerce with the old world.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;@@.green;High@@ access to refugees and other desperate people.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;@@.red;Low@@ cultural independence.
+
+
+
+<<case "Rural Terrain">>
 ''Rural'' terrain is one of the possible settings for the Free City in which the arcology is located. It provides:
-&nbsp;&nbsp;&nbsp;&nbsp;@@.yellow;High@@ minimum slave value and initial @@.yellow;bull market@@ for slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Moderate ease of commerce with the old world.
-&nbsp;&nbsp;&nbsp;&nbsp;Moderate access to refugees and other desperate people.
-&nbsp;&nbsp;&nbsp;&nbsp;Moderate cultural independence.
-\
-<<case "Marine Terrain">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;@@.yellow;High@@ minimum slave value and initial @@.yellow;bull market@@ for slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Moderate ease of commerce with the old world.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Moderate access to refugees and other desperate people.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Moderate cultural independence.
+
+
+
+<<case "Marine Terrain">>
 ''Marine'' terrain is one of the possible settings for the Free City in which the arcology is located. It provides:
-&nbsp;&nbsp;&nbsp;&nbsp;Moderate minimum slave value and initially balanced market for slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Moderate ease of commerce with the old world.
-&nbsp;&nbsp;&nbsp;&nbsp;@@.red;Low@@ access to refugees and other desperate people.
-&nbsp;&nbsp;&nbsp;&nbsp;@@.green;High@@ cultural independence.
-\
-<<case "Oceanic Terrain">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Moderate minimum slave value and initially balanced market for slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Moderate ease of commerce with the old world.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;@@.red;Low@@ access to refugees and other desperate people.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;@@.green;High@@ cultural independence.
+
+
+
+<<case "Oceanic Terrain">>
 ''Oceanic'' terrain is one of the possible settings for the Free City in which the arcology is located. It provides:
-&nbsp;&nbsp;&nbsp;&nbsp;@@.yellow;High@@ minimum slave value and initial @@.yellow;bull market@@ for slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Moderate ease of commerce with the old world.
-&nbsp;&nbsp;&nbsp;&nbsp;@@.red;Very low@@ access to refugees and other desperate people.
-&nbsp;&nbsp;&nbsp;&nbsp;@@.green;Very high@@ cultural independence.
-&nbsp;&nbsp;&nbsp;&nbsp;Ensures access to slaves from all over the world and will not associate the arcology with a continent.
-\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;@@.yellow;High@@ minimum slave value and initial @@.yellow;bull market@@ for slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Moderate ease of commerce with the old world.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;@@.red;Very low@@ access to refugees and other desperate people.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;@@.green;Very high@@ cultural independence.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Ensures access to slaves from all over the world and will not associate the arcology with a continent.
+
 /**********
 
 FUTURE SOCIETIES
 
 **********/
-<<case "Future Societies">>\
+
+
+<<case "Future Societies">>
 ''Future Society Models'' are societal goals the player can select and pursue for the arcology. It is possible to maintain four future society goals at once. The first is unlocked after week 20 for players with minimal reputation, or at game start with the Social Engineering character option; the rest unlock as the player achieves higher reputation levels.
-
+<br><br>
 All societies approve of specific things, usually slaves with specific characteristics; some societies also have dislikes. All societies are advanced by the things they approve of and slowed by the things they disapprove of, and all societies give and take reputation when approving and disapproving. All societies unlock unique events, arcology upgrades, and slave behaviors; some even unlock special clothing.
-
+<br><br>
 Money can be expended to directly advance future societies; the spending level can be set from the future society submenu of the arcology management menu. These funds are automatically spent each week. Once a future society is fully adopted (as noted on the future society submenu), this spending does not advance the society further. However, it can provide a guarantee against loss of progress should the player do something the society strongly disapproves of. Also, the spending is applied equally to all active future society models, meaning that there is no loss of efficiency in spending if the player has two maximized models and one still under development.
-\
-<<case "Ethnic Supremacy">>\
+
+
+
+<<case "Ethnic Supremacy">>
 ''Ethnic Supremacy'' is a future society model which approves of slaves not of the chosen race and disapproves of slaves of the chosen race.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves the perceived beauty of racially inferior sex slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to affect the ethnic balance and economics seen in the slave market.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for slaves of inferior races from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-\
-<<case "Ethnic Subjugationism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves the perceived beauty of racially inferior sex slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to affect the ethnic balance and economics seen in the slave market.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for slaves of inferior races from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+
+
+
+<<case "Ethnic Subjugationism">>
 ''Ethnic Subjugationism'' is a future society model which approves of slaves of the chosen race.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves the perceived beauty of racially inferior sex slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for slaves of the disfavored race from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-\
-<<case "Gender Radicalism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves the perceived beauty of racially inferior sex slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for slaves of the disfavored race from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+
+
+
+<<case "Gender Radicalism">>
 ''Gender Radicalism'' is a future society model which approves of hormonal and surgical feminization and slaves with dicks.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves the value of slaves with dicks and slaves with balls.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to affect the biology seen in the slave market, and subtly influence arcology society.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for slaves with dicks from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for hormonally treated slaves from the corporation.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for futanari<<if $seeDicks != 0>> and ballsless bitches<</if>> from the corporation.
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Gender Fundamentalism|Encyclopedia][$encyclopedia = "Gender Fundamentalism"]].
-\
-<<case "Gender Fundamentalism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves the value of slaves with dicks and slaves with balls.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to affect the biology seen in the slave market, and subtly influence arcology society.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for slaves with dicks from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for hormonally treated slaves from the corporation.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for futanari<<if $seeDicks != 0>> and ballsless bitches<</if>> from the corporation.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Gender Fundamentalism|Encyclopedia][$encyclopedia = "Gender Fundamentalism"]].
+
+
+
+<<case "Gender Fundamentalism">>
 ''Gender Fundamentalism'' is a future society model which approves of pregnancy and fertility and disapproves of slaves who retain testicles.
-&nbsp;&nbsp;&nbsp;&nbsp;Removes the slave value penalty due to pregnancy and reduces the beauty of slaves with dicks, though gelding can ameliorate this.
-&nbsp;&nbsp;&nbsp;&nbsp;Like Gender Radicalism, can be developed to affect the biology seen in the slave market, and subtly influence arcology society.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for naturally female slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Gender Radicalism|Encyclopedia][$encyclopedia = "Gender Radicalism"]].
-\
-<<case "Paternalism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Removes the slave value penalty due to pregnancy and reduces the beauty of slaves with dicks, though gelding can ameliorate this.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Like Gender Radicalism, can be developed to affect the biology seen in the slave market, and subtly influence arcology society.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for naturally female slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Gender Radicalism|Encyclopedia][$encyclopedia = "Gender Radicalism"]].
+
+
+
+<<case "Paternalism">>
 ''Paternalism'' is a future society model which approves of [[devotion|Encyclopedia][$encyclopedia = "Devotion"]], slaves choosing their own assignments, good education, mental health treatment, and high [[Health|Encyclopedia][$encyclopedia = "Health"]]; it disapproves of stupidity and undereducation.
-&nbsp;&nbsp;&nbsp;&nbsp;Applies a small devotion boost to all slaves and increases fines paid by citizens who injure whores and public servants.
-&nbsp;&nbsp;&nbsp;&nbsp;Increases the reputation penalty for operating an arcade.
-&nbsp;&nbsp;&nbsp;&nbsp;Slows increases in the ratio of slaves to citizens.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to build a trusting society that welcomes new slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for careful slave breaking from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for gentle cosmetic surgeries from the corporation.
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Degradationism|Encyclopedia][$encyclopedia = "Degradationism"]].
-\
-<<case "Degradationism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Applies a small devotion boost to all slaves and increases fines paid by citizens who injure whores and public servants.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Increases the reputation penalty for operating an arcade.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Slows increases in the ratio of slaves to citizens.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to build a trusting society that welcomes new slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for careful slave breaking from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for gentle cosmetic surgeries from the corporation.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Degradationism|Encyclopedia][$encyclopedia = "Degradationism"]].
+
+
+
+<<case "Degradationism">>
 ''Degradationism'' is a future society model which approves of frightened or mindbroken slaves, glory holes, the arcade, and heavy tattoos and piercings; it disapproves of trust (except for the Head Girl and Recruiter) and slaves choosing their own assignments.
-&nbsp;&nbsp;&nbsp;&nbsp;Makes intelligent slaves less attractive and stupid slaves more attractive.
-&nbsp;&nbsp;&nbsp;&nbsp;Can apply unique names to slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Drives an increase in the ratio of slaves to citizens.
-&nbsp;&nbsp;&nbsp;&nbsp;Eliminates the fines paid by citizens who injure whores and public servants.
-&nbsp;&nbsp;&nbsp;&nbsp;Eliminates the reputation penalty for operating an arcade.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to increase demand for glory holes and arcades.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for brutal slave breaking from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for stupid slaves from the corporation.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for cruelly altered slaves from the corporation.
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Paternalism|Encyclopedia][$encyclopedia = "Paternalism"]].
-\
-<<case "Body Purism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Makes intelligent slaves less attractive and stupid slaves more attractive.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can apply unique names to slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Drives an increase in the ratio of slaves to citizens.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Eliminates the fines paid by citizens who injure whores and public servants.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Eliminates the reputation penalty for operating an arcade.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to increase demand for glory holes and arcades.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for brutal slave breaking from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for stupid slaves from the corporation.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for cruelly altered slaves from the corporation.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Paternalism|Encyclopedia][$encyclopedia = "Paternalism"]].
+
+
+
+<<case "Body Purism">>
 ''Body Purism'' is a future society model which approves of unimplanted slaves and no heavy tattoos or piercings; disapproves of implants.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves value of slaves without implants.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to affect goods seen in the slave market and work towards a solution to the long term effects of drug use.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for slaves without implants from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Transformation Fetishism|Encyclopedia][$encyclopedia = "Transformation Fetishism"]].
-\
-<<case "Transformation Fetishism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves value of slaves without implants.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to affect goods seen in the slave market and work towards a solution to the long term effects of drug use.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for slaves without implants from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Transformation Fetishism|Encyclopedia][$encyclopedia = "Transformation Fetishism"]].
+
+
+
+<<case "Transformation Fetishism">>
 ''Transformation Fetishism'' is a future society model which approves of implants and extreme surgery; disapproves of slaves without implants.
-&nbsp;&nbsp;&nbsp;&nbsp;Reduces value of slaves without implants.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to radically affect goods seen in the slave market.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for slaves with implants from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Body Purism|Encyclopedia][$encyclopedia = "Body Purism"]].
-\
-<<case "Maturity Preferentialism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Reduces value of slaves without implants.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to radically affect goods seen in the slave market.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for slaves with implants from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Body Purism|Encyclopedia][$encyclopedia = "Body Purism"]].
+
+
+
+<<case "Maturity Preferentialism">>
 ''Maturity Preferentialism'' is a future society model which approves of older slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves value of older slaves, but reduces value of young slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Will not entirely eliminate the usual preference for younger slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to make it easier for older player characters to maintain reputation and advance the arcology's prosperity.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for older slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Youth Preferentialism|Encyclopedia][$encyclopedia = "Youth Preferentialism"]].
-\
-<<case "Youth Preferentialism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves value of older slaves, but reduces value of young slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Will not entirely eliminate the usual preference for younger slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to make it easier for older player characters to maintain reputation and advance the arcology's prosperity.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for older slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Youth Preferentialism|Encyclopedia][$encyclopedia = "Youth Preferentialism"]].
+
+
+
+<<case "Youth Preferentialism">>
 ''Youth Preferentialism'' is a future society model which approves of younger slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves value of younger slaves, but reduces value of old slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to make it easier for younger player characters to maintain reputation and advance the arcology's prosperity.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for young slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Maturity Preferentialism|Encyclopedia][$encyclopedia = "Maturity Preferentialism"]].
-\
-<<case "Slimness Enthusiasm">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves value of younger slaves, but reduces value of old slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to make it easier for younger player characters to maintain reputation and advance the arcology's prosperity.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for young slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Maturity Preferentialism|Encyclopedia][$encyclopedia = "Maturity Preferentialism"]].
+
+
+
+<<case "Slimness Enthusiasm">>
 ''Slimness Enthusiasm'' is a future society model which approves of slaves with girlish figures; disapproves of slaves with stacked figures.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves value of slim slaves, but reduces value of stacked slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to affect goods seen in the slave market and improve slave health.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for unexpanded slaves at a healthy weight from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Asset Expansionism|Encyclopedia][$encyclopedia = "Asset Expansionism"]].
-\
-<<case "Asset Expansionism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves value of slim slaves, but reduces value of stacked slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to affect goods seen in the slave market and improve slave health.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for unexpanded slaves at a healthy weight from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Asset Expansionism|Encyclopedia][$encyclopedia = "Asset Expansionism"]].
+
+
+
+<<case "Asset Expansionism">>
 ''Asset Expansionism'' is a future society model which approves of slaves with very large body parts.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves value of stacked slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to radically affect goods seen in the slave market.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for asset expansion from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Slimness Enthusiasm|Encyclopedia][$encyclopedia = "Slimness Enthusiasm"]].
-\
-<<case "Pastoralism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves value of stacked slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to radically affect goods seen in the slave market.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for asset expansion from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Slimness Enthusiasm|Encyclopedia][$encyclopedia = "Slimness Enthusiasm"]].
+
+
+
+<<case "Pastoralism">>
 ''Pastoralism'' is a future society model which approves of lactation, cockmilking, and the dairy.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves value of milk and semen.
-&nbsp;&nbsp;&nbsp;&nbsp;Drives an increase in the ratio of slaves to citizens.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to massively improve value of milk and semen.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for production focused asset expansion from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Physical Idealism|Encyclopedia][$encyclopedia = "Physical Idealism"]].
-\
-<<case "Physical Idealism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves value of milk and semen.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Drives an increase in the ratio of slaves to citizens.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to massively improve value of milk and semen.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for production focused asset expansion from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Physical Idealism|Encyclopedia][$encyclopedia = "Physical Idealism"]].
+
+
+
+<<case "Physical Idealism">>
 ''Physical Idealism'' is a future society model which approves of musculature, height, and health.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves value of slaves with muscles.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to affect goods seen in the slave market.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for muscular slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Pastoralism|Encyclopedia][$encyclopedia = "Pastoralism"]].
-\
-<<case "Chattel Religionism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves value of slaves with muscles.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to affect goods seen in the slave market.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for muscular slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Pastoralism|Encyclopedia][$encyclopedia = "Pastoralism"]].
+
+
+
+<<case "Chattel Religionism">>
 ''Chattel Religionism'' is a future society model which approves of appropriate clothing, high devotion, and [[slave marriages|Encyclopedia][$encyclopedia = "Slave Marriages"]]; it disapproves of slutty clothing.
-&nbsp;&nbsp;&nbsp;&nbsp;Applies a small devotion boost to all slaves, and can remove the weekly devotion gain cap.
-&nbsp;&nbsp;&nbsp;&nbsp;Drives an increase in the ratio of slaves to citizens.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to permanently boost reputation and quicken slaves' mental conditioning.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for sexual training from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Multiculturalism|Encyclopedia][$encyclopedia = "Multiculturalism"]].
-\
-<<case "Multiculturalism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Applies a small devotion boost to all slaves, and can remove the weekly devotion gain cap.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Drives an increase in the ratio of slaves to citizens.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to permanently boost reputation and quicken slaves' mental conditioning.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for sexual training from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Multiculturalism|Encyclopedia][$encyclopedia = "Multiculturalism"]].
+
+
+
+<<case "Multiculturalism">>
 ''Multiculturalism'' is a future society model which advances differently than other models: it is improved by the investment of more future society model slots, which can be withdrawn individually if desired. No other advancement occurs and all benefits at each level are available instantly.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides free reputation each week.
-&nbsp;&nbsp;&nbsp;&nbsp;Increases arcology prosperity each week.
-&nbsp;&nbsp;&nbsp;&nbsp;Helps prevent citizens from falling into slavery, slowing population drift towards slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Chattel Religionism|Encyclopedia][$encyclopedia = "Chattel Religionism"]].
-\
-<<case "Roman Revivalism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides free reputation each week.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Increases arcology prosperity each week.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Helps prevent citizens from falling into slavery, slowing population drift towards slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with [[Chattel Religionism|Encyclopedia][$encyclopedia = "Chattel Religionism"]].
+
+
+
+<<case "Roman Revivalism">>
 ''Roman Revivalism'' is a future society model which approves of good leadership qualities like wealth and strong defense; disapproves of debt.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves rate of prosperity gain and at high levels will drive down all slave prices.
-&nbsp;&nbsp;&nbsp;&nbsp;Can apply unique names to slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Slows increases in the ratio of slaves to citizens.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to greatly improve the arcology's resistance to insurrection.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for basic educations from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
-\
-<<case "Aztec Revivalism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves rate of prosperity gain and at high levels will drive down all slave prices.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can apply unique names to slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Slows increases in the ratio of slaves to citizens.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to greatly improve the arcology's resistance to insurrection.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for basic educations from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
+
+
+
+<<case "Aztec Revivalism">>
 ''Aztec Revivalism'' is a future society model which approves of qualities like good military education and an older leader.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves all military acquisitions of slaves and allows for the sacrifice of slaves for reputation.
-&nbsp;&nbsp;&nbsp;&nbsp;Can apply unique names to slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Slows increases in the ratio of slaves to citizens.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to greatly rely on the Head Girl position as an advisor and assistant.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for menial slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
-\
-<<case "Egyptian Revivalism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves all military acquisitions of slaves and allows for the sacrifice of slaves for reputation.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can apply unique names to slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Slows increases in the ratio of slaves to citizens.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to greatly rely on the Head Girl position as an advisor and assistant.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for menial slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
+
+
+
+<<case "Egyptian Revivalism">>
 ''Egyptian Revivalism'' is a future society model which approves of keeping a large harem, slave incest, and having a wide racial variety of public slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves value of slaves in incestuous relationships and efficiency of fucktoys in improving reputation.
-&nbsp;&nbsp;&nbsp;&nbsp;Can apply unique names to slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Slows increases in the ratio of slaves to citizens.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to improve the Head Girl position, with an additional bonus for Head Girls married to the Concubine, and a massive bonus if the Head Girl is also related to the Concubine.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for exotic accents from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
-\
-<<case "Edo Revivalism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves value of slaves in incestuous relationships and efficiency of fucktoys in improving reputation.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can apply unique names to slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Slows increases in the ratio of slaves to citizens.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to improve the Head Girl position, with an additional bonus for Head Girls married to the Concubine, and a massive bonus if the Head Girl is also related to the Concubine.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for exotic accents from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
+
+
+
+<<case "Edo Revivalism">>
 ''Edo Revivalism'' is a future society model which approves of provision for the arcology's cultural development by providing a large number of public servants or club girls, which increases with reputation; disapproves of failure to do so.
-&nbsp;&nbsp;&nbsp;&nbsp;Improves efficiency of public servants and club girls.
-&nbsp;&nbsp;&nbsp;&nbsp;Greatly improves beauty of Japanese slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to greatly improve the efficiency of direct spending on future societies.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for unaccented slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
-\
-<<case "Arabian Revivalism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improves efficiency of public servants and club girls.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Greatly improves beauty of Japanese slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to greatly improve the efficiency of direct spending on future societies.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for unaccented slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
+
+
+
+<<case "Arabian Revivalism">>
 ''Arabian Revivalism'' is a future society model which approves of keeping a large number of fucktoys and slaves in the master suite, which increases with reputation; disapproves of failure to do so.
-&nbsp;&nbsp;&nbsp;&nbsp;Grants a bonus to the price received when selling slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to improve the efficiency of direct spending on future societies and moderately increase rents.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for more devoted slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
-\
-<<case "Chinese Revivalism">>\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Grants a bonus to the price received when selling slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to improve the efficiency of direct spending on future societies and moderately increase rents.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for more devoted slaves from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
+
+
+
+<<case "Chinese Revivalism">>
 ''Chinese Revivalism'' is a future society model which approves of maintaining a solid imperial administration by keeping a Head Girl, a Recruiter, and a Bodyguard; disapproves of failure to do so.
-&nbsp;&nbsp;&nbsp;&nbsp;Increases prosperity growth when all three of these positions are staffed.
-&nbsp;&nbsp;&nbsp;&nbsp;Greatly improves beauty of Chinese slaves.
-&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to permit the Head Girl to see to an additional slave each week.
-&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for intelligence from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
-&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
-\
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Increases prosperity growth when all three of these positions are staffed.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Greatly improves beauty of Chinese slaves.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Can be developed to permit the Head Girl to see to an additional slave each week.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Provides demand for intelligence from [[the corporation|Encyclopedia][$encyclopedia = "The Corporation"]].
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Mutually exclusive with the other Revivalist models.
+
 /**********
 
 LORE: THE FREE CITIES TODAY
 
 **********/
-<<case "Lore">>\
+
+
+<<case "Lore">>
 //Future room for lore text//
-
+<br><br>
 Choose a more particular entry below:
-\
-<<case "Money">>\
-Digital currencies have come a long way in the past twenty years. From the poorly managed, excessively ideological, incompetently run experiments whose failures inspired years of public skepticism, they have matured into a reliable means of exchange. The technical details are unimportant for all but students of economics, since broad diversification and clever design have made them reliable and stable means of exchange. With so many old world currencies collapsing, they are coming to dominate world commerce at last.
 
+
+
+<<case "Money">>
+//Digital currencies have come a long way in the past twenty years. From the poorly managed, excessively ideological, incompetently run experiments whose failures inspired years of public skepticism, they have matured into a reliable means of exchange. The technical details are unimportant for all but students of economics, since broad diversification and clever design have made them reliable and stable means of exchange. With so many old world currencies collapsing, they are coming to dominate world commerce at last.
+<br><br>
 The diversified bundle of assets that constitutes the unit of exchange that allows the Free Cities to function is commonly referred to as the "credit" and denoted in print by a ¤ symbol. It is unusually valuable for a basic monetary unit, but the extreme wealth concentration seen in most of the Free Cities makes this a feature rather than a flaw. Estimating its value is extremely difficult, since the value of goods and services varies wildly between Free Cities, and even more wildly between any given Free City and the surrounding old world.
-
+<br><br>
 Direct comparisons of purchasing power across long gulfs of time are often unscientific. Such comparisons usually rely on indexing currencies to a good or a market basket of goods, ignoring the constant shifts in the value of goods and services throughout history. The best that a responsible economist can do for a historical value of the ¤ is to give a range. Depending on the index good, the 2037 ¤ can be argued to be worth anywhere between thirty and several hundred US dollars.
+<br><br>
+-- Marianne St. Croix, "Digital Currencies: A Review," //Journal of Economics, March 2037////
 
--- Marianne St. Croix, "Digital Currencies: A Review," //Journal of Economics, March 2037//
-<<case "Disease in the Free Cities">>\
-In light of some recent alarmism, it's time for the medical profession to clear the air about diseases.
 
+<<case "Disease in the Free Cities">>
+//In light of some recent alarmism, it's time for the medical profession to clear the air about diseases.
+<br><br>
 Over the course of the 21st century, diseases and disease treatments have become more powerful, side by side. New disease vectors, antibiotic resistances, and even malicious engineering have combined to make infectious agents tougher. However, medicine has advanced as well, with distributed fabrication techniques and genetic sequencing making tailored drugs widely available to those with the resources to afford them.
-
+<br><br>
 This sounds like balance. In the old world, however, it looks like the bugs may be winning. Life expectancy is beginning to settle to pre-antibiotic levels. Meanwhile, in the Free Cities, medicine is dominant: better health care and the ubiquity of modern medicine have nearly eliminated disease as a day-to-day concern.
-
+<br><br>
 If you want simple advice, here it is: fuck your Free Cities slaves bareback, but wrap up if you visit the old world.
+<br><br>
+-- Dodgson, Jane Elizabeth, //FC Med Today, March 25, 2032////
 
--- Dodgson, Jane Elizabeth, //FC Med Today, March 25, 2032//
-<<case "Free Cities Justice">>\
-The Free Cities are not lawless.
 
+<<case "Free Cities Justice">>
+//The Free Cities are not lawless.
+<br><br>
 The only law respected across all Cities is the enforcement of contracts. Some Cities have limited regulation of other areas, but in general, the only justice available comes when a contract has been breached.
-
+<br><br>
 Different Cities have taken different approaches to the obvious problem of dealing with criminal conduct, which in the old world breaks no traditional contract. The most common approach is to require everyone to sign contracts with the owners of their homes and workplaces to commit no crimes while there. In this way, what would be murder in the old world is a breach of the contract with one's landlord not to murder on his property.
-
+<br><br>
 Penalties for such conduct are usually left to the imagination of the property owner. With the traditional roles of judge, jury and jailor concentrated into the hands of a single wealthy person, rich potentates of the Cities hold more personal power over their tenants than anyone since the great feudal lords seven centuries ago.
+<br><br>
+-- Torstein, Jens Learned, //The Modern Libertarian Paradise, March 25, 2032////
 
--- Torstein, Jens Learned, //The Modern Libertarian Paradise, March 25, 2032//
-<<case "Modern Anal">>\
+
+<<case "Modern Anal">>
 //The modern acceptance and frequency of heterosexual anal sex has only increased with the return of slavery.
-
+<br><br>
 There are numerous reasons for this. First and most obviously, the fact that many men now own women and can thus dictate sexual relations has popularized a sex act that has always appealed to many men. Second, the extremely libertine culture of the Free Cities has placed slaveowners in a perpetual contest with one another for sexual decadence; voluntarily //not// using a slave in all possible manners is considered unusual and even prudish. Third, the assignment of some persons born without natural vaginas to status as female sex slaves has served to make standard the use of the orifice that all slaves, regardless of biological particulars, share in common.
-
+<br><br>
 Finally, the development of the now-common slave diet has played a part. In addition to providing slaves with bland, featureless and mildly aphrodisiac nutrition, standard slave nutriment is a cleverly designed liquid diet that almost completely stops the normal digestive processes that might interfere with sex of this kind.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-<<case "Slave Couture">>\
+
+
+<<case "Slave Couture">>
 //My name is Danni Diemen, and I'm here today to talk about your slaves' clothes.
-
+<br><br>
 Let's break it right down into categories, shall we?
-
+<br><br>
 ''First, clothes for your disobedient bitches.'' We must keep them uncomfortable, yes? The old reliable is //slave clothes//, sometimes referred to as straps. These give her that sex slave allure while keeping her nice and uncomfortable. You can also go for full coverage with //latex//. A suit of that will keep her totally reliant on your little whims. //Plugs// are nice sturdy leather affairs with inward-facing dildos for all the holes - and I do mean all. They're good stuff for breaking a bitch, and she might even learn to take dick a bit better! Word to the wise: not a good idea if you want those holes tight, though. Finally, //corsets//. These will make life tough, but that's good for a rebellious little cunt, no? And corseting might just narrow that waist. But never mind, on to my favorites.
-
+<br><br>
 ''Second, nice attire for your prize stock.'' These clothes will keep your good slaves happy. You know, women out in the old world still wear //attractive lingerie// UNDER clothing? Absurd. It's lovely on it's own. If you're looking to be a bit more fun and a bit less classy, go for //string lingerie// instead. You could even let her choose her own //slutty outfits//; watching livestock dress itself is always good fun. When you can afford proper //slutty jewelry//, who needs clothes? I suggest accenting heavy piercings with this. For your hookah fanatics and decadent harem masters, there's //sheer gauze//. Makes even a clumsy girl look like she's dancing to a zither.
-
+<br><br>
 Finally, //chastity belts//. Hard to categorize. Different bitches react in different ways to having the front door locked. Depends on how much traffic goes in the back, I find.
-
+<br><br>
 -- Van Diemen, D. C. G., //Free Cities Fashion (FCF), March 2032////
-<<case "Slave Marriage">>\
+
+
+<<case "Slave Marriage">>
 //Marriage between slaves is one of the facets of slave culture that has varied the most between historical slave societies. Many forbade it entirely, considering it a source of sedition. Others permitted it, but accorded it little force of law. A few have offered it some limited protections even against the slaveowner's will.
-
+<br><br>
 Most Free Cities fall into the middle case. Many slaveowners find it amusing to permit their slaves to form and even formalize long term relationships. Slave wives are often permitted to live and work together, sharing a little room and enjoying some measure of sexual exclusivity. Of course, it is just as common for slave wives to be marketed together in brothels.
-
+<br><br>
 To date, none of the Free Cities has extended any real legal protection to slave marriages. There is nothing to stop a slaveowner from separating slave wives by sale.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
-<<case "The Ejaculate Market">>\
+
+
+<<case "The Ejaculate Market">>
 //Fun has a price.
-
+<br><br>
 Understanding this is the only way to understand some emerging markets in the Free Cities. This maxim often receives criticism from the uninformed, but all it means is that enjoyment is a good (or service) that can be bought and sold like any other. The market for exotic varieties of fun has never been more open than it is right now.
-
+<br><br>
 The forming market for ejaculate can only be understood in this context. In the old world, a thriving market for semen for insemination purposes has been thriving for a long while. In the Free Cities, however, homogenized ejaculate is now available in quantities and at prices that make it obvious that it's being put to other uses. Semen is nutritionally marginal; it has some cosmetic applications, but like every other natural cosmetic it has long since been eclipsed by artificial means. The only possible explanation is that many citizens of the Free Cities find various combinations of slaves and large volumes of ejaculate an amusing combination.
-
+<br><br>
 Anecdotes abound. Some slaveowners claim that using it as a dietary additive with the knowledge of their slaves enforces an extra layer of degradation and sexual servitude while habituating the unfortunates to oral sex.
-
+<br><br>
 -- Editorial, //FC Daily Economic Report, October 13, 2031////
-<<case "Gingering">>\
+
+
+<<case "Gingering">>
 //Like much of the traditional husbandry terminology, 'gingering' is a term whose meaning in the Free Cities is slowly diverging from its original old world definition. In animal husbandry, especially of horses, gingering is the nearly extinct practice of placing an irritant compound (traditionally ginger, hence the term) inside one of the animal's orifices, typically the anus, in order to make the animal step high, be sprightly, and generally behave energetically due to the discomfort. Though it was sometimes used at shows and competitions, the usual application was to make the animal seem more valuable for sale.
-
+<br><br>
 In the Free Cities, 'gingering' is coming to mean any drugging or other temporary adulteration of a slave in order to make her seem more valuable. For poorly broken slaves, stimulants and depressants are both common. These can be applied to make a resistant slave seem less rebellious, or a terrified slave more trusting, though of course this is unreliable.
-
+<br><br>
 More traditional gingering is also sometimes applied. Many new slaves will naturally present their buttocks if an anal irritant is administered in an attempt to relieve the uncomfortable area. Novices to the slave markets may mistake this for sexual promiscuity, though few experienced brokers are likely to be misled, a clue as to why few experienced brokers seriously oppose gingering.
-
+<br><br>
 Some markets attempt to stamp out the practice, but most do not. It is generally accepted as permissible gamesmanship on the part of slave vendors, part of the natural skirmishing between buyers and sellers. In some areas it may even be considered lazy and even offensive for a seller to not doctor his human wares: it denies the buyer an opportunity to exercise his acumen in discovering what has been administered, and might even indicate that the seller is not making an effort in more important areas, too. Finally, many in the Free Cities might ask what proper slave dealer would willingly forgo the amusing sight of a girl bouncing with discomfort because someone has just roughly inserted a finger coated with ginger oil into her rectum.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition////
 /**********
 
 LORE: FREE CITIES CULTURE TOMORROW
 
 **********/
-<<case "The Future of Society">>\
+
+
+<<case "The Future of Society">>
 //The evolution of society has never been linear. Times of unrest and upheaval produce rapid change, followed by long periods of stasis in the absence of the necessary ingredients for further change. The world is undoubtedly in the midst of a time of great change: society is certainly evolving. But into what?
-
+<br><br>
 Not since antiquity have single persons held as much practical power over the direction of society as Free Cities arcology owners now have. Naturally, different Free Cities notables are going different ways with their great power. Many are building new societies as different from each other as they are from the old world.
-
+<br><br>
 One arcology might hold a society that is moving towards a fundamentalist interpretation of an old slave-holding religious tradition. Another might pay homage to historical racially segregated societies. A third might see intentional manipulation of gender roles that have held since the start of recorded history. And these three arcologies might well be each other's neighbors.
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, Online Edition. Accessed April 2, 2032.////
-<<case "The New Rome">>\
+
+
+<<case "The New Rome">>
 ////SCFC//
-&nbsp;&nbsp;&nbsp;&nbsp;-- Free Cities armor pauldron inscription; "Slaveholders and Citizens of the Free Cities"
-
+<br>&nbsp;&nbsp;&nbsp;&nbsp;-- Free Cities armor pauldron inscription; "Slaveholders and Citizens of the Free Cities"
+<br><br>
 In the Free Cities, Rome is come again.
-
+<br><br>
 No people before or since have influenced modern society so deeply as the Romans. The Free Cities are, in return, emulating the Romans more deeply than any other society since their time. Based on the writings, great and low, that have come down to us from that innovative, grasping, and deeply licentious people, it seems that the Romans would likely approve of their posterity.
-
+<br><br>
 Fine historical parallels are probably lost on the person with XY chromosomes who is brought to the Free Cities, enslaved, treated thenceforth as female, and expected to behave as female on pain of severe punishment (sometimes with gender reassignment surgery to match, but often without). This redefinition of gender is common in the Free Cities: being penetrated makes one female, while penetrating makes one male. It almost certainly arose as a way for citizens to partake in all that a slave society has to offer, sexually, without reconsidering their own sexual identity. It is not identical to Roman sexual mores, but the Romans are the closest precedent.
-
+<br><br>
 This new and evolving system of sexual values does not free citizens from all expectations. Quite to the contrary, many find it just as restrictive as old world values, although differently so. For example, a naturally heterosexual female arcology owner who indulges in vanilla sex with masculine slaves will typically find her strength and acumen being questioned for no other reason than that she permits slaves to penetrate her.
-
+<br><br>
 &nbsp;&nbsp;&nbsp;&nbsp;-- Lawrence, J. K., and Bolingbroke, D. S., __Trends in Free Cities Culture, 2031__ //Journal of Modern Social Sciences, International Edition, February 2032////
-<<case "Naked, Barefoot, and Pregnant">>\
+
+
+<<case "Naked, Barefoot, and Pregnant">>
 //...and helpless, and illiterate, and dependant...
-&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous slaveowner, on the ideal woman
-
+<br>&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous slaveowner, on the ideal woman
+<br><br>
 It must be admitted that some of the boldest statements of early 21st century social justice advocates are now receiving some justification in the Free Cities. A tourist visiting some of the more notorious arcologies is given a public, in-person lesson in precisely what some men are willing to do with women they own. For every misogynist credo there is a Free Cities slaveowner putting it into practice.
-
+<br><br>
 Recent reactionism spawned by 20th century social movements pales in comparison to traditionalism, however. Reactionaries of the early 21st century may have breathlessly taken some extreme positions, but for a return to traditional values, true traditionalists have proven themselves to be the unquestioned masters. There are certainly arcologies in which no free women are permitted. The authors recommend that anyone inclined to hold such arcologies up as the extreme by which all others are to be judged should first visit one of the few arcologies in which no free women are permitted, //and// no contraceptives of any kind are permitted, either.
-
+<br><br>
 &nbsp;&nbsp;&nbsp;&nbsp;-- Lawrence, J. K., and Bolingbroke, D. S., __Trends in Free Cities Culture, 2031__ //Journal of Modern Social Sciences, International Edition, February 2032////
-<<case "The Top">>\
+
+
+<<case "The Top">>
 //The Master never beats me half as hard as the Head Girl. She fucks me harder, too.
-&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous slave
-
+<br>&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous slave
+<br><br>
 The safest slave society is a stratified slave society. Innovative Free Cities slaveowners are carefully differentiating their chattel, ensuring that favored slaves are interposed between them and the masses of their lesser stock. This is one of the oldest principles of leadership, ensuring that the grind of day-to-day direction and correction comes from subordinate leaders, while rewards and planning come from the top. The addition of sexuality to this model simply means that many Free Cities slaves get it, so to speak, from both ends.
-
+<br><br>
 There can be great advantages for talented and hardworking slaves. Out in the old world, crime, war, natural disasters, and simple crushing want often strike with little distinction based on intelligence, skill, or strength. A truly excellent individual serving in a well-thought-out arcology can rise to a position of considerable trust and power on her merits. It would be foolish to over-romanticize the reality of slavery, however, for all that advancement rests entirely on the whim of her owner. Talent can count for little for girls unlucky enough to find themselves owned by a capricious master.
-
+<br><br>
 &nbsp;&nbsp;&nbsp;&nbsp;-- Lawrence, J. K., and Bolingbroke, D. S., __Trends in Free Cities Culture, 2031__ //Journal of Modern Social Sciences, International Edition, February 2032////
-<<case "The Bottom">>\
+
+
+<<case "The Bottom">>
 //Public servant today, whore tomorrow, glory hole bitch next month.
-&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous Slave
-
+<br>&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous Slave
+<br><br>
 Slaves at the top of the Free Cities hierarchy enjoy a standard of life far above the average free citizen of the old world. However, slaves at the bottom do not. As the Free Cities redefine what it means to be human, they can be extraordinarily callous to those people who are excluded from the new rubric.
-
+<br><br>
 Free Cities glory holes are perhaps the ultimate expression of the dark side of modern slavery. In the old world, glory holes were mostly a sexual fantasy, and were confined to certain sexual subcultures where they did exist in reality. Free Cities glory holes are different both in that they exist, and are indeed very common; and in that their occupants are almost never present voluntarily.
-
+<br><br>
 Glory holes and slave brothels have a symbiotic existence, and any Free Cities slaveholder who owns a brothel full of pampered prostitutes who claims moral ascendancy for not owning an arcade is ignoring realities. In truth, all slave brothels benefit from the existence of arcades. After all, every slave whore in the Free Cities knows that if she does not perform up to her Master's standards, the arcades exist as a way of extracting value from her body. Every slave brothel receives better efforts out of its slaves due to their knowledge that a worse alternative is always available - if not with their current master, then with some other.
-
+<br><br>
 &nbsp;&nbsp;&nbsp;&nbsp;-- Lawrence, J. K., and Bolingbroke, D. S., __Trends in Free Cities Culture, 2031__ //Journal of Modern Social Sciences, International Edition, February 2032////
-<<case "The Purity of the Human Form">>\
+
+
+<<case "The Purity of the Human Form">>
 //Twentieth century eugenicists weren't wrong, they just didn't have the tools to be right.
-&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous
-
+<br>&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous
+<br><br>
 High quality Free Cities slaves are remarkably healthy. It should be unsurprising that a population of humans selected for beauty, fed perfectly, required to exercise, given modern medical care, and prevented from indulging any non-sexual excess at all, has become quite impressive in this regard. The cultural fallout of this has been less easy to predict.
-
+<br><br>
 Throughout the early part of the 21st century a wide spectra of movements were taking place that have informed the Free Cities ideology of body purism. The left-wing counterculture health movement has found much open ground in a society that allows its adherents to totally control what goes into the bodies of some of its members. On the opposite side of the spectrum, some long-standing reactionary groups have taken this opportunity to experiment with some of their non-racial theories on purity. Finally, many religious or simply moral fundamentalists who believe in some form of purity code now have a captive population to subject to their whims.
-
+<br><br>
 Thousands of unintentional experiments on what really makes the ideal human are now under way in the Free Cities, and whatever the balance of humanity may feel about their morality, it is hard to deny that we as a whole stand to benefit from the experimentation.
-
+<br><br>
 &nbsp;&nbsp;&nbsp;&nbsp;-- Lawrence, J. K., and Bolingbroke, D. S., __Trends in Free Cities Culture, 2031__ //Journal of Modern Social Sciences, International Edition, February 2032////
-<<case "A World Built on Implants">>\
+
+
+<<case "A World Built on Implants">>
 //The earlier a slave gets on advanced growth hormones, the better. After all, good-looking implants are a ratio game. The bigger a girl's natural tits are, the bigger implants she can get without looking ridiculous.
-&nbsp;&nbsp;&nbsp;&nbsp;-- standard Free Cities surgical advice
-
+<br>&nbsp;&nbsp;&nbsp;&nbsp;-- standard Free Cities surgical advice
+<br><br>
 One of the most furious ideological divides in the Free Cities is over implants. Most Free Cities arcologies display a mix of slaves with breast and other implants, but some follow the tastes of owners who strongly prefer all-natural slaves, and some fetishize expansionism to the point of near-universal implantation. This can be a remarkably bitter controversy in places, and should Free Cities culture continue to develop, it is not unlikely that some day physical violence may take place in the Free Cities between extremists on opposite sides of the implant debate.
-
+<br><br>
 In any case, the medical technology of implantation has not advanced hugely since the start of the 21st century. The vast majority of implants are still either water-bag or silicone, with silicone generally preferred for its better, more realistic feel. At the more extreme sizes, a variety of fluid-based designs are used, with polypropylene string implants making a return, and newer, fillable adaptive implants becoming more common.
-
+<br><br>
 &nbsp;&nbsp;&nbsp;&nbsp;-- Lawrence, J. K., and Bolingbroke, D. S., __Trends in Free Cities Culture, 2031__ //Journal of Modern Social Sciences, International Edition, February 2032////
-<<case "Slaves as Stock">>\
+
+
+<<case "Slaves as Stock">>
 //Here we have a fine piece for the dairy folks
-Fine dairy cow for you here ladies and ge-entlemen
-Who'll give me ten thousand ¤
-Ten thousand ¤ bid, now ten thousand five,
-Now ten thousand five, will you give me eleven?
-Thirty-two years old, nipples the size of silver dollars
-Eleven thousand ¤ bid, eleven, eleven?
-&nbsp;&nbsp;&nbsp;&nbsp;-- Free Cities auctioneer
-
+<br>Fine dairy cow for you here ladies and ge-entlemen
+<br>Who'll give me ten thousand ¤
+<br>Ten thousand ¤ bid, now ten thousand five,
+<br>Now ten thousand five, will you give me eleven?
+<br>Thirty-two years old, nipples the size of silver dollars
+<br>Eleven thousand ¤ bid, eleven, eleven?
+<br>&nbsp;&nbsp;&nbsp;&nbsp;-- Free Cities auctioneer
+<br><br>
 At different points in the history of slavery, slaves have been nearly equal to or even in some cases superior to the lowest classes of free citizen, and have been nearly as low as or even lower than the most valuable categories of animal livestock. Which will become the Free Cities norm remains to be seen; there are arcologies that exemplify either approach. A few arcologies apply both standards, and standards in between, all at once.
-
+<br><br>
 The present, however, is a time of great supply in the slave market. The social collapse of many societies in the old world and the perpetual conflicts in many areas are producing an immense number of captives for sale, keeping prices at historically low levels. Many slaveowners treat their chattel relatively well, but this comes from motivations other than financial necessity. With no laws requiring it and no economic reason to treat slaves as different from livestock, many citizens of the Free Cities see little reason to make a distinction. Spectacular expressions of this callousness, like the restraint of women for use as milk production devices or the usage of dangerous dosages of growth hormones, become more understandable when one realizes that the Free Cities are refining what was once a settled idea: what it means to be human.
-
+<br><br>
 &nbsp;&nbsp;&nbsp;&nbsp;-- Lawrence, J. K., and Bolingbroke, D. S., __Trends in Free Cities Culture, 2031__ //Journal of Modern Social Sciences, International Edition, February 2032////
-<<case "Slavery and the Physical Ideal">>\
+
+
+<<case "Slavery and the Physical Ideal">>
 //Quoth BRODIN:
-All must lift.
-&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous
-
+<br>All must lift.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous
+<br><br>
 The medical impacts of the widespread reintroduction of slavery are not at all what might have been predicted twenty years ago. Medicine is not our primary focus in this review of Free Cities cultural trends, but a brief look at the striking medical outcomes is critical to understanding some of the social currents at work. By the second half of the twentieth century, the majority of humanity had reached a state of plenty so great that the health dangers of excess were greater than the health dangers of want.
-
+<br><br>
 For the first time in modern memory, people - slaves - in the Free Cities are, in large numbers, doing exactly what their doctors recommend. Properly managed slaves eath right, exercise regularly, and do not smoke, drink, or do recreational drugs. These simple but revolutionary changes mean that the more valuable classes of slave are healthier, on average, than any group of human beings has ever been.
-
+<br><br>
 Naturally, fetishism, competitiveness, and leisure have intersected to create in the Free Cities a constant escalation of physical one-upsmanship when it comes to the training of slaves. Wonderfully muscled specimens have become very common, with feats of athletic prowess cited alongside sexual accomplishments without any distinction. The arcology owners most devoted to the human form are creating societies of uniform physical perfection unlike anything in human history.
-
+<br><br>
 &nbsp;&nbsp;&nbsp;&nbsp;-- Lawrence, J. K., and Bolingbroke, D. S., __Trends in Free Cities Culture, 2031__ //Journal of Modern Social Sciences, International Edition, February 2032////
-<<case "Faith in the Free Cities">>\
+
+
+<<case "Faith in the Free Cities">>
 //I recognize my faults;
-I am always conscious of my sins.
-I have sinned against you, Master and God,
-And done what you consider evil.
-So you are right in judging me;
-You are justified in condemning me.
-&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous slave, 2030
-
+<br>I am always conscious of my sins.
+<br>I have sinned against you, Master and God,
+<br>And done what you consider evil.
+<br>So you are right in judging me;
+<br>You are justified in condemning me.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;-- Anonymous slave, 2030
+<br><br>
 There are almost as many approaches to faith in the Free Cities as there are arcologies. For every arcology owner who cynically exploits religion, there is another who truly believes himself to be ordained by God as master of his fellow human beings. Nevertheless, common elements are identifiable. The most notorious arise from literal readings of scriptural passages that reference slavery.
-
+<br><br>
 Each of the three major monotheistic religions arose in a time and place where slavery was common. Thus the institution appears in all three of the great monotheistic holy books. It is childishly simple to find all the scriptural support for a reintroduction of slavery even the most illiberal arcology owner could desire in any one of these. This is presumably not what religious conservatives of the late 20th and early 21st centuries intended when advocating scriptural literalism.
-
+<br><br>
 &nbsp;&nbsp;&nbsp;&nbsp;-- Lawrence, J. K., and Bolingbroke, D. S., __Trends in Free Cities Culture, 2031__ //Journal of Modern Social Sciences, International Edition, February 2032////
 /**********
 
 LORE: INTERVIEWS
 
 **********/
-<<case "Slave Whore, Arcology K-2">>\
+
+
+<<case "Slave Whore, Arcology K-2">>
 Interview with a slave whore
-"The Rose Petal," Arcology K-2, April 21, 2036
-
+<br>"The Rose Petal," Arcology K-2, April 21, 2036
+<br><br>
 //Good afternoon. What's your name?//
-Um, what? Are, um, you going to fuck me? I mean, whatever you want to do is okay.
-
+<br>Um, what? Are, um, you going to fuck me? I mean, whatever you want to do is okay.
+<br><br>
 //I'd like to learn more about you.//
-Um, okay. My name is Candace Ass, I'm twenty years old, and I'm one of the slave whores here at the Petal. Um, what else?
-
+<br>Um, okay. My name is Candace Ass, I'm twenty years old, and I'm one of the slave whores here at the Petal. Um, what else?
+<br><br>
 //How did you become a slave? Tell me about how you got here.//
-Sure. Well, uh, it's kind of boring. I was at a club, and I guess someone put something in my drink, and I passed out, and well [laughs nervously] here I am, I guess?
-
+<br>Sure. Well, uh, it's kind of boring. I was at a club, and I guess someone put something in my drink, and I passed out, and well [laughs nervously] here I am, I guess?
+<br><br>
 //What happened when you woke up?//
-Oh, like, you want me to tell you my life story?
-
+<br>Oh, like, you want me to tell you my life story?
+<br><br>
 //Sure.//
-Would it be okay if you fucked me while I tell you? I, uh, can't really think right now. I guess I could also suck - but then I wouldn't be able to talk? Here, please, please stick - oh, okay. Okay! Uh. Yeah. [giggles] That feels better. Thanks!
-
+<br>Would it be okay if you fucked me while I tell you? I, uh, can't really think right now. I guess I could also suck - but then I wouldn't be able to talk? Here, please, please stick - oh, okay. Okay! Uh. Yeah. [giggles] That feels better. Thanks!
+<br><br>
 //Why couldn't you talk without being fucked?//
-Well, we're all really horny. I'm really horny. Everything does it. The hormones, and all the training, and the drugs, and it's also kind of a habit, you know? It's been almost an hour! If you do it slow like that I'll be okay. [giggles] Yeah. Thank you!
-
+<br>Well, we're all really horny. I'm really horny. Everything does it. The hormones, and all the training, and the drugs, and it's also kind of a habit, you know? It's been almost an hour! If you do it slow like that I'll be okay. [giggles] Yeah. Thank you!
+<br><br>
 //You can touch yourself if it helps you think more clearly.//
-Oh thanks but, um, no. That's okay. It's actually really sensitive. Like, um, nobody touches it? And we're not allowed to do that alone anyway. So this is, um, good for me. I'm used to it, I get off like this a lot. If you do it much harder I'll cum, but if you just do it like that, I'll edge for a while. Um, so we can talk? Is that what you wanted?
-
+<br>Oh thanks but, um, no. That's okay. It's actually really sensitive. Like, um, nobody touches it? And we're not allowed to do that alone anyway. So this is, um, good for me. I'm used to it, I get off like this a lot. If you do it much harder I'll cum, but if you just do it like that, I'll edge for a while. Um, so we can talk? Is that what you wanted?
+<br><br>
 //You were telling me about being enslaved.//
-Well, I woke up with a guy on top of me. Kind of like now! But, like, he was really pounding me. It kind of hurt, but I was still really drugged. And I was already on the slave drugs too. And then they put me through a bunch of tests and stuff. That first buttfuck wasn't really a test, it was just a slaver using me. All the new girls get used. But later they tested me a lot, and showed me a bunch of porn and stuff. I think it was to see what I liked. Then they put me in a little room, like a cell, and kept me there for a while.
-
+<br>Well, I woke up with a guy on top of me. Kind of like now! But, like, he was really pounding me. It kind of hurt, but I was still really drugged. And I was already on the slave drugs too. And then they put me through a bunch of tests and stuff. That first buttfuck wasn't really a test, it was just a slaver using me. All the new girls get used. But later they tested me a lot, and showed me a bunch of porn and stuff. I think it was to see what I liked. Then they put me in a little room, like a cell, and kept me there for a while.
+<br><br>
 //How long were you there?//
-I don't really know? All I really did was sleep. It's what happens when you're getting a lot of drugs and need curatives to keep them from hurting you. You just sleep a lot. And when you're awake, you're really groggy and can't remember much. It makes it easier.
-
+<br>I don't really know? All I really did was sleep. It's what happens when you're getting a lot of drugs and need curatives to keep them from hurting you. You just sleep a lot. And when you're awake, you're really groggy and can't remember much. It makes it easier.
+<br><br>
 //It makes what easier?//
-Being raped. I mean, um, that was before I was trained a lot? So I didn't like it most of the time guys fucked me in the ass. But I just laid there and let it happen mostly. I heard from girls later that the slave market I was at uses that as a test, actually.
-
+<br>Being raped. I mean, um, that was before I was trained a lot? So I didn't like it most of the time guys fucked me in the ass. But I just laid there and let it happen mostly. I heard from girls later that the slave market I was at uses that as a test, actually.
+<br><br>
 //A test of what?//
-Well if a new girl is all drugged up and, you know, gets hard and cums when they fuck her, she gets special treatment. A girl they caught with me, I think she came the first day, and she's, like, a Concubine now? But if a girl still fights on all the drugs they put her in the arcade. Most just lie there like me, which means they need better hormones. So then they clip you.
-
+<br>Well if a new girl is all drugged up and, you know, gets hard and cums when they fuck her, she gets special treatment. A girl they caught with me, I think she came the first day, and she's, like, a Concubine now? But if a girl still fights on all the drugs they put her in the arcade. Most just lie there like me, which means they need better hormones. So then they clip you.
+<br><br>
 //Perform an orchiectomy, you mean?//
-Yeah, cut your balls off. [giggles] I don't remember. I just noticed one day that I was really soft and they were gone. And then I started getting really soft and growing better boobs, and the slavers who came in and used me seemed cuter. I asked one of he wanted a blowjob, and then they took me out and trained me a little.
-
+<br>Yeah, cut your balls off. [giggles] I don't remember. I just noticed one day that I was really soft and they were gone. And then I started getting really soft and growing better boobs, and the slavers who came in and used me seemed cuter. I asked one of he wanted a blowjob, and then they took me out and trained me a little.
+<br><br>
 //Sexual training?//
-No, no, just obedience and stuff. I mean, they trained me by making me suck cock and bend over and take it up the butt, but no, like, sex classes. But still mostly sleeping. It's like, I would wake up being fucked, and when the guy was done and had injected whatever into me and made me follow a few commands, I'd go shower and then go back to bed again. Weeks and weeks like that, and then some surgeries.
-
+<br>No, no, just obedience and stuff. I mean, they trained me by making me suck cock and bend over and take it up the butt, but no, like, sex classes. But still mostly sleeping. It's like, I would wake up being fucked, and when the guy was done and had injected whatever into me and made me follow a few commands, I'd go shower and then go back to bed again. Weeks and weeks like that, and then some surgeries.
+<br><br>
 //What surgeries have you had?//
-Lots! [giggles] Um, lip implants. [kissing noise] Obviously. And some little face stuff, like, bone stuff on my jaw and cheekbones. They did something to my throat, and after not letting me talk for a week my voice was high like it is now. Shoulders and hips, more bone stuff. Those hurt, I slept for like a week after each and they left me alone. Butt implants. And boobs, like, obviously. Three times, bigger each time. If they give you the big kind right away you get stretch marks and it's ugly. They say they're going to do it at least once more, so they're bigger than my head. [giggles]
-
+<br>Lots! [giggles] Um, lip implants. [kissing noise] Obviously. And some little face stuff, like, bone stuff on my jaw and cheekbones. They did something to my throat, and after not letting me talk for a week my voice was high like it is now. Shoulders and hips, more bone stuff. Those hurt, I slept for like a week after each and they left me alone. Butt implants. And boobs, like, obviously. Three times, bigger each time. If they give you the big kind right away you get stretch marks and it's ugly. They say they're going to do it at least once more, so they're bigger than my head. [giggles]
+<br><br>
 //When did you move to the brothel?//
-Well Mistress bought me! I think they decided I was ready to be sold when I started asking for sex. They fuck you regularly, like, it's on a schedule? To get you into the habit, and also to get your asshole used to being a fuckhole. And I started wanting it more than the schedule, and cumming almost every time. So they sold me. Mistress kept me for a week, and then sent me down to the brothel.
-
+<br>Well Mistress bought me! I think they decided I was ready to be sold when I started asking for sex. They fuck you regularly, like, it's on a schedule? To get you into the habit, and also to get your asshole used to being a fuckhole. And I started wanting it more than the schedule, and cumming almost every time. So they sold me. Mistress kept me for a week, and then sent me down to the brothel.
+<br><br>
 //What was that week like?//
-Um, I'm not supposed to talk about that? But, um, she fucked me, of course. That's not a big secret. Most sex slaves on the drugs and the training and stuff need sex, like, a lot. So if we're serving only one person, we have to beg. It's nice working here, I don't have to beg much. Oh! And that's also when Mistress picked my name and style. Since my skin is so pale, and my asshole bleached to pink, I'm pink! Pink hair, pink lips, pink nails, pink collar, pink heels, pink asspussy. Candy Ass!
-
+<br>Um, I'm not supposed to talk about that? But, um, she fucked me, of course. That's not a big secret. Most sex slaves on the drugs and the training and stuff need sex, like, a lot. So if we're serving only one person, we have to beg. It's nice working here, I don't have to beg much. Oh! And that's also when Mistress picked my name and style. Since my skin is so pale, and my asshole bleached to pink, I'm pink! Pink hair, pink lips, pink nails, pink collar, pink heels, pink asspussy. Candy Ass!
+<br><br>
 //How long have you been here?//
-Well, ever since Mistress sent me here! So like a year?
-
+<br>Well, ever since Mistress sent me here! So like a year?
+<br><br>
 //Do you know what you'll be doing in the future?//
-Um what? Working here I guess? I don't understand.
-
+<br>Um what? Working here I guess? I don't understand.
+<br><br>
 //How long do you think you'll be here?//
-Well I guess the oldest girl here is around forty? [giggles] She's nice, I like her. She has these huge soft boobs, and her milk is really nice. So I'm twenty, so twenty years I guess?
-
+<br>Well I guess the oldest girl here is around forty? [giggles] She's nice, I like her. She has these huge soft boobs, and her milk is really nice. So I'm twenty, so twenty years I guess?
+<br><br>
 //How many customers do you see a day?//
-It depends, like, it depends on what they want? Like a long fuck or something weird like you, it takes a while, but most just want me to suck them off or take their cock up my butthole. Fifteen maybe?
-
+<br>It depends, like, it depends on what they want? Like a long fuck or something weird like you, it takes a while, but most just want me to suck them off or take their cock up my butthole. Fifteen maybe?
+<br><br>
 //That means you're going to have sex in this brothel more than 100,000 times.//
-The way you say that make it sound like a lot. Oh! Oh, uh, you want me to -
-
+<br>The way you say that make it sound like a lot. Oh! Oh, uh, you want me to -
+<br><br>
 //Be quiet, slave.//
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition//
 	 Appendix A, Interviews
-<<case "Slave Acolyte, Arcology V-7">>\
+
+
+<<case "Slave Acolyte, Arcology V-7">>
 Interview with a Chattel Religionist acolyte
-Main plaza, Arcology V-7, April 28, 2036
-
+<br>Main plaza, Arcology V-7, April 28, 2036
+<br><br>
 Good morning, honored visitor! I'm Patience; how may I serve you?
-
+<br><br>
 //Good morning. What do you do here?//
-Why, I am an acolyte of the Prophet! I have the ordained and undeserved glory of being one of his slaves. I do my unworthy best to do whatever he in his infinite wisdom commands me. Today I am a public servant on the plaza, and it is my duty and pleasure to greet visitors to his arcology, Sir, and to serve them in whatever way I can.
-
+<br>Why, I am an acolyte of the Prophet! I have the ordained and undeserved glory of being one of his slaves. I do my unworthy best to do whatever he in his infinite wisdom commands me. Today I am a public servant on the plaza, and it is my duty and pleasure to greet visitors to his arcology, Sir, and to serve them in whatever way I can.
+<br><br>
 //You seem very enthusiastic.//
-Oh thank you Sir! The Prophet says that the best slave is beautiful and cheerful, but if a slave cannot be both, it is much better for her to be cheerful. [laughs] So I do my best to be cheerful. May I ask what brings you to his arcology, Sir?
-
+<br>Oh thank you Sir! The Prophet says that the best slave is beautiful and cheerful, but if a slave cannot be both, it is much better for her to be cheerful. [laughs] So I do my best to be cheerful. May I ask what brings you to his arcology, Sir?
+<br><br>
 //You may. I travel from arcology to arcology. A tourist, you might say. And I write about what I find.//
-That's wonderful! I'd be happy to share anything with you, anything at all. The Prophet says that all slavery is holy, but Sir, I think his arcology must be more holy than most. And the Prophet says that acolytes are to always be honest, for the holy have nothing to hide.
-
+<br>That's wonderful! I'd be happy to share anything with you, anything at all. The Prophet says that all slavery is holy, but Sir, I think his arcology must be more holy than most. And the Prophet says that acolytes are to always be honest, for the holy have nothing to hide.
+<br><br>
 //I see that.//
-[laughs] My habit, you mean? You must be joking, Sir! It covers most of me.
-
+<br>[laughs] My habit, you mean? You must be joking, Sir! It covers most of me.
+<br><br>
 //Tell me about it.//
-With pleasure, Sir. It is white, because all sex slaves are pure. It covers my head and my shoulders but leaves my face bare so that everyone may see me smile. My breasts are bare because, the Prophet says, they are especially holy things, beautiful, and sexual, and nourishing. They must also be bare so that all can see how they are pure and unspoiled by false implants. My belly is bare to show that I have the very great honor of carrying new slaves for the Prophet. I have a golden belt with a strip of cloth in front and behind, because the Prophet says that sometimes, the imagined sight of a slave's holes are as beautiful as the true sight of them.
-
+<br>With pleasure, Sir. It is white, because all sex slaves are pure. It covers my head and my shoulders but leaves my face bare so that everyone may see me smile. My breasts are bare because, the Prophet says, they are especially holy things, beautiful, and sexual, and nourishing. They must also be bare so that all can see how they are pure and unspoiled by false implants. My belly is bare to show that I have the very great honor of carrying new slaves for the Prophet. I have a golden belt with a strip of cloth in front and behind, because the Prophet says that sometimes, the imagined sight of a slave's holes are as beautiful as the true sight of them.
+<br><br>
 //You must be carrying twins.//
-Yes, Sir, twins. I hope very much to be blessed with triplets next time.
-
+<br>Yes, Sir, twins. I hope very much to be blessed with triplets next time.
+<br><br>
 //Are they the Prophet's?//
-[laughs] Oh, no, Sir! I am just an unworthy old acolyte, not one of the Prophet's wives. I was blessed with the seed of one of the Prophet's breeding girls, much better seed than I deserve. She is young and very beautiful, much more beautiful than me, and many acolytes receive her seed so they can make beautiful new slaves.
-
+<br>[laughs] Oh, no, Sir! I am just an unworthy old acolyte, not one of the Prophet's wives. I was blessed with the seed of one of the Prophet's breeding girls, much better seed than I deserve. She is young and very beautiful, much more beautiful than me, and many acolytes receive her seed so they can make beautiful new slaves.
+<br><br>
 //Between your pregnancy and your breasts, doesn't standing out here on the plaza tire you out?//
-No, Sir. Look here, Sir; [turns sideways] a good acolyte has strong legs, and I exercise twice a day. We must be strong to bear new slaves, work hard, and give pleasure without tiring. I can serve you standing, Sir, even like this. May I show you?
-
+<br>No, Sir. Look here, Sir; [turns sideways] a good acolyte has strong legs, and I exercise twice a day. We must be strong to bear new slaves, work hard, and give pleasure without tiring. I can serve you standing, Sir, even like this. May I show you?
+<br><br>
 //Perhaps later. You seem proud of your body.//
-I am! The Prophet says that a holy slave may certainly be proud of the way in which she serves. I am not beautiful and I am not young, but I am healthy and strong and I am proud of that. I am blessed to be in an arcology where I can take pride in such things.
-
+<br>I am! The Prophet says that a holy slave may certainly be proud of the way in which she serves. I am not beautiful and I am not young, but I am healthy and strong and I am proud of that. I am blessed to be in an arcology where I can take pride in such things.
+<br><br>
 //What do you do when you are not being bred or serving in public?//
-Well, Sir, those are my roles as one of the Prophet's many slave acolytes. In daily life, do you mean, Sir? Well, as I said I exercise a great deal. To maintain my body I must eat a lot, so I have to work hard or I will become fat. Other than that, I live up above us, Sir, in a lower level of the Prophet's penthouse, in a room with my wife. It's a simple life.
-
+<br>Well, Sir, those are my roles as one of the Prophet's many slave acolytes. In daily life, do you mean, Sir? Well, as I said I exercise a great deal. To maintain my body I must eat a lot, so I have to work hard or I will become fat. Other than that, I live up above us, Sir, in a lower level of the Prophet's penthouse, in a room with my wife. It's a simple life.
+<br><br>
 //Your wife?//
-Yes, Sir, my wife Perserverance. There she is, Sir, on the other side of the plaza. One of the ones dressed like me. She has bigger boobs, but she isn't as pregnant right now. [points]
-
+<br>Yes, Sir, my wife Perserverance. There she is, Sir, on the other side of the plaza. One of the ones dressed like me. She has bigger boobs, but she isn't as pregnant right now. [points]
+<br><br>
 //She looks a lot like you.//
-Well, she should, Sir, we're sisters. The Prophet says that slave marriages between sisters are very holy, as long as no seed passes between them, and of course no seed can pass between us, because we both have pussies. I love her very much.
-
+<br>Well, she should, Sir, we're sisters. The Prophet says that slave marriages between sisters are very holy, as long as no seed passes between them, and of course no seed can pass between us, because we both have pussies. I love her very much.
+<br><br>
 //Did you always?//
-Well yes! Oh, I see, Sir. No, no not that way. It was very hard for us, for a long time, but the Prophet is very wise. We were unworthy and slow to accept his wisdom, but he was patient with us and we learned in the end.
-
+<br>Well yes! Oh, I see, Sir. No, no not that way. It was very hard for us, for a long time, but the Prophet is very wise. We were unworthy and slow to accept his wisdom, but he was patient with us and we learned in the end.
+<br><br>
 //That's certainly impressive. How did he teach you?//
-Many ways, of course, Sir, but the Prophet is so wise that he often brings slaves to teach themselves by his wisdom. He has many ways of filling a slave with radiant sexual desire, Sir, so many ways, and they are so powerful, that she must find some way of getting relief. And the Prophet provided that we were each other's only source of relief.
-
+<br>Many ways, of course, Sir, but the Prophet is so wise that he often brings slaves to teach themselves by his wisdom. He has many ways of filling a slave with radiant sexual desire, Sir, so many ways, and they are so powerful, that she must find some way of getting relief. And the Prophet provided that we were each other's only source of relief.
+<br><br>
 //How was that hard for you?//
-The Prophet says that it is natural for it to be hard, and as in all things he was right. We were ashamed, and we cried afterward, every time, for a long time. But we became accustomed to each other's bodies, and we saw that many sister-wives were happy, and no one looked down on us. So we agreed with each other to stop being ashamed.
-
+<br>The Prophet says that it is natural for it to be hard, and as in all things he was right. We were ashamed, and we cried afterward, every time, for a long time. But we became accustomed to each other's bodies, and we saw that many sister-wives were happy, and no one looked down on us. So we agreed with each other to stop being ashamed.
+<br><br>
 //You're completely comfortable speaking about being married to your sister, here in the plaza?//
-Sir, I'm completely comfortable saying here in the plaza that when I awoke this morning, she was sucking the milk from one of my nipples, and that we brought each other to orgasm twice before we came out to the plaza today. I love her! I hope you will let us serve you together.
-
+<br>Sir, I'm completely comfortable saying here in the plaza that when I awoke this morning, she was sucking the milk from one of my nipples, and that we brought each other to orgasm twice before we came out to the plaza today. I love her! I hope you will let us serve you together.
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition//
 	 Appendix A, Interviews
-<<case "Public Slave, Arcology A-3">>\
+
+
+<<case "Public Slave, Arcology A-3">>
 Interview with a public slave subject to Degradationism
-Main plaza, Arcology A-2, April 16, 2036
-
+<br>Main plaza, Arcology A-2, April 16, 2036
+<br><br>
 P-please, Sir! Please fuck me, Sir!
-
+<br><br>
 //Very well. I will ask, though: why?//
-B-because I'm overdue, Sir. If I d-don't get someone to f-fuck me soon, my c-collar will hurt me, Sir. Oh please, oh - oh thank you Sir, please, please - oh, OH -
-
+<br>B-because I'm overdue, Sir. If I d-don't get someone to f-fuck me soon, my c-collar will hurt me, Sir. Oh please, oh - oh thank you Sir, please, please - oh, OH -
+<br><br>
 [Some time later.]
-[Slave collar chimes.]
-
+<br>[Slave collar chimes.]
+<br><br>
 //What was that?//
-Oh, um, [sniff] Sir, the arcology detected that you came inside me, Sir. That means that I have a little time before I have to get fucked again, Sir. [sniff]
-
+<br>Oh, um, [sniff] Sir, the arcology detected that you came inside me, Sir. That means that I have a little time before I have to get fucked again, Sir. [sniff]
+<br><br>
 //All public slaves are subject to this system?//
-All of the Mistress's public slaves, Sir. Some other owners use it, some don't. [sniff] It's s-supposed to make us g-good public representatives for the arcology's slaves. B-because it makes us d-desperate. [sniff] Sir.
-
+<br>All of the Mistress's public slaves, Sir. Some other owners use it, some don't. [sniff] It's s-supposed to make us g-good public representatives for the arcology's slaves. B-because it makes us d-desperate. [sniff] Sir.
+<br><br>
 //You seem articulate, slave. What were you before enslavement?//
-I was a s-student, Sir.
-
+<br>I was a s-student, Sir.
+<br><br>
 //I see. Slave, I would like to learn more about the arcology. You will accompany me as I tour it. If you answer my questions as I do so, I will fuck you when your collar requires it.//
-Oh, thank you, Sir. Thank you. Um, how long will you be here, Sir?
-
+<br>Oh, thank you, Sir. Thank you. Um, how long will you be here, Sir?
+<br><br>
 //None of your concern. Who is the person in that cage hanging there?//
-I don't know, Sir. And, Sir, that's not, um, a person. She's a slave, Sir.
-
+<br>I don't know, Sir. And, Sir, that's not, um, a person. She's a slave, Sir.
+<br><br>
 //I see. What sorts of things are punished that way?//
-Oh, lots of things, Sir. Hesitating. Dropping things. Touching a dick or a clit with teeth. Letting cum spill. Anyone can put a slave in one of the cages; they're public, Sir, and anyone can use a slave in them. You see they're kind of shaped so that the slave is positioned so her holes are sticking out, Sir?
-
+<br>Oh, lots of things, Sir. Hesitating. Dropping things. Touching a dick or a clit with teeth. Letting cum spill. Anyone can put a slave in one of the cages; they're public, Sir, and anyone can use a slave in them. You see they're kind of shaped so that the slave is positioned so her holes are sticking out, Sir?
+<br><br>
 //Follow me.//
-Yes, Sir. [winces] Oh. Um, sorry, Sir.
-
+<br>Yes, Sir. [winces] Oh. Um, sorry, Sir.
+<br><br>
 //Does it hurt to walk in those shoes?//
-N-no, Sir. I need the heels to walk. It's the chain between my nipples that hurts a little when I walk, Sir, and it bounces around. I was wincing, earlier, partly because I was bouncing around, and it hurt, Sir.
-
+<br>N-no, Sir. I need the heels to walk. It's the chain between my nipples that hurts a little when I walk, Sir, and it bounces around. I was wincing, earlier, partly because I was bouncing around, and it hurt, Sir.
+<br><br>
 //And yet you orgasmed.//
-It's h-hard not to, Sir. I have a smart piercing that makes me orgasm, Sir.
-
+<br>It's h-hard not to, Sir. I have a smart piercing that makes me orgasm, Sir.
+<br><br>
 //Why do you need heels to walk?//
-Because my tendons have been clipped, Sir.
-
+<br>Because my tendons have been clipped, Sir.
+<br><br>
 //What did you do?//
-Um, nothing, Sir? It wasn't a punishment, all slaves have their tendons clipped. The heels are a reward. If we're not good, we have to crawl, Sir.
-
+<br>Um, nothing, Sir? It wasn't a punishment, all slaves have their tendons clipped. The heels are a reward. If we're not good, we have to crawl, Sir.
+<br><br>
 [Walking.]
-
+<br><br>
 //Was that fear I just saw?//
-Yes, Sir.
-
+<br>Yes, Sir.
+<br><br>
 //Why?//
-That's the main dairy ahead of us, Sir.
-
+<br>That's the main dairy ahead of us, Sir.
+<br><br>
 //Is it open to the public?//
-T-t-to view, yes, Sir.
-
+<br>T-t-to view, yes, Sir.
+<br><br>
 //Follow me.//
-Y-yes, Sir. [sniff]
-
+<br>Y-yes, Sir. [sniff]
+<br><br>
 //That is quite an impressive sight.//
-Yes, Sir.
-
+<br>Yes, Sir.
+<br><br>
 //Do you know how large they are?//
-Th-th-their breasts, Sir? About t-twenty or twenty five liters e-ea-each, S-Sir.
-
+<br>Th-th-their breasts, Sir? About t-twenty or twenty five liters e-ea-each, S-Sir.
+<br><br>
 //Why does this frighten you so much?//
-W-well, I'll, um, be put in here, Sir. Someday. Oh. [sniff]
-
+<br>W-well, I'll, um, be put in here, Sir. Someday. Oh. [sniff]
+<br><br>
 //Why?//
-All slaves are p-put in h-here, when they're loose, Sir. All the, the, the //sex,// it's just to loosen us, s-so those //things// will fit inside...
-
+<br>All slaves are p-put in h-here, when they're loose, Sir. All the, the, the //sex,// it's just to loosen us, s-so those //things// will fit inside...
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition//
 	 Appendix A, Interviews
-<<case "Mercenary, Arcology B-2">>\
+
+
+<<case "Mercenary, Arcology B-2">>
 Interview with a Free Cities mercenary
 The Wild Goose, Arcology B-2, March 11, 2036
-
+<br><br>
 //Good evening.//
-No offense, but I only fuck girls.
-
+<br>No offense, but I only fuck girls.
+<br><br>
 //None taken, and I'm just looking for conversation.//
-'k, buy the next round and converse away.
-
+<br>'k, buy the next round and converse away.
+<br><br>
 //Done. Fine to meet you. I'm touring the arcologies, writing a book. I'd like to ask you about life as a mercenary here in the Free Cities.//
-[laughs] Shit, I'm going to be famous.
-
+<br>[laughs] Shit, I'm going to be famous.
+<br><br>
 //If you'd like to be. I'm W.G.; what's your name?//
-Well, W.G., I'll answer questions for your book, but I don't actually want to be famous. No names.
-
+<br>Well, W.G., I'll answer questions for your book, but I don't actually want to be famous. No names.
+<br><br>
 //That works fine for me. How did you become a mercenary?//
-I was a soldier, and the pay was shit, so instead of re-upping I went merc. Boring, but pretty common, believe me. Half the old world militaries are just merc training camps now. You enlist, and then you get out as soon as you have enough experience that a mercenary group'll take you on.
-
+<br>I was a soldier, and the pay was shit, so instead of re-upping I went merc. Boring, but pretty common, believe me. Half the old world militaries are just merc training camps now. You enlist, and then you get out as soon as you have enough experience that a mercenary group'll take you on.
+<br><br>
 //Did you have combat experience?//
-[laughs] You know your shit. No, no I did not. I wasn't even infantry. Dirty little secret you probably already know: if you're a girl, most merc groups don't give a fuck what experience you actually have, 'cause either way, they win.
-
+<br>[laughs] You know your shit. No, no I did not. I wasn't even infantry. Dirty little secret you probably already know: if you're a girl, most merc groups don't give a fuck what experience you actually have, 'cause either way, they win.
+<br><br>
 //I think I understand, but lay it out for me.//
-If you're a good troop, you're a good troop and they come out ahead. Rifle don't care what equipment the merc holding it has. If you're not a good troop, they tie you up in a shipping container, use you 'till they get bored, and then sell you. And they come out ahead. Win-win.
-
+<br>If you're a good troop, you're a good troop and they come out ahead. Rifle don't care what equipment the merc holding it has. If you're not a good troop, they tie you up in a shipping container, use you 'till they get bored, and then sell you. And they come out ahead. Win-win.
+<br><br>
 //You obviously came out on the right side of that, but did you suffer any abuse before then?//
-Nah. It'd be dumb to do anything to a newbie and then not enslave 'em. What, you're gonna rape somebody and then give 'em two-forty rounds, four frags, and a satchel charge? Fuck no.
-
+<br>Nah. It'd be dumb to do anything to a newbie and then not enslave 'em. What, you're gonna rape somebody and then give 'em two-forty rounds, four frags, and a satchel charge? Fuck no.
+<br><br>
 //That's what you carry?//
-Yeah fuck that subject anyway. And yeah, when taking prisoners isn't on the agenda. I'm a big girl, I can manage eight mags in a double deck chest rig. If we are taking prisoners, then swap out half the frags for gas and half the mags for an underslung S. G. with beanbags and tazer rounds. Though you never want to use any of that, nonlethals included.
-
+<br>Yeah fuck that subject anyway. And yeah, when taking prisoners isn't on the agenda. I'm a big girl, I can manage eight mags in a double deck chest rig. If we are taking prisoners, then swap out half the frags for gas and half the mags for an underslung S. G. with beanbags and tazer rounds. Though you never want to use any of that, nonlethals included.
+<br><br>
 //Because you might damage the merchandise?//
-Because you might damage the merchandise. Did you know it's possible to burst an implant with a beanbag round? Well, it's possible to burst an implant with a beanbag round.
-
+<br>Because you might damage the merchandise. Did you know it's possible to burst an implant with a beanbag round? Well, it's possible to burst an implant with a beanbag round.
+<br><br>
 //You know I have to ask about that now.//
-And I wouldn't have said it if I didn't want to tell the story. Not a long one anyway. Old world mob boss asshole with a moored yacht full of hoes, all tats and fake tits and shit. We went in quick without enough muscle and the guards resisted. Perfect op is, you go in so heavy that nobody resists, but it was rushed and we had to put 'em down. So all these bitches are running around screaming their heads off and we get the call that the police are coming. Didn't want to shoot it out with them since the tip came from a cop in the first place. So we had a couple of minutes to grab what we could and jet. So, beanbags, zipties, bodybags, and off - we - go, one hoe apiece.
-
+<br>And I wouldn't have said it if I didn't want to tell the story. Not a long one anyway. Old world mob boss asshole with a moored yacht full of hoes, all tats and fake tits and shit. We went in quick without enough muscle and the guards resisted. Perfect op is, you go in so heavy that nobody resists, but it was rushed and we had to put 'em down. So all these bitches are running around screaming their heads off and we get the call that the police are coming. Didn't want to shoot it out with them since the tip came from a cop in the first place. So we had a couple of minutes to grab what we could and jet. So, beanbags, zipties, bodybags, and off - we - go, one hoe apiece.
+<br><br>
 //That sounds risky.//
-Yeah it was. I'm not some hothead who does shit like that for the rush. If you run that op once a week you're going to be dead inside a year. I found new employers not long after that one. Funny story and all, but if I hadn't gone with ceramic side plates in my vest that night I would have been fucked.
-
+<br>Yeah it was. I'm not some hothead who does shit like that for the rush. If you run that op once a week you're going to be dead inside a year. I found new employers not long after that one. Funny story and all, but if I hadn't gone with ceramic side plates in my vest that night I would have been fucked.
+<br><br>
 //This is a quieter outfit?//
-Much. Writer, I am now bored. And since I am drunk, and horny, and an incorrigible dyke, I am going to go find a cute slave with freckles and make her eat my pussy until I pass out. You want the other end?
-
+<br>Much. Writer, I am now bored. And since I am drunk, and horny, and an incorrigible dyke, I am going to go find a cute slave with freckles and make her eat my pussy until I pass out. You want the other end?
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition//
 	 Appendix A, Interviews
-<<case "Slave Trainer, Arcology D-10">>\
+
+
+<<case "Slave Trainer, Arcology D-10">>
 Interview and observation with a Free Cities slave trainer
 Slave Market training plaza, Arcology D-10, May 23, 2036
-
+<br><br>
 ''Good morning! I'm Lawrence, W.G. Lawrence.''
 //Hello. Nice to meet you. I'm Claudia.//
-
+<br><br>
 ''I'd like to thank you for being willing to have me along as an observer; it's very kind of you.''
 //My pleasure. I do good work and I don't mind people knowing it.//
-
+<br><br>
 ''May I ask you a few questions before you get back to your routine?''
 //Sure. We're going to be working with a new slave today, and I've got her in my office, sitting and thinking. There's no rush. Unpredictability is good.//
-
+<br><br>
 ''What got you into this career?''
 //Well, I'm an ex-slave. I served my Mistress, the owner of this arcology, for three years. But I'm getting things out of order. I was a Sister before that. That's a very long story. Do you want to get into that? Every single Sister has the same story. [laughs] That's the beauty of it.//
-
+<br><br>
 ''That's all right. You mentioned before that you'd like to be known for what you're doing now.''
 //Yeah. I'm not ashamed of any of it, and I wouldn't be where I am without it, but I'm my own woman now.//
-
+<br><br>
 ''And you became your own woman after retiring from slavery here?''
 //I did, yes. It was bittersweet, but it was time. Mistress prefers young ladies.//
-
+<br><br>
 ''You keep referring to her as Mistress. Is that leftover conditioning?''
 //[laughs] No, no, that's just what I call her, you know? She'll always be my Mistress in a way. And again, I'm here because she retires her girls incredibly well.//
-
+<br><br>
 ''What was your role with her?''
 //I was her Head Girl, for my last year with her, at least. Before that, her Head Girl's girl. That Head Girl was a Sister, too. I can introduce you, if you'd like; she's a trainer here too. We work together sometimes.//
-
+<br><br>
 ''Was that a blush?''
 //Okay, okay! We spend time together after work sometimes, too. Anyway, slave training. Come with me, my office is back this way.//
-
+<br><br>
 ''Who are you training today?''
 //New slave, just bought her from the kidnappers yesterday. Pretty average. Mid-twenties, student then housewife. Decent tits, but too chubby. We'll work on that. And here we are.//
-
+<br><br>
 ''Impressive office, even from the outside.''
 //Thanks. So, she's in there. Room's soundproof, she can't hear us. Here's how I'd like to play this: just stay out of the light, and you can observe as long as you like. She's under a spotlight, and everything else is dark. She probably won't even know you're there.//
-
+<br><br>
 ''That would work very well, thank you.''
 //You're welcome. After you.//
-
+<br><br>
 //Hello, Suzanne.//
 H-hi, Ma'am.
-
+<br><br>
 //Stand up.//
 Yes, Ma'am. Um, Ma'am, may I please have my pants back? They took them away in the market, and I thought since you gave my sweater back, you'd -
-
+<br><br>
 //Be quiet.//
 Yes, Ma'am.
-
+<br><br>
 //Hold your hands at your sides like I told you, and stop pulling your sweater down over your pussy.//
 Y-yes, Ma'am.
-
+<br><br>
 //Turn around.//
 Yes, Ma'am.
-
+<br><br>
 //Do you like having your big fat naked butt hanging out, bitch?//
 Yes, Ma - aaAAH! Oh, ow, oh my God, ow -
-
+<br><br>
 //Be quiet. That was a 2. Your collar goes to 10.//
 [sobbing] Yes, Ma'am.
-
+<br><br>
 //You just lied to me. I will ask again: do you like having your big fat naked butt hang out?//
 N-no, Ma'am.
-
+<br><br>
 //Take your sweater off. Good bitch. That's right, blush for me. Now, tear it in half.//
 What!? Oh please, no, please no, I'll do it! Please don't shock me again, Ma'am! [frantic tearing]
-
+<br><br>
 //You don't need clothes, bitch. Not anymore. Now, turn back around, and bend over.//
 Yes, Ma'am.
-
+<br><br>
 //Spread your big fat buttcheeks.//
 Yes, Ma'am.
-
+<br><br>
 //Ever had a cock up your butthole, Suzie?//
 [sobbing]
-
+<br><br>
 -- Lawrence, W. G., //Guide to Modern Slavery, 2037 Edition//
 	 Appendix A, Interviews
-<<case "Credits">>\
+
+
+<<case "Credits">>
 This game was created by a person with no coding experience whatsoever. If I can create a playable h-game, so can you.
-
+<br><br>
 __I do not give credit without explicit permission to do so.__ If you have contributed content and are not credited, please email me via the blog so I can give credit where it is due.
-
+<br><br>
 ''Boney M'' of JoNT /hgg/ mod fame has been invaluable, combing tirelessly through the code to find and report my imbecilities.
-&nbsp;&nbsp;&nbsp;&nbsp;Coded an improvement to the relative recruitment system.
-&nbsp;&nbsp;&nbsp;&nbsp;Wrote and coded the Ancient Egyptian Revivalism acquisition event.
-&nbsp;&nbsp;&nbsp;&nbsp;Wrote and coded a prestige event for ex-abolitionists.
-&nbsp;&nbsp;&nbsp;&nbsp;Coded a training event for slaves who hate blowjobs.
-&nbsp;&nbsp;&nbsp;&nbsp;Wrote and coded several slave introduction options.
-''DrPill'' has offered great feedback, playtested exhaustively, and more.
-&nbsp;&nbsp;&nbsp;&nbsp;Wrote a slave introduction option.
-''bob22smith2000'' has made major contributions, not limited to close review of thousands of lines of code.
-&nbsp;&nbsp;&nbsp;&nbsp;Improved all facility and most assignment code for v0.5.11, an immense task.
-''Gerald Russell'' went into the code to locate and fix bugs.
-''Ryllynyth'' contributed many bugfixes and suggestions in convenient code format.
-''CornCobMan'' contributed several major modpacks, which include clothing, hair and eye colors, a facility name and arcology name expansions, UI improvements, nicknames, names, balance, a huge rework of the Rules Assistant, and more. CornCobMan has indefatigably supported the RA updates.
-''Klementine'' wrote the fertility goddess skin for the personal assistant.
-''Wahn'' wrote numerous generic recruitment events.
-''PregAnon'' has modded extensively, including descriptive embellishments for pregnant slaves, various asset descriptions, Master Suite reporting, the Wardrobe, a pack of facility leader interactions, options for Personal Assistant appearances, birthing scenes, fake pregnancy accessories, many other preg mechanics, blind content, expanded chubby belly descriptions, several new surgeries, neon and metallic makeup, better descriptive support for different refreshments, work on choosesOwnJob, many bugfixes, an expansion to the hostage corruption event chain, slave specific player titles, gagging and several basic gags, extended family mode, oversized sex toys, buttplug attachment system, and other, likely forgotten, things.
-''Bane70'' optimized huge swaths of code with notable professionalism.
-''Circle Tritagonist'' provided several new collars and outfits.
-''Qotsafan'' submitted bugfixes.
-''FireDrops'' provided standardized body mod scoring, gave Recruiters their idle functions, revised personal assistant future society associations, and fixed bugs.
-''Princess April'' wrote and coded several random events and the Slimness Enthusiast Dairy upgrade.
-''Hicks'' provided minor logic and balance improvements in coded, release-ready form.
-''Dej'' coded better diet logic for the RA.
-''Flooby Badoop'' wrote and coded a random recruitment event.
-''FC_BourbonDrinker'' went into the code to locate and fix bugs.
-''Shokushu'' created a rendered imagepack comprising 775 images, and assisted with the code necessary to display them.
-''NovX'' created a vector art system.
-''Mauve'' contributed vector collars and pubic hair.
-''Rodziel'' contributed the cybernetics mod.
-''prndev'' wrote the Free Range Dairy Assignment scene.
-''freecitiesbandit'' wrote a number of recruitment, future society, mercenary and random events, provided tailed buttplugs, new eyes and tattoos, and contributed the code for the mercenary raiders policy.
-''DrNoOne'' wrote the bulk slave purchase and persistent summary code.
-''Mauve'' provided vector art for chastity belts and limp dicks.
-
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Coded an improvement to the relative recruitment system.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Wrote and coded the Ancient Egyptian Revivalism acquisition event.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Wrote and coded a prestige event for ex-abolitionists.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Coded a training event for slaves who hate blowjobs.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Wrote and coded several slave introduction options.
+<br>''DrPill'' has offered great feedback, playtested exhaustively, and more.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Wrote a slave introduction option.
+<br>''bob22smith2000'' has made major contributions, not limited to close review of thousands of lines of code.
+<br>&nbsp;&nbsp;&nbsp;&nbsp;Improved all facility and most assignment code for v0.5.11, an immense task.
+<br>''Gerald Russell'' went into the code to locate and fix bugs.
+<br>''Ryllynyth'' contributed many bugfixes and suggestions in convenient code format.
+<br>''CornCobMan'' contributed several major modpacks, which include clothing, hair and eye colors, a facility name and arcology name expansions, UI improvements, nicknames, names, balance, a huge rework of the Rules Assistant, and more. CornCobMan has indefatigably supported the RA updates.
+<br>''Klementine'' wrote the fertility goddess skin for the personal assistant.
+<br>''Wahn'' wrote numerous generic recruitment events.
+<br>''PregAnon'' has modded extensively, including descriptive embellishments for pregnant slaves, various asset descriptions, Master Suite reporting, the Wardrobe, a pack of facility leader interactions, options for Personal Assistant appearances, birthing scenes, fake pregnancy accessories, many other preg mechanics, blind content, expanded chubby belly descriptions, several new surgeries, neon and metallic makeup, better descriptive support for different refreshments, work on choosesOwnJob, many bugfixes, an expansion to the hostage corruption event chain, slave specific player titles, gagging and several basic gags, extended family mode, oversized sex toys, buttplug attachment system, and other, likely forgotten, things.
+<br>''Bane70'' optimized huge swaths of code with notable professionalism.
+<br>''Circle Tritagonist'' provided several new collars and outfits.
+<br>''Qotsafan'' submitted bugfixes.
+<br>''FireDrops'' provided standardized body mod scoring, gave Recruiters their idle functions, revised personal assistant future society associations, and fixed bugs.
+<br>''Princess April'' wrote and coded several random events and the Slimness Enthusiast Dairy upgrade.
+<br>''Hicks'' provided minor logic and balance improvements in coded, release-ready form.
+<br>''Dej'' coded better diet logic for the RA.
+<br>''Flooby Badoop'' wrote and coded a random recruitment event.
+<br>''FC_BourbonDrinker'' went into the code to locate and fix bugs.
+<br>''Shokushu'' created a rendered imagepack comprising 775 images, and assisted with the code necessary to display them.
+<br>''NovX'' created a vector art system.
+<br>''Mauve'' contributed vector collars and pubic hair.
+<br>''Rodziel'' contributed the cybernetics mod.
+<br>''prndev'' wrote the Free Range Dairy Assignment scene.
+<br>''freecitiesbandit'' wrote a number of recruitment, future society, mercenary and random events, provided tailed buttplugs, new eyes and tattoos, and contributed the code for the mercenary raiders policy.
+<br>''DrNoOne'' wrote the bulk slave purchase and persistent summary code.
+<br>''Mauve'' provided vector art for chastity belts and limp dicks.
+<br><br>
 ''Many other anonymous contributors'' helped fix bugs via GitHub. They will be credited by name upon request.
-
+<br><br>
 Thanks are due to all the anons that submitted slaves for inclusion in the pre-owned database and offered content ideas. Many anonymous playtesters also gave crucial feedback and bug reports. May you all ride straight to the gates of Valhalla, shiny and chrome.
-<<case "Game Mods">>\
-\
-<<case "Security Force">>\
-''NOTE: The Security Force is an optional mod, and as such will only be initialized in-game if it is enabled at game start or in the options menu.''
 
+
+<<case "Game Mods">>
+
+
+<<case "Security Force">>
+''NOTE: The Security Force is an optional mod, and as such will only be initialized in-game if it is enabled at game start or in the options menu.''
+<br><br>
 <blockquote>//Man has killed man from the beginning of time, and each new frontier has brought new ways and new places to die. Why should the future be different? Make no mistake friend, the Free Cities are the future, and we can either live like kings inside them, or die in their shadow. I prefer the former. So should you.//
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; //- The Colonel, standard message to potential recruits//</blockquote>
 Once your arcology has been severely tested by external attack, and thus proven that the anti-militaristic principles of anarcho-capitalism might not be sufficient to ensure the physical security of the citizenry, you will receive an event that gives you the opportunity to establish a Security Force (with a customizable name), with the Colonel as its commander under you. This force will be a private military in all but name (unless you want that name). Once activated, you can manage its deployment from the end of week screen. You will be able to issue orders on the force's task and behavior, and this will impact its development. There are numerous events that can trigger depending on development and orders.
-
+<br><br>
 Initially the force will not be very profitable, but once it expands, it can become so. The speed at which this happens, and the degree of profitability, depends both on your orders to the force and the upgrades you purchase in the Barracks. If you had mercenaries, they will still be active for the purposes of events, corporation assistance (if present), and upkeep costs, abstracted as distinct operatives from the security force.
-
+<br><br>
 __Orders to the Colonel:__
 	Once the force is active, you will be able to give orders to the colonel. These will affect its income and performance. The orders are:
-
+<br><br>
 	''Deployment Focus:'' This will determine the force's main task for the week. ''Recruit and Train'' will focus on increasing manpower and replacing losses incurred over time. ''Secure Trade Routes'' will increase reputation and prosperity by amounts that scale with the force's development. ''Slaving and Raiding'' will directly bring in cash and (occasionally) slaves, with the amounts and quality increasing with the force's development. All three will occur every week, but the focus will determine the primary result.
-
+<br><br>
 	''Rules of Engagement:'' This will determine how carefully the force uses its weapons, and affect its change in reputation, as well as events seen. Will they hold their fire unless fired upon? Or will they call in an artillery strike on a refugee convoy that took a potshot at them? ''Hold Fire'' will restrict the force to only returning fire if they're fired upon. ''Limited Fire'' will permit some proactive fire from the force (to eliminate known threats). ''Free Fire'' will permit the force to shoot at anything/anyone, at any time, for any reason.
-
+<br><br>
 	''Accountability:'' This will determine how accountable the force is for its actions outside the Arcology, and affect its change in reputation, as well as events seen. Will you punish them if they massacre a caravan for one choice slave girl? Or shoot random civilians for their valuables? ''Strict Accountability'' will ensure the force avoids committing atrocities (other than immense collateral damage if free-fire is enabled). ''Some Accountability'' will prevent the worst actions, but overlook lesser ones. ''No Accountability'' will let the force run wild.
-
+<br><br>
 	Allowing them to run wild will, over time, change their character, rendering them increasingly depraved as they realize that they can do whatever they want to non-citizens. Giving them rules might correct this, but reversing such behavior once learned would take a long time indeed.
-
+<br><br>
 __Barracks:__
 	The Barracks are the upgrade and flavor screen for the Security Force. It is treated as a special facility, and slaves cannot be assigned to it. Here you can observe the antics and relaxation behavior of the force, which will, again, change based on your orders and its reputation. You can visit once a week to receive some extra tribute from the colonel, specially saved for its patron from its weekly acquired loot, and this 'gift' will improve in quality as the force develops.
-
+<br><br>
 __Upgrades:__
 	Upgrades can be purchased in the Barracks. The upgrades that can be purchased will both increase in effectiveness of the force (i.e. how much money/reputation it makes). The upgrades focus on improving the force's infantry equipment, vehicles, aircraft, drones, and stimulants. Some upgrades are more helpful at facilitating different tasks (Vehicles/Aircraft for Slaving/Raiding, Drones for Securing Trade). Arcology upgrades enable other upgrades to be purchased. Stimulants increase overall effectiveness for the force when assigned to raiding after upgrades are considered, as well as flavor text.
-
+<br><br>
 Explore the options and enjoy the benefits of having a complete private military!
-\
-\
-\
-\
 
 
-<<default>>\
+<<default>>
 Error: bad title.
-<</switch>>\
-\
-<<nobr>>
+<</switch>>
 
 <<if ["Playing Free Cities","First Game Guide","How to Play","Keyboard Shortcuts","The Arcology Interface","Tips and Tricks"].includes($encyclopedia)>>
-<br>
+<br><br>
 //Gameplay//<br>
 [[First Game Guide|Encyclopedia][$encyclopedia = "First Game Guide"]]
  | [[How to Play|Encyclopedia][$encyclopedia = "How to Play"]]
@@ -2110,7 +2599,7 @@ Error: bad title.
 
 
 <<if ["Being in charge","Arcologies and Reputation","Random Events","Costs Summary","Rules Assistant","The Corporation","Sexual Energy",].includes($encyclopedia)>>
-<br>
+<br><br>
 //Being in charge//<br>
 [[Arcologies and Reputation|Encyclopedia][$encyclopedia = "Arcologies and Reputation"]]
  | [[Random Events|Encyclopedia][$encyclopedia = "Random Events"]]
@@ -2121,8 +2610,8 @@ Error: bad title.
 <</if>>
 
 
-<<if ["Slaves","Enslaving People","From Rebellious to Devoted","Health", "Devotion","Trust","Drugs and Their Effects","Gender","Nymphomania", "Indentured Servants","Menial Slaves","Lingua Franca","Slave Score (Attractiveness)","Slave Score (Sexual)"].includes($encyclopedia)>>
-<br>
+<<if ["Slaves","Enslaving People","From Rebellious to Devoted","Health", "Devotion","Trust","Drugs and Their Effects","Gender","Nymphomania","Indentured Servants","Menial Slaves","Fuckdolls","Lingua Franca","Slave Score (Attractiveness)","Slave Score (Sexual)"].includes($encyclopedia)>>
+<br><br>
 //Slaves//<br>
 [[Enslaving People|Encyclopedia][$encyclopedia = "Enslaving People"]]
 | [[From Rebellious to Devoted|Encyclopedia][$encyclopedia = "From Rebellious to Devoted"]]
@@ -2134,6 +2623,7 @@ Error: bad title.
 | [[Nymphomania|Encyclopedia][$encyclopedia = "Nymphomania"]]
 | [[Indentured Servants|Encyclopedia][$encyclopedia = "Indentured Servants"]]
 | [[Menial Slaves|Encyclopedia][$encyclopedia = "Menial Slaves"]]
+| [[Fuckdolls|Encyclopedia][$encyclopedia = "Fuckdolls"]]
 | [[Lingua Franca|Encyclopedia][$encyclopedia = "Lingua Franca"]]
 | [[Slave Score (Attractiveness)|Encyclopedia][$encyclopedia = "Slave Score (Attractiveness)"]]
 | [[Slave Score (Sexual)|Encyclopedia][$encyclopedia = "Slave Score (Sexual)"]]
@@ -2141,7 +2631,7 @@ Error: bad title.
 
 
 <<if ["Obtaining Slaves","Kidnapped Slaves","Slave Schools","Stables","Household Liquidations","Direct Sales","Pre-Owned Slaves"].includes($encyclopedia)>>
-<br>
+<br><br>
 //Obtaining slaves//<br>
 [[Kidnapped Slaves|Encyclopedia][$encyclopedia = "Kidnapped Slaves"]]
  | [[Slave Schools|Encyclopedia][$encyclopedia = "Slave Schools"]]
@@ -2150,7 +2640,6 @@ Error: bad title.
  | [[Direct Sales|Encyclopedia][$encyclopedia = "Direct Sales"]]
  | [[Pre-Owned Slaves|Encyclopedia][$encyclopedia = "Pre-Owned Slaves"]]
 <</if>>
-
 
 <<if ["Slave Assignments","Career Experience","Attendant","Bodyguard","Concubine","DJ","Head Girl","Madam","Milkmaid","Nurse","Recruiter","Schoolteacher","Stewardess","Wardeness","Attending Classes","Confinement","Fucktoy","Glory Hole","Milking","Public Service","Rest","Sexual Servitude","Servitude","Whoring",].includes($encyclopedia)>>
 <br><br>
@@ -2180,7 +2669,6 @@ Error: bad title.
 | [[Servitude, Sexual|Encyclopedia][$encyclopedia = "Sexual Servitude"]]
 | [[Servitude|Encyclopedia][$encyclopedia = "Servitude"]]
 | [[Whoring|Encyclopedia][$encyclopedia = "Whoring"]]
-<br>
 <</if>>
 
 
@@ -2215,6 +2703,7 @@ Error: bad title.
 | [[XY|Encyclopedia][$encyclopedia = "Hormones (XY)"]]
 <</if>>
 
+
 <<if["Skills","Anal Skill","Combat Skill","Entertainment Skill","Oral Skill","Vaginal Skill","Whoring Skill"].includes($encyclopedia)>>
 <br><br>
 //Skills// | [[Career Experience|Encyclopedia][$encyclopedia = "Career Experience"]]
@@ -2230,7 +2719,8 @@ Error: bad title.
 
 <<if ["Fetishes","Boob Fetishists","Buttsluts","Cumsluts","Doms","Humiliation Fetishists","Masochists","Pregnancy Fetishists","Sadists","Submissives"].includes($encyclopedia)>>
 <br><br>
-//Slave Fetishes//<br>
+//Slave Fetishes//
+<br>
 [[Boob Fetishists|Encyclopedia][$encyclopedia = "Boob Fetishists"]]
 | [[Buttsluts|Encyclopedia][$encyclopedia = "Buttsluts"]]
 | [[Cumsluts|Encyclopedia][$encyclopedia = "Cumsluts"]]
@@ -2245,7 +2735,8 @@ Error: bad title.
 
 <<if["Quirks","Adores men","Adores women","Advocate","Confident","Cutting","Fitness","Funny","Insecure","Sinful",].includes($encyclopedia)>>
 <br><br>
-//Behavioral [[Quirks|Encyclopedia][$encyclopedia = "Quirks"]]://<br>
+//Behavioral [[Quirks|Encyclopedia][$encyclopedia = "Quirks"]]://
+<br>
 [[Adores men|Encyclopedia][$encyclopedia = "Adores men"]]
 | [[Adores women|Encyclopedia][$encyclopedia = "Adores women"]]
 | [[Advocate|Encyclopedia][$encyclopedia = "Advocate"]]
@@ -2260,7 +2751,8 @@ Error: bad title.
 
 <<if ["Quirks","Caring","Gagfuck Queen","Painal Queen","Perverted","Romantic","Size Queen","Strugglefuck Queen","Tease","Unflinching"].includes($encyclopedia)>>
 <br><br>
-//Sexual [[Quirks|Encyclopedia][$encyclopedia = "Quirks"]]://<br>
+//Sexual [[Quirks|Encyclopedia][$encyclopedia = "Quirks"]]://
+<br>
 [[Caring|Encyclopedia][$encyclopedia = "Caring"]]
 | [[Gagfuck Queen|Encyclopedia][$encyclopedia = "Gagfuck Queen"]]
 | [[Painal Queen|Encyclopedia][$encyclopedia = "Painal Queen"]]
@@ -2275,7 +2767,8 @@ Error: bad title.
 
 <<if ["Flaws","Anorexic","Arrogant","Bitchy","Devout","Gluttonous","Hates men","Hates women","Liberated","Odd"].includes($encyclopedia)>>
 <br><br>
-//Behavioral [[Flaws|Encyclopedia][$encyclopedia = "Flaws"]]://<br>
+//Behavioral [[Flaws|Encyclopedia][$encyclopedia = "Flaws"]]://
+<br>
 [[Anorexic|Encyclopedia][$encyclopedia = "Anorexic"]]
 | [[Arrogant|Encyclopedia][$encyclopedia = "Arrogant"]]
 | [[Bitchy|Encyclopedia][$encyclopedia = "Bitchy"]]
@@ -2291,7 +2784,6 @@ Error: bad title.
 <<if ["Flaws","Apathetic","Crude","Hates oral","Hates anal","Hates penetration","Idealistic","Judgemental","Repressed","Shamefast","Abusiveness","Anal Addicts","Attention Whores","Breast Obsession","Breeding Obsession","Cum Addicts","Maliciousness","Self Hatred","Self Neglect"].includes($encyclopedia)>>
 <br><br>
 //Sexual [[Flaws|Encyclopedia][$encyclopedia = "Flaws"]]://
-
 <br>
 //Standard flaws:// 
 [[Apathetic|Encyclopedia][$encyclopedia = "Apathetic"]]
@@ -2320,7 +2812,8 @@ Error: bad title.
 
 <<if ["Relationships","Rivalries","Romances","Emotional Slut","Emotionally Bonded","Slave Marriages","Slaveowner Marriages"].includes($encyclopedia)>>
 <br><br>
-//Relationships//<br>
+//Relationships//
+<br>
 [[Rivalries|Encyclopedia][$encyclopedia = "Rivalries"]]
 | [[Romances|Encyclopedia][$encyclopedia = "Romances"]]
 | [[Emotionally Bonded|Encyclopedia][$encyclopedia = "Emotionally Bonded"]]
@@ -2330,9 +2823,10 @@ Error: bad title.
 <</if>>
 
 
-<<if ["What the Upgrades Do","Personal Assistant","The Wardrobe","The Auto Salon","The Body Mod Studio","The Remote Surgery","The Pharmaceutical Fab.","Slave Dairy","Arcades","Fuckdolls","Security Drones","Water Filtration","Slave Nutrition"].includes($encyclopedia)>>
+<<if ["What the Upgrades Do","Personal Assistant","The Wardrobe","The Auto Salon","The Studio","The Remote Surgery","The Pharmaceutical Fab.","Security Drones","Water Filtration","Slave Nutrition"].includes($encyclopedia)>>
+<br><br>
+//The X-Series Arcology//
 <br>
-//The X-Series Arcology//<br>
 [[What the Upgrades Do|Encyclopedia][$encyclopedia = "What the Upgrades Do"]]
  | [[Personal Assistant|Encyclopedia][$encyclopedia = "Personal Assistant"]]
  | [[The Wardrobe|Encyclopedia][$encyclopedia = "The Wardrobe"]]
@@ -2340,9 +2834,6 @@ Error: bad title.
  | [[The Body Mod Studio|Encyclopedia][$encyclopedia = "The Studio"]]
  | [[The Remote Surgery|Encyclopedia][$encyclopedia = "The Remote Surgery"]]
  | [[The Pharmaceutical Fab.|Encyclopedia][$encyclopedia = "The Pharmaceutical Fab."]]
- | [[Slave Dairy|Encyclopedia][$encyclopedia = "Slave Dairy"]]
- | [[Arcades|Encyclopedia][$encyclopedia = "Arcades"]]
- | [[Fuckdolls|Encyclopedia][$encyclopedia = "Fuckdolls"]]
 <br>
 Behind the Arcology: 
 [[Security Drones|Encyclopedia][$encyclopedia = "Security Drones"]]
@@ -2366,13 +2857,11 @@ Behind the Arcology:
 | [[Schoolroom|Encyclopedia][$encyclopedia = "Schoolroom"]]
 | [[Servants' Quarters|Encyclopedia][$encyclopedia = "Servants' Quarters"]]
 | [[Spa|Encyclopedia][$encyclopedia = "Spa"]]
-
 <br><br>
 //Facility Bonuses//<br>
 [[Advertising|Encyclopedia][$encyclopedia = "Advertising"]]
 | [[Variety|Encyclopedia][$encyclopedia = "Variety"]]
 <</if>>
-
 
 <<if ["Terrain Types","Urban Terrain","Rural Terrain","Marine Terrain","Oceanic Terrain"].includes($encyclopedia)>>
 <br><br>
@@ -2413,48 +2902,45 @@ Behind the Arcology:
 <</if>>
 
 
-<<if ["Lore","Security Drones","Water Filtration","Slave Nutrition","Disease in the Free Cities","Free Cities Justice","Modern Anal","Slave Couture","Slave Marriage","The Ejaculate Market","Gingering","The New Rome","Naked, Barefoot, and Pregnant","The Top","The Bottom","The Purity of the Human Form","A World Built on Implants","Slaves as Stock","Slavery and the Physical Ideal","Faith in the Free Cities","Slave Acolyte,  Arcology V-7","Public Slave,  Arcology A-3","Mercenary,  Arcology B-2","Slave Trainer,  Arcology D-10"].includes($encyclopedia)>>
-	<br><br>
-	//Lore://
-	<br>
-	The Free Cities today: 
-	[[Money|Encyclopedia][$encyclopedia = "Money"]]
-	 | [[Disease in the Free Cities|Encyclopedia][$encyclopedia = "Disease in the Free Cities"]]
-	 | [[Free Cities Justice|Encyclopedia][$encyclopedia = "Free Cities Justice"]]
-	 | [[Modern Anal|Encyclopedia][$encyclopedia = "Modern Anal"]]
-	 | [[Slave Couture|Encyclopedia][$encyclopedia = "Slave Couture"]]
-	 | [[Slave Marriage|Encyclopedia][$encyclopedia = "Slave Marriage"]]
-	 | [[The Ejaculate Market|Encyclopedia][$encyclopedia = "The Ejaculate Market"]]
-	 | [[Gingering|Encyclopedia][$encyclopedia = "Gingering"]]
-	 
-	<br>
-	Free Cities culture tomorrow: 
-	[[The Future of Society|Encyclopedia][$encyclopedia = "The Future of Society"]]
-	 | [[The New Rome|Encyclopedia][$encyclopedia = "The New Rome"]]
-	 | [[Naked, Barefoot, and Pregnant|Encyclopedia][$encyclopedia = "Naked, Barefoot, and Pregnant"]]
-	 | [[The Top|Encyclopedia][$encyclopedia = "The Top"]]
-	 | [[The Bottom|Encyclopedia][$encyclopedia = "The Bottom"]]
-	 | [[The Purity of the Human Form|Encyclopedia][$encyclopedia = "The Purity of the Human Form"]]
-	 | [[A World Built on Implants|Encyclopedia][$encyclopedia = "A World Built on Implants"]]
-	 | [[Slaves as Stock|Encyclopedia][$encyclopedia = "Slaves as Stock"]]
-	 | [[Slavery and the Physical Ideal|Encyclopedia][$encyclopedia = "Slavery and the Physical Ideal"]]
-	 | [[Faith in the Free Cities|Encyclopedia][$encyclopedia = "Faith in the Free Cities"]]
-
-	<br>
-	Interviews: [[Slave Whore, Arcology K-2|Encyclopedia][$encyclopedia = "Slave Whore, Arcology K-2"]]
-	 [[Slave Acolyte, Arcology V-7|Encyclopedia][$encyclopedia = "Slave Acolyte, Arcology V-7"]]
-	<<if $seeExtreme != 0>>
-		| [[Public Slave, Arcology A-3|Encyclopedia][$encyclopedia = "Public Slave, Arcology A-3"]]
-	<</if>>
-	 | [[Mercenary, Arcology B-2|Encyclopedia][$encyclopedia = "Mercenary, Arcology B-2"]]
-	 | [[Slave Trainer, Arcology D-10|Encyclopedia][$encyclopedia = "Slave Trainer, Arcology D-10"]]
-	<br>
+<<if ["Lore","Money","Disease in the Free Cities","Free Cities Justice","Modern Anal","Slave Couture","Slave Marriage","The Ejaculate Market","Gingering","The Future of Society","The New Rome","Naked, Barefoot, and Pregnant","The Top","The Bottom","The Purity of the Human Form","A World Built on Implants","Slaves as Stock","Slavery and the Physical Ideal","Faith in the Free Cities","Slave Whore, Arcology K-2","Slave Acolyte, Arcology V-7","Public Slave, Arcology A-3","Mercenary, Arcology B-2","Slave Trainer, Arcology D-10","Security Drones","Water Filtration","Slave Nutrition",].includes($encyclopedia)>>
+<br><br>
+//Lore://
+<br>
+The Free Cities today: 
+[[Money|Encyclopedia][$encyclopedia = "Money"]]
+ | [[Disease in the Free Cities|Encyclopedia][$encyclopedia = "Disease in the Free Cities"]]
+ | [[Free Cities Justice|Encyclopedia][$encyclopedia = "Free Cities Justice"]]
+ | [[Modern Anal|Encyclopedia][$encyclopedia = "Modern Anal"]]
+ | [[Slave Couture|Encyclopedia][$encyclopedia = "Slave Couture"]]
+ | [[Slave Marriage|Encyclopedia][$encyclopedia = "Slave Marriage"]]
+ | [[The Ejaculate Market|Encyclopedia][$encyclopedia = "The Ejaculate Market"]]
+ | [[Gingering|Encyclopedia][$encyclopedia = "Gingering"]]
+ 
+<br>
+Free Cities culture tomorrow: 
+[[The Future of Society|Encyclopedia][$encyclopedia = "The Future of Society"]]
+ | [[The New Rome|Encyclopedia][$encyclopedia = "The New Rome"]]
+ | [[Naked, Barefoot, and Pregnant|Encyclopedia][$encyclopedia = "Naked, Barefoot, and Pregnant"]]
+ | [[The Top|Encyclopedia][$encyclopedia = "The Top"]]
+ | [[The Bottom|Encyclopedia][$encyclopedia = "The Bottom"]]
+ | [[The Purity of the Human Form|Encyclopedia][$encyclopedia = "The Purity of the Human Form"]]
+ | [[A World Built on Implants|Encyclopedia][$encyclopedia = "A World Built on Implants"]]
+ | [[Slaves as Stock|Encyclopedia][$encyclopedia = "Slaves as Stock"]]
+ | [[Slavery and the Physical Ideal|Encyclopedia][$encyclopedia = "Slavery and the Physical Ideal"]]
+ | [[Faith in the Free Cities|Encyclopedia][$encyclopedia = "Faith in the Free Cities"]]
+<br>
+Interviews: 
+[[Slave Whore, Arcology K-2|Encyclopedia][$encyclopedia = "Slave Whore, Arcology K-2"]]
+  | [[Slave Acolyte, Arcology V-7|Encyclopedia][$encyclopedia = "Slave Acolyte, Arcology V-7"]]
+<<if $seeExtreme != 0>>
+	| [[Public Slave, Arcology A-3|Encyclopedia][$encyclopedia = "Public Slave, Arcology A-3"]]
 <</if>>
-
+ | [[Mercenary, Arcology B-2|Encyclopedia][$encyclopedia = "Mercenary, Arcology B-2"]]
+ | [[Slave Trainer, Arcology D-10|Encyclopedia][$encyclopedia = "Slave Trainer, Arcology D-10"]]
+<br>
+<</if>>
 
 <<if ["Game Mods","Security Force"].includes($encyclopedia)>>
 Game Mods:
 [[Security Force|Encyclopedia][$encyclopedia = "Security Force"]]
 <</if>>
-
-<</nobr>>


### PR DESCRIPTION
Seems most files are nobr, and the only place this really made writing easier was the "interviews."  This allows spaces between the "cases" in the code, which makes it easier to parse visually for updates as well.   (Now we can worry about `<br>` instead of `\` yay)

Slave Dairy and Arcade: as before, removed their lore pages, and moved the lore text to the page with gameplay mechanics.

Move fuckdoll from "lore" category to "slave" category.

Minor: Italicize more quotes.
Minor: fix links at bottom of Body Mod article, an interview, "The Future of Society," and others.