### PR TITLE
Widget tweaking

### DIFF
--- a/src/uncategorized/longSlaveDescription.tw
+++ b/src/uncategorized/longSlaveDescription.tw
@@ -143,36 +143,31 @@ She comes to you for an inspection
 
 <<if $activeSlave.fuckdoll == 0>>
 <<if $activeSlave.voice != 0>>
-  <<if $activeSlave.speechRules == "restrictive">>
-	She is not allowed to speak unless spoken to, but when allowed, she speaks in a
-  <<else>>
-	She is allowed to ask questions, and when she speaks, she does so in a
-  <</if>>
-  <<if $activeSlave.voice == 1>>
-	deep, unfeminine voice.
-  <<elseif $activeSlave.voice == 2>>
-	<<if $activeSlave.voiceImplant == 1>>
-	  slightly artificial feminine voice.
+	<<if $activeSlave.speechRules == "restrictive">>
+		She is not allowed to speak unless spoken to, but when allowed, she speaks in a
 	<<else>>
-	  pretty, feminine voice.
+		She is allowed to ask questions, and when she speaks, she does so in a
 	<</if>>
-  <<elseif $activeSlave.voice == 3>>
-	<<if $activeSlave.voiceImplant == 1>>
-	  ridiculously high, bubblegum voice.
-	<<else>>
-	  high, girly voice.
+	<<if $activeSlave.voice == 1>>
+		deep, unfeminine voice.
+	<<elseif $activeSlave.voice == 2>>
+		<<if $activeSlave.voiceImplant == 1>>
+			slightly artificial feminine voice.
+		<<else>>
+			pretty, feminine voice.
+		<</if>>
+	<<elseif $activeSlave.voice == 3>>
+		<<if $activeSlave.voiceImplant == 1>>
+			ridiculously high, bubblegum voice.
+		<<else>>
+			high, girly voice.
+		<</if>>
 	<</if>>
-  <</if>>
-  <<if $activeSlave.accent != 0>>
-	<<if $activeSlave.accent == 1>>
-	  <<set $seed = either("lovely", "distinctive", "rich", "beautiful")>>
-	  She speaks $language in a $seed $activeSlave.nationality accent<<if $activeSlave.speechRules == "accent elimination">>, which the rules encourage her to suppress<</if>>.
-	<<elseif $activeSlave.accent == 2>>
-	  She speaks $language in a thick $activeSlave.nationality accent that can be hard to understand<<if $activeSlave.speechRules == "accent elimination">>, and the rules encourage her to make an effort to suppress it<</if>>.
-	<<else>>
-	  She speaks little $language, but understands enough to be given orders.
+	
+	<<if canTalk($activeSlave)>>
+		<<accentDescription>>
 	<</if>>
-  <</if>>
+
 <</if>>
 <</if>>
 

--- a/src/uncategorized/remoteSurgery.tw
+++ b/src/uncategorized/remoteSurgery.tw
@@ -235,6 +235,7 @@ $pronounCap has
 	$pronounCap has had surgery on $possessive voicebox to raise $possessive voice.
 <</if>>
 
+<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <<if ($activeSlave.voice != 0) && ($activeSlave.voiceImplant == 0) && ($activeSlave.voice < 3)>>
 	<<if $activeSlave.indentureRestrictions < 1>>
 	[[Perform surgery to raise voice|Surgery Degradation][$activeSlave.voice += 1, $activeSlave.voiceImplant += 1, $cash -= $surgeryCost,  $activeSlave.health -= 10, $surgeryType = "voice"]]

--- a/src/uncategorized/remoteSurgery.tw
+++ b/src/uncategorized/remoteSurgery.tw
@@ -370,7 +370,10 @@ $pronounCap has
 ''GENITALIA''<br>
 
 <<if ($activeSlave.vagina > -1) || ($activeSlave.dick > 0)>>
-	//<<VaginaDescription>> ''Bold'' surgeries will set her back in this skill.//
+	//<<VaginaDescription>>
+	<<if ($activeSlave.vagina > -1)>>
+		''Bold'' surgeries will set her back in this skill.
+	<</if>>//		
 <</if>>
 
 <<if $activeSlave.vagina > -1>>

--- a/src/uncategorized/surgeryDegradation.tw
+++ b/src/uncategorized/surgeryDegradation.tw
@@ -1326,6 +1326,9 @@ As the remote surgery's long recovery cycle completes,
 	<<elseif ($activeSlave.devotion >= -20)>>
 		She leaves the surgery with a terribly sore rear end. She knows she'll have to endure the pain of being fucked in a tight asshole again soon enough, but trepidation is nothing new for her. If she had much in the way of anal skills, @@.red;they've likely suffered.@@ As with all surgery @@.red;her health has been slightly affected.@@ She is @@.gold;sensibly fearful@@ of your total power over her body.
 		<<set $activeSlave.trust -= 5>>
+		<<if $activeSlave.analSkill > 10>>
+			<<set $activeSlave.analSkill -= 10>>
+		<</if>>
 	<<else>>
 		She leaves the surgery with a terribly sore rear end. She's @@.mediumorchid;horrified@@ at surgical alteration of her rear end, and knows that this means that she'll have to take the pain of sodomy in a tight ass all over again. If she had much in the way of anal skills, @@.red;they've likely suffered.@@ As with all surgery @@.red;her health has been slightly affected.@@ She is @@.gold;terribly afraid@@ of your total power over her most intimate parts.
 		<<set $activeSlave.trust -= 10>>

--- a/src/utility/descriptionWidgetsFlesh.tw
+++ b/src/utility/descriptionWidgetsFlesh.tw
@@ -2483,11 +2483,11 @@ $pronounCap's got a
 <<else>>
 	<<if $activeSlave.vagina == -1>>
 		<<if $seeDicks >= 100>><<elseif $activeSlave.anus == 0>><<else>>Since $pronoun lacks a vagina, $pronoun takes it up <<if $seeRace == 1>>$possessive $activeSlave.race<<else>>the<</if>> ass instead.<</if>>
-	<<elseif $activeSlave.vaginalSkill >= 100>>$pronounCap is a @@.aquamarine;vanilla sex master@@.
-	<<elseif $activeSlave.vaginalSkill > 60>>$pronounCap is a @@.aquamarine;vanilla sex expert@@.
-	<<elseif $activeSlave.vaginalSkill > 30>>$pronounCap is @@.aquamarine;skilled at vanilla sex@@.
-	<<elseif $activeSlave.vaginalSkill > 10>>$pronounCap has @@.aquamarine;basic knowledge about vanilla sex@@.
-	<<else>>$pronounCap is unskilled at vaginal sex.
+		<<elseif $activeSlave.vaginalSkill >= 100>>$pronounCap is a @@.aquamarine;vanilla sex master@@.
+		<<elseif $activeSlave.vaginalSkill > 60>>$pronounCap is a @@.aquamarine;vanilla sex expert@@.
+		<<elseif $activeSlave.vaginalSkill > 30>>$pronounCap is @@.aquamarine;skilled at vanilla sex@@.
+		<<elseif $activeSlave.vaginalSkill > 10>>$pronounCap has @@.aquamarine;basic knowledge about vanilla sex@@.
+		<<else>>$pronounCap is unskilled at vaginal sex.
 	<</if>>
 <</if>>
 
@@ -3028,6 +3028,12 @@ $pronounCap has
 	<</if>>
 <</if>>
 
+<<if $showBodyMods == 1>>
+	<<lipsPiercingDescription>>
+	<<tonguePiercingDescription>>
+<</if>>
+
+
 <<if $activeSlave.fuckdoll > 0>>
 	<<if $PC.dick == 1>>Sticking a dick<<else>>Sliding a dildo<</if>> into $possessive <<if $activeSlave.lips > 95>>facepussy<<else>>mouth insert<</if>>
 	<<if $activeSlave.fuckdoll <= 45>>
@@ -3045,10 +3051,6 @@ $pronounCap has
 	<</if>>
 <</if>>
 
-<<if $showBodyMods == 1>>
-	<<lipsPiercingDescription>>
-	<<tonguePiercingDescription>>
-<</if>>
 
 <</widget>>
 

--- a/src/utility/descriptionWidgetsFlesh.tw
+++ b/src/utility/descriptionWidgetsFlesh.tw
@@ -4077,17 +4077,15 @@ and
 
 <<widget "accentDescription">>
 
-<<if canTalk($activeSlave)>>
-  <<if $activeSlave.accent != 0>>
+<<if $activeSlave.accent != 0>>
 	<<if $activeSlave.accent == 1>>
-	  <<set $seed = either("lovely", "distinctive", "rich", "beautiful")>>
-	  She speaks $language in a $seed $activeSlave.nationality accent<<if $activeSlave.speechRules == "accent elimination">>, which the rules encourage her to suppress<</if>>.
+		<<set $seed = either("lovely", "distinctive", "rich", "beautiful")>>
+		She speaks $language in a $seed $activeSlave.nationality accent<<if $activeSlave.speechRules == "accent elimination">>, which the rules encourage her to suppress<</if>>.
 	<<elseif $activeSlave.accent == 2>>
-	  She speaks $language in a thick $activeSlave.nationality accent that can be hard to understand<<if $activeSlave.speechRules == "accent elimination">>, and the rules encourage her to make an effort to suppress it<</if>>.
+		She speaks $language in a thick $activeSlave.nationality accent that can be hard to understand<<if $activeSlave.speechRules == "accent elimination">>, and the rules encourage her to make an effort to suppress it<</if>>.
 	<<else>>
-	  She speaks little $language, but understands enough to be given orders.
+		She speaks little $language, but understands enough to be given orders.
 	<</if>>
-  <</if>>
 <</if>>
 
 <</widget>>


### PR DESCRIPTION
Adjust accentDescription widget so it can properly appear while it needs to, while still being hidden where it needs to be hidden.

In longSlave, we don't need to hear about accents if a slave is not allowed to talk (That's how it is set up anyway. )

However, in surgery I think we're more interested in the raw biological possibility of the slave, and this is needed info when making major voice decisions.  Stronger weight to taking away a voice.

Minor: Standardize whitespace in the code here, so this looks like a bigger change than it is.