### PR TITLE
Fix for compile_debug.bat 

### DIFF
--- a/compile_debug.bat
+++ b/compile_debug.bat
@@ -1,3 +1,3 @@
 @echo off
-call %~dp0compile.bat
+call "%~dp0compile.bat"
 PAUSE


### PR DESCRIPTION
Fix for #930: Added quotes to compile_debug.bat so it works for directories with whitespace.