### PR TITLE
Widget tweaks

### DIFF
--- a/src/uncategorized/longSlaveDescription.tw
+++ b/src/uncategorized/longSlaveDescription.tw
@@ -1502,7 +1502,9 @@ $pronounCap is
 
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
 
-<<VaginaDescription>>
+<<crotchDescription>>
+<<dickDescription>>
+<<vaginaDescription>>
 
 <<AnusDescription>>
 

--- a/src/uncategorized/longSlaveDescription.tw
+++ b/src/uncategorized/longSlaveDescription.tw
@@ -143,36 +143,31 @@ She comes to you for an inspection
 
 <<if $activeSlave.fuckdoll == 0>>
 <<if $activeSlave.voice != 0>>
-  <<if $activeSlave.speechRules == "restrictive">>
-	She is not allowed to speak unless spoken to, but when allowed, she speaks in a
-  <<else>>
-	She is allowed to ask questions, and when she speaks, she does so in a
-  <</if>>
-  <<if $activeSlave.voice == 1>>
-	deep, unfeminine voice.
-  <<elseif $activeSlave.voice == 2>>
-	<<if $activeSlave.voiceImplant == 1>>
-	  slightly artificial feminine voice.
+	<<if $activeSlave.speechRules == "restrictive">>
+		She is not allowed to speak unless spoken to, but when allowed, she speaks in a
 	<<else>>
-	  pretty, feminine voice.
+		She is allowed to ask questions, and when she speaks, she does so in a
 	<</if>>
-  <<elseif $activeSlave.voice == 3>>
-	<<if $activeSlave.voiceImplant == 1>>
-	  ridiculously high, bubblegum voice.
-	<<else>>
-	  high, girly voice.
+	<<if $activeSlave.voice == 1>>
+		deep, unfeminine voice.
+	<<elseif $activeSlave.voice == 2>>
+		<<if $activeSlave.voiceImplant == 1>>
+			slightly artificial feminine voice.
+		<<else>>
+			pretty, feminine voice.
+		<</if>>
+	<<elseif $activeSlave.voice == 3>>
+		<<if $activeSlave.voiceImplant == 1>>
+			ridiculously high, bubblegum voice.
+		<<else>>
+			high, girly voice.
+		<</if>>
 	<</if>>
-  <</if>>
-  <<if $activeSlave.accent != 0>>
-	<<if $activeSlave.accent == 1>>
-	  <<set $seed = either("lovely", "distinctive", "rich", "beautiful")>>
-	  She speaks $language in a $seed $activeSlave.nationality accent<<if $activeSlave.speechRules == "accent elimination">>, which the rules encourage her to suppress<</if>>.
-	<<elseif $activeSlave.accent == 2>>
-	  She speaks $language in a thick $activeSlave.nationality accent that can be hard to understand<<if $activeSlave.speechRules == "accent elimination">>, and the rules encourage her to make an effort to suppress it<</if>>.
-	<<else>>
-	  She speaks little $language, but understands enough to be given orders.
+	
+	<<if canTalk($activeSlave)>>
+		<<accentDescription>>
 	<</if>>
-  <</if>>
+
 <</if>>
 <</if>>
 

--- a/src/uncategorized/remoteSurgery.tw
+++ b/src/uncategorized/remoteSurgery.tw
@@ -369,13 +369,144 @@ $pronounCap has
 <br><br>
 ''GENITALIA''<br>
 
-<<if ($activeSlave.vagina > -1) || ($activeSlave.dick > 0)>>
-	//<<VaginaDescription>>
-	<<if ($activeSlave.vagina > -1)>>
-		''Bold'' surgeries will set her back in this skill.
-	<</if>>//		
+//<<crotchDescription>>//
+
+/* MAJOR ADD/REMOVE */
+<<if ($activeSlave.dick == 0) && ($activeSlave.vagina == -1)>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	$pronounCap is a null, possessing neither penis nor vagina.
+<<elseif ($seeCircumcision == 1) && ($activeSlave.indentureRestrictions < 2)>>
+	<<if ($activeSlave.dick != 0) && ($activeSlave.vagina == -1) && ($activeSlave.foreskin == 0)>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	$pronounCap has a circumcised penis.
+	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina == -1) && ($activeSlave.foreskin >= 1)>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	$pronounCap has an uncircumcised penis.
+	<<elseif ($activeSlave.dick != 0) && ($activeSlave.ovaries != 0) && ($activeSlave.foreskin == 0)>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	$pronounCap has a circumcised penis and a vagina.
+	<<elseif ($activeSlave.dick != 0) && ($activeSlave.ovaries != 0) && ($activeSlave.foreskin >= 1)>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	$pronounCap has an uncircumcised penis and a vagina.
+	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina != -1) && ($activeSlave.foreskin == 0)>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	$pronounCap has a circumcised penis and an artificial vagina.
+	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina != -1) && ($activeSlave.foreskin >= 1)>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	$pronounCap has an uncircumcised penis and an artificial vagina.
+	<</if>>
+<<else>>
+	<<if ($activeSlave.dick != 0) && ($activeSlave.vagina == -1)>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	$pronounCap has a penis.
+	<<elseif ($activeSlave.dick != 0) && ($activeSlave.ovaries != 0)>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp
+	$pronounCap has a penis and a vagina.
+	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina != -1)>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	$pronounCap has a penis and an artificial vagina.
+	<</if>>
 <</if>>
 
+<<if $activeSlave.indentureRestrictions < 1>>
+	<<if ($activeSlave.vagina == -1) && ($activeSlave.dick != 0)>>
+		[[Convert genitalia to female|Surgery Degradation][$activeSlave.dick = 0,$activeSlave.dickAccessory = "none",$activeSlave.scrotum = 0,$activeSlave.balls = 0,$activeSlave.vagina = 0,$activeSlave.preg = -2,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "mtf"]]
+	<</if>>
+	
+	<<if ($activeSlave.vagina == -1) && ($activeSlave.dick == 0) && ($surgeryUpgrade == 1)>>	
+		[[Create a vagina|Surgery Degradation][$activeSlave.vagina = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "mtf"]]
+	<</if>>
+	
+	<<if ($activeSlave.dick > 0) && ($seeExtreme == 1)>>
+		 | [[Remove penis|Surgery Degradation][$activeSlave.dick = 0,$activeSlave.dickAccessory = "none",$activeSlave.foreskin = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 20, $surgeryType = "chop"]]
+	<</if>>
+	
+	<<if ($activeSlave.vagina > -1) && ($activeSlave.dick > 0)>>
+		| [[Remove pussy|Surgery Degradation][$activeSlave.vagina = -1,$activeSlave.ovaries = 0,$activeSlave.preg = -2,$activeSlave.pregSource = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost,$activeSlave.health -= 20,$surgeryType = "vaginaRemoval"]] <<if $activeSlave.ovaries == 1>>//This will remove $possessive ovaries as well//<</if>>
+	<</if>>
+	
+<</if>>
+
+
+/* HERM */
+<<if ($activeSlave.dick != 0) && ($activeSlave.vagina == -1) && ($surgeryUpgrade == 1)>>
+	<<if $activeSlave.indentureRestrictions < 1>>
+		| [[Create surgical hermaphrodite|Surgery Degradation][$activeSlave.vagina = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "herm"]]
+	<</if>>
+<</if>>
+
+<<if ($activeSlave.dick != 0) || ($activeSlave.balls > 0)>>
+<br><br>//<<dickDescription>>//
+
+<<if ($activeSlave.foreskin > 0)>>
+<<if $seeCircumcision == 1>>
+<<if $activeSlave.indentureRestrictions < 2>>
+<<if $activeSlave.dick != 0>>
+	[[Remove foreskin|Surgery Degradation][$activeSlave.foreskin = 0,$cash -= $surgeryCost, $activeSlave.health -= 10, $surgeryType = "circumcision"]]
+<</if>>
+<</if>>
+<</if>>
+<</if>>
+<</if>>
+
+/* BALLS */
+<<if ($activeSlave.balls > 0)>>
+	<<if ($activeSlave.balls == 1)>>
+		<br>&nbsp;&nbsp;&nbsp;&nbsp;
+		$possessiveCap testicles are vestigial, but $pronoun has balls. Technically. They are 
+	<<elseif ($activeSlave.balls > 1)>>
+		<br>&nbsp;&nbsp;&nbsp;&nbsp;
+		$pronounCap has testicles 
+	<</if>>
+	<<if ($activeSlave.scrotum > 0)>>
+		located in $possessive scrotum.
+		<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<<if $activeSlave.indentureRestrictions < 1>>
+		[[Move them inside abdomen and remove scrotum|Surgery Degradation][$activeSlave.scrotum = 0,$cash -= $surgeryCost, $activeSlave.health -= 20, $surgeryType = "relocate"]]
+		<</if>>
+		//This will have a negative impact on cum production//
+			<<else>>
+		<<if ($activeSlave.genes == "XY")>>
+			relocated inside $possessive abdomen, and $possessive scrotum has been removed.
+		<<else>>
+			implanted inside $possessive abdomen.
+		<</if>>
+	<</if>>	
+	<<if ($seeExtreme == 1)>>
+		<<if ($activeSlave.scrotum > 0)>>
+			| 
+		<</if>>
+		[[Geld|Surgery Degradation][$activeSlave.balls = 0,$activeSlave.scrotum = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "geld"]]
+	<</if>>	
+<</if>>
+
+
+/* PROSTATE */
+<<if $activeSlave.prostate>>
+	<br>&nbsp;&nbsp;&nbsp;&nbsp;
+	$pronounCap has a <<if $activeSlave.prostate > 1>>hyperactive<<else>>normal<</if>> prostate.
+	<<if $activeSlave.prostate < 2>>
+		<<if $activeSlave.indentureRestrictions < 2>>
+			<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+			[[Implant slow-release productivity drugs|Surgery Degradation][$activeSlave.prostate=2,$cash-=$surgeryCost,$activeSlave.health-=10,$surgeryType="precum"]] //This may cause some leaking//
+		<</if>>
+	<<elseif $activeSlave.prostate > 1>>
+		<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		 [[Remove drug implant|Surgery Degradation][$activeSlave.prostate=1,$cash-=$surgeryCost,$surgeryType="endprecum"]]
+	<</if>>
+	<<if ($seeExtreme == 1)>>
+		<<if $activeSlave.indentureRestrictions < 1>>
+			 | [[Remove prostate|Surgery Degradation][$activeSlave.prostate = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "prostate"]]
+		<</if>>
+	<</if>>
+<</if>>
+
+<<if ($activeSlave.vagina > -1)>>
+	<br><br>//<<vaginaDescription>>
+	''Bold'' surgeries will set her back in this skill.//
+<</if>>
+
+/* VAGINA */
 <<if $activeSlave.vagina > -1>>
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
 <<if $activeSlave.labia == 0>>
@@ -421,7 +552,19 @@ $pronounCap has
 		 [[Increase clit|Surgery Degradation][$activeSlave.clit += 1,$cash -= $surgeryCost, $activeSlave.health -= 10,$surgeryType = "clitoral enlargement"]]
 		<</if>>
 	<</if>>
+	
+	<<if ($activeSlave.foreskin > 0)>>
+	<<if $seeCircumcision == 1>>
+	<<if $activeSlave.indentureRestrictions < 2>>
+	<<if ($activeSlave.vagina >= 0)>>
+		 | [[Remove clitoral hood|Surgery Degradation][$activeSlave.foreskin = 0,$cash -= $surgeryCost, $activeSlave.health -= 10, $surgeryType = "circumcision"]]
+	<</if>>
+	<</if>>
+	<</if>>
+	<</if>>
 <</if>>
+
+/* WOMB */
 <</if>>
 <<if ($activeSlave.preg > -2) && ($activeSlave.preg < 1) && ($activeSlave.vagina > -1) && ($activeSlave.ovaries != 0)>>
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
@@ -438,6 +581,7 @@ $pronounCap has
 	[[Restore fertility|Surgery Degradation][$activeSlave.preg = 0,$cash -= $surgeryCost, $activeSlave.health -= 10,$surgeryType = "fert"]]
 <</if>>
 
+/* OVARIES */
 <<if ($activeSlave.ovaries == 1) && ($activeSlave.preg < 1)>>
 	<<if $activeSlave.indentureRestrictions < 1>>
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
@@ -446,6 +590,7 @@ $pronounCap has
 	<</if>>
 <</if>>
 
+/* LABIA */
 <<if ($activeSlave.vagina > 3)>>
 	<br>&nbsp;&nbsp;&nbsp;&nbsp;
 	$possessiveCap vagina could benefit from surgical repair.
@@ -462,129 +607,7 @@ $pronounCap has
 	<</if>>
 <</if>>
 
-<<if ($activeSlave.vagina > -1) && ($activeSlave.dick > 0)>>
-	<<if $activeSlave.indentureRestrictions < 1>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	Since $pronoun has both a penis and a vagina, it's possible to remove $possessive pussy and leave $possessive sexually functional.
-	[[Remove pussy|Surgery Degradation][$activeSlave.vagina = -1,$activeSlave.ovaries = 0,$activeSlave.preg = -2,$activeSlave.pregSource = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost,$activeSlave.health -= 20,$surgeryType = "vaginaRemoval"]] <<if $activeSlave.ovaries == 1>>//This will remove $possessive ovaries as well//<</if>>
-	<</if>>
-<</if>>
-
-<<if ($activeSlave.dick == 0) && ($activeSlave.vagina == -1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap is a null, possessing neither penis nor vagina.
-<<elseif ($seeCircumcision == 1) && ($activeSlave.indentureRestrictions < 2)>>
-	<<if ($activeSlave.dick != 0) && ($activeSlave.vagina == -1) && ($activeSlave.foreskin == 0)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has a circumcised penis.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina == -1) && ($activeSlave.foreskin >= 1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has an uncircumcised penis.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.ovaries != 0) && ($activeSlave.foreskin == 0)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has a circumcised penis and a vagina.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.ovaries != 0) && ($activeSlave.foreskin >= 1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has an uncircumcised penis and a vagina.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina != -1) && ($activeSlave.foreskin == 0)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has a circumcised penis and an artificial vagina.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina != -1) && ($activeSlave.foreskin >= 1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has an uncircumcised penis and an artificial vagina.
-	<</if>>
-<<else>>
-	<<if ($activeSlave.dick != 0) && ($activeSlave.vagina == -1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has a penis.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.ovaries != 0)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp
-	$pronounCap has a penis and a vagina.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina != -1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has a penis and an artificial vagina.
-	<</if>>
-<</if>>
-
-<<if $activeSlave.indentureRestrictions < 1>>
-	<<if ($activeSlave.vagina == -1) && ($activeSlave.dick != 0)>>
-		[[Convert genitalia to female|Surgery Degradation][$activeSlave.dick = 0,$activeSlave.dickAccessory = "none",$activeSlave.scrotum = 0,$activeSlave.balls = 0,$activeSlave.vagina = 0,$activeSlave.preg = -2,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "mtf"]]
-	<</if>>
-	<<if ($activeSlave.vagina == -1) && ($activeSlave.dick == 0) && ($surgeryUpgrade == 1)>>	
-		[[Create a vagina|Surgery Degradation][$activeSlave.vagina = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "mtf"]]
-	<</if>>
-	<<if ($activeSlave.dick > 0) && ($seeExtreme == 1)>>
-		 | [[Remove penis|Surgery Degradation][$activeSlave.dick = 0,$activeSlave.dickAccessory = "none",$activeSlave.foreskin = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 20, $surgeryType = "chop"]]
-	<</if>>
-	<<if ($activeSlave.foreskin > 0)>>
-		<<if $seeCircumcision == 1>>
-			<<if $activeSlave.indentureRestrictions < 2>>
-			<<if $activeSlave.dick != 0>>
-				 | [[Remove foreskin|Surgery Degradation][$activeSlave.foreskin = 0,$cash -= $surgeryCost, $activeSlave.health -= 10, $surgeryType = "circumcision"]]
-			<<elseif ($activeSlave.vagina >= 0)>>
-				 | [[Remove clitoral hood|Surgery Degradation][$activeSlave.foreskin = 0,$cash -= $surgeryCost, $activeSlave.health -= 10, $surgeryType = "circumcision"]]
-			<</if>>
-			<</if>>
-		<</if>>
-	<</if>>
-<</if>>
-
-<<if ($activeSlave.dick != 0) && ($activeSlave.vagina == -1) && ($surgeryUpgrade == 1)>>
-	<<if $activeSlave.indentureRestrictions < 1>>
-		| [[Create surgical hermaphrodite|Surgery Degradation][$activeSlave.vagina = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "herm"]]
-	<</if>>
-<</if>>
-
-<<if ($activeSlave.balls > 0)>>
-	<<if ($activeSlave.balls == 1)>>
-		<br>&nbsp;&nbsp;&nbsp;&nbsp;
-		$possessiveCap testicles are vestigial, but $pronoun has balls. Technically. They are 
-	<<elseif ($activeSlave.balls > 1)>>
-		<br>&nbsp;&nbsp;&nbsp;&nbsp;
-		$pronounCap has testicles 
-	<</if>>
-	<<if ($activeSlave.scrotum > 0)>>
-		located in $possessive scrotum.
-		<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-		<<if $activeSlave.indentureRestrictions < 1>>
-		[[Move them inside abdomen and remove scrotum|Surgery Degradation][$activeSlave.scrotum = 0,$cash -= $surgeryCost, $activeSlave.health -= 20, $surgeryType = "relocate"]]
-		<</if>>
-		//This will have a negative impact on cum production//
-			<<else>>
-		<<if ($activeSlave.genes == "XY")>>
-			relocated inside $possessive abdomen, and $possessive scrotum has been removed.
-		<<else>>
-			implanted inside $possessive abdomen.
-		<</if>>
-	<</if>>	
-	<<if ($seeExtreme == 1)>>
-		<<if ($activeSlave.scrotum > 0)>>
-			| 
-		<</if>>
-		[[Geld|Surgery Degradation][$activeSlave.balls = 0,$activeSlave.scrotum = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "geld"]]
-	<</if>>	
-<</if>>
-
-<<if $activeSlave.prostate>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has a <<if $activeSlave.prostate > 1>>hyperactive<<else>>normal<</if>> prostate.
-	<<if $activeSlave.prostate < 2>>
-		<<if $activeSlave.indentureRestrictions < 2>>
-			<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-			[[Implant slow-release productivity drugs|Surgery Degradation][$activeSlave.prostate=2,$cash-=$surgeryCost,$activeSlave.health-=10,$surgeryType="precum"]] //This may cause some leaking//
-		<</if>>
-	<<elseif $activeSlave.prostate > 1>>
-		<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-		 [[Remove drug implant|Surgery Degradation][$activeSlave.prostate=1,$cash-=$surgeryCost,$surgeryType="endprecum"]]
-	<</if>>
-	<<if ($seeExtreme == 1)>>
-		<<if $activeSlave.indentureRestrictions < 1>>
-			 | [[Remove prostate|Surgery Degradation][$activeSlave.prostate = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "prostate"]]
-		<</if>>
-	<</if>>
-<</if>>
-
-
+/* ASSHOLE */
 <<if ($activeSlave.anus > 3)>>
 	<br><br>//<<AnusDescription>> ''Bold'' surgeries will set her back in this skill.//
 	''[[Repair asshole|Surgery Degradation][$activeSlave.anus = 3,$cash -= $surgeryCost, $activeSlave.health -= 10,$surgeryType = "anus"]]''
@@ -598,13 +621,16 @@ $pronounCap has
 <</if>>
 
 <br><br>
-''THICKNESS''<br>
+''THICKNESS''<br>  
+
 <<waistDescription>>
+
 <<if $activeSlave.waist >= -75>>
 	<<if $activeSlave.indentureRestrictions < 2>>
 	[[Liposuction|Surgery Degradation][$activeSlave.waist -= 20,$cash -= $surgeryCost, $activeSlave.health -= 10,$surgeryType = "lipo"]]
 	<</if>>
 <</if>>
+
 <<if ($activeSlave.waist >= -95) && ($activeSlave.waist < -75) && ($seeExtreme == 1)>>
 	<<if $activeSlave.indentureRestrictions < 1>>
 	[[Remove ribs to severely narrow her waist|Surgery Degradation][$activeSlave.waist = -100,$cash -= $surgeryCost, $activeSlave.health -= 40,$surgeryType = "ribs"]]

--- a/src/uncategorized/remoteSurgery.tw
+++ b/src/uncategorized/remoteSurgery.tw
@@ -372,59 +372,23 @@ $pronounCap has
 //<<crotchDescription>>//
 
 /* MAJOR ADD/REMOVE */
-<<if ($activeSlave.dick == 0) && ($activeSlave.vagina == -1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap is a null, possessing neither penis nor vagina.
-<<elseif ($seeCircumcision == 1) && ($activeSlave.indentureRestrictions < 2)>>
-	<<if ($activeSlave.dick != 0) && ($activeSlave.vagina == -1) && ($activeSlave.foreskin == 0)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has a circumcised penis.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina == -1) && ($activeSlave.foreskin >= 1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has an uncircumcised penis.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.ovaries != 0) && ($activeSlave.foreskin == 0)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has a circumcised penis and a vagina.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.ovaries != 0) && ($activeSlave.foreskin >= 1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has an uncircumcised penis and a vagina.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina != -1) && ($activeSlave.foreskin == 0)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has a circumcised penis and an artificial vagina.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina != -1) && ($activeSlave.foreskin >= 1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has an uncircumcised penis and an artificial vagina.
-	<</if>>
-<<else>>
-	<<if ($activeSlave.dick != 0) && ($activeSlave.vagina == -1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has a penis.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.ovaries != 0)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp
-	$pronounCap has a penis and a vagina.
-	<<elseif ($activeSlave.dick != 0) && ($activeSlave.vagina != -1)>>
-	<br>&nbsp;&nbsp;&nbsp;&nbsp;
-	$pronounCap has a penis and an artificial vagina.
-	<</if>>
-<</if>>
-
+<br>&nbsp;&nbsp;&nbsp;&nbsp;
 <<if $activeSlave.indentureRestrictions < 1>>
-	<<if ($activeSlave.vagina == -1) && ($activeSlave.dick != 0)>>
-		[[Convert genitalia to female|Surgery Degradation][$activeSlave.dick = 0,$activeSlave.dickAccessory = "none",$activeSlave.scrotum = 0,$activeSlave.balls = 0,$activeSlave.vagina = 0,$activeSlave.preg = -2,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "mtf"]]
-	<</if>>
-	
-	<<if ($activeSlave.vagina == -1) && ($activeSlave.dick == 0) && ($surgeryUpgrade == 1)>>	
-		[[Create a vagina|Surgery Degradation][$activeSlave.vagina = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "mtf"]]
+	<<if ($activeSlave.vagina == -1)>>
+		<<if ($activeSlave.dick != 0)>>
+			[[Convert genitalia to female|Surgery Degradation][$activeSlave.dick = 0,$activeSlave.dickAccessory = "none",$activeSlave.scrotum = 0,$activeSlave.balls = 0,$activeSlave.vagina = 0,$activeSlave.preg = -2,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "mtf"]]
+		<<elseif ($activeSlave.dick == 0) && ($surgeryUpgrade == 1)>>	
+			[[Create a vagina|Surgery Degradation][$activeSlave.vagina = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 40, $surgeryType = "mtf"]]
+		<</if>>
 	<</if>>
 	
 	<<if ($activeSlave.dick > 0) && ($seeExtreme == 1)>>
 		 | [[Remove penis|Surgery Degradation][$activeSlave.dick = 0,$activeSlave.dickAccessory = "none",$activeSlave.foreskin = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost, $activeSlave.health -= 20, $surgeryType = "chop"]]
 	<</if>>
 	
-	<<if ($activeSlave.vagina > -1) && ($activeSlave.dick > 0)>>
+	<<if ($activeSlave.vagina > -1) && ($seeExtreme == 1)>>
 		| [[Remove pussy|Surgery Degradation][$activeSlave.vagina = -1,$activeSlave.ovaries = 0,$activeSlave.preg = -2,$activeSlave.pregSource = 0,$activeSlave.vaginalSkill = 0,$cash -= $surgeryCost,$activeSlave.health -= 20,$surgeryType = "vaginaRemoval"]] <<if $activeSlave.ovaries == 1>>//This will remove $possessive ovaries as well//<</if>>
 	<</if>>
-	
 <</if>>
 
 

--- a/src/uncategorized/remoteSurgery.tw
+++ b/src/uncategorized/remoteSurgery.tw
@@ -235,6 +235,7 @@ $pronounCap has
 	$pronounCap has had surgery on $possessive voicebox to raise $possessive voice.
 <</if>>
 
+<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <<if ($activeSlave.voice != 0) && ($activeSlave.voiceImplant == 0) && ($activeSlave.voice < 3)>>
 	<<if $activeSlave.indentureRestrictions < 1>>
 	[[Perform surgery to raise voice|Surgery Degradation][$activeSlave.voice += 1, $activeSlave.voiceImplant += 1, $cash -= $surgeryCost,  $activeSlave.health -= 10, $surgeryType = "voice"]]

--- a/src/uncategorized/remoteSurgery.tw
+++ b/src/uncategorized/remoteSurgery.tw
@@ -160,12 +160,12 @@ $pronounCap has
 <</if>>
 <<if $activeSlave.lipsImplant != 0>>
 	<<if $activeSlave.indentureRestrictions < 2>>
-	 | [[Remove lip implants|Surgery Degradation][$activeSlave.lips = ($activeSlave.lips-$activeSlave.lipsImplant),$activeSlave.lipsImplant = 0,$cash -= $surgeryCost, $surgeryType = "lips"]]
+	 ''| [[Remove lip implants|Surgery Degradation][$activeSlave.lips = ($activeSlave.lips-$activeSlave.lipsImplant),$activeSlave.lipsImplant = 0,$cash -= $surgeryCost, $surgeryType = "lips"]]''
 	<</if>>
 <</if>>
 <<if ($activeSlave.lips >= 10) && ($activeSlave.lipsImplant == 0)>>
 	<<if $activeSlave.indentureRestrictions < 2>>
-	 | [[Reduce lips|Surgery Degradation][$activeSlave.lips -= 10,$cash -= $surgeryCost, $surgeryType = "lips"]]
+	 ''| [[Reduce lips|Surgery Degradation][$activeSlave.lips -= 10,$cash -= $surgeryCost, $surgeryType = "lips"]]''
 	<</if>>
 <</if>>
 
@@ -373,6 +373,7 @@ $pronounCap has
 
 /* MAJOR ADD/REMOVE */
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
+
 <<if $activeSlave.indentureRestrictions < 1>>
 	<<if ($activeSlave.vagina == -1)>>
 		<<if ($activeSlave.dick != 0)>>

--- a/src/uncategorized/remoteSurgery.tw
+++ b/src/uncategorized/remoteSurgery.tw
@@ -370,7 +370,10 @@ $pronounCap has
 ''GENITALIA''<br>
 
 <<if ($activeSlave.vagina > -1) || ($activeSlave.dick > 0)>>
-	//<<VaginaDescription>> ''Bold'' surgeries will set her back in this skill.//
+	//<<VaginaDescription>>
+	<<if ($activeSlave.vagina > -1)>>
+		''Bold'' surgeries will set her back in this skill.
+	<</if>>//		
 <</if>>
 
 <<if $activeSlave.vagina > -1>>

--- a/src/uncategorized/surgeryDegradation.tw
+++ b/src/uncategorized/surgeryDegradation.tw
@@ -1326,6 +1326,9 @@ As the remote surgery's long recovery cycle completes,
 	<<elseif ($activeSlave.devotion >= -20)>>
 		She leaves the surgery with a terribly sore rear end. She knows she'll have to endure the pain of being fucked in a tight asshole again soon enough, but trepidation is nothing new for her. If she had much in the way of anal skills, @@.red;they've likely suffered.@@ As with all surgery @@.red;her health has been slightly affected.@@ She is @@.gold;sensibly fearful@@ of your total power over her body.
 		<<set $activeSlave.trust -= 5>>
+		<<if $activeSlave.analSkill > 10>>
+			<<set $activeSlave.analSkill -= 10>>
+		<</if>>
 	<<else>>
 		She leaves the surgery with a terribly sore rear end. She's @@.mediumorchid;horrified@@ at surgical alteration of her rear end, and knows that this means that she'll have to take the pain of sodomy in a tight ass all over again. If she had much in the way of anal skills, @@.red;they've likely suffered.@@ As with all surgery @@.red;her health has been slightly affected.@@ She is @@.gold;terribly afraid@@ of your total power over her most intimate parts.
 		<<set $activeSlave.trust -= 10>>

--- a/src/utility/descriptionWidgetsFlesh.tw
+++ b/src/utility/descriptionWidgetsFlesh.tw
@@ -2483,11 +2483,11 @@ $pronounCap's got a
 <<else>>
 	<<if $activeSlave.vagina == -1>>
 		<<if $seeDicks >= 100>><<elseif $activeSlave.anus == 0>><<else>>Since $pronoun lacks a vagina, $pronoun takes it up <<if $seeRace == 1>>$possessive $activeSlave.race<<else>>the<</if>> ass instead.<</if>>
-	<<elseif $activeSlave.vaginalSkill >= 100>>$pronounCap is a @@.aquamarine;vanilla sex master@@.
-	<<elseif $activeSlave.vaginalSkill > 60>>$pronounCap is a @@.aquamarine;vanilla sex expert@@.
-	<<elseif $activeSlave.vaginalSkill > 30>>$pronounCap is @@.aquamarine;skilled at vanilla sex@@.
-	<<elseif $activeSlave.vaginalSkill > 10>>$pronounCap has @@.aquamarine;basic knowledge about vanilla sex@@.
-	<<else>>$pronounCap is unskilled at vaginal sex.
+		<<elseif $activeSlave.vaginalSkill >= 100>>$pronounCap is a @@.aquamarine;vanilla sex master@@.
+		<<elseif $activeSlave.vaginalSkill > 60>>$pronounCap is a @@.aquamarine;vanilla sex expert@@.
+		<<elseif $activeSlave.vaginalSkill > 30>>$pronounCap is @@.aquamarine;skilled at vanilla sex@@.
+		<<elseif $activeSlave.vaginalSkill > 10>>$pronounCap has @@.aquamarine;basic knowledge about vanilla sex@@.
+		<<else>>$pronounCap is unskilled at vaginal sex.
 	<</if>>
 <</if>>
 
@@ -3028,6 +3028,12 @@ $pronounCap has
 	<</if>>
 <</if>>
 
+<<if $showBodyMods == 1>>
+	<<lipsPiercingDescription>>
+	<<tonguePiercingDescription>>
+<</if>>
+
+
 <<if $activeSlave.fuckdoll > 0>>
 	<<if $PC.dick == 1>>Sticking a dick<<else>>Sliding a dildo<</if>> into $possessive <<if $activeSlave.lips > 95>>facepussy<<else>>mouth insert<</if>>
 	<<if $activeSlave.fuckdoll <= 45>>
@@ -3045,10 +3051,6 @@ $pronounCap has
 	<</if>>
 <</if>>
 
-<<if $showBodyMods == 1>>
-	<<lipsPiercingDescription>>
-	<<tonguePiercingDescription>>
-<</if>>
 
 <</widget>>
 

--- a/src/utility/descriptionWidgetsFlesh.tw
+++ b/src/utility/descriptionWidgetsFlesh.tw
@@ -2487,28 +2487,6 @@ $pronounCap's got a
 <</if>>
 <</if>>
 
-<<if $activeSlave.fuckdoll > 0>>
-	<<if $activeSlave.vagina > 0>>
-		$possessiveCap front hole
-		<<if $activeSlave.fuckdoll <= 45>>
-			is mostly useful when it's restrained for rape.
-		<<else>>
-			will massage <<if $PC.dick == 1>>cocks<<else>>anything<</if>> placed inside it on command.
-			<<if $activeSlave.fuckdoll <= 85>>
-				$pronounCap is even capable of riding <<if $PC.dick == 1>>dick<<else>>a strap-on<</if>>.
-			<</if>>
-		<</if>>
-	<</if>>
-<<else>>
-	<<if $activeSlave.vagina == -1>>
-		<<if $seeDicks >= 100>><<elseif $activeSlave.anus == 0>><<else>>Since $pronoun lacks a vagina, $pronoun takes it up <<if $seeRace == 1>>$possessive $activeSlave.race<<else>>the<</if>> ass instead.<</if>>
-		<<elseif $activeSlave.vaginalSkill >= 100>>$pronounCap is a @@.aquamarine;vanilla sex master@@.
-		<<elseif $activeSlave.vaginalSkill > 60>>$pronounCap is a @@.aquamarine;vanilla sex expert@@.
-		<<elseif $activeSlave.vaginalSkill > 30>>$pronounCap is @@.aquamarine;skilled at vanilla sex@@.
-		<<elseif $activeSlave.vaginalSkill > 10>>$pronounCap has @@.aquamarine;basic knowledge about vanilla sex@@.
-		<<else>>$pronounCap is unskilled at vaginal sex.
-	<</if>>
-<</if>>
 
 <<if ($activeSlave.dick == 0)>>
 	<<if ($activeSlave.clit > 0)>>
@@ -2736,7 +2714,32 @@ $pronounCap's got a
 <</if>>
 <</if>>
 <</if>>
+
+<<if $activeSlave.fuckdoll > 0>>
+	<<if $activeSlave.vagina > 0>>
+		$possessiveCap front hole
+		<<if $activeSlave.fuckdoll <= 45>>
+			is mostly useful when it's restrained for rape.
+		<<else>>
+			will massage <<if $PC.dick == 1>>cocks<<else>>anything<</if>> placed inside it on command.
+			<<if $activeSlave.fuckdoll <= 85>>
+				$pronounCap is even capable of riding <<if $PC.dick == 1>>dick<<else>>a strap-on<</if>>.
+			<</if>>
+		<</if>>
+	<</if>>
+<<else>>
+	<<if $activeSlave.vagina == -1>>
+		<<if $seeDicks >= 100>><<elseif $activeSlave.anus == 0>><<else>>Since $pronoun lacks a vagina, $pronoun takes it up <<if $seeRace == 1>>$possessive $activeSlave.race<<else>>the<</if>> ass instead.<</if>>
+		<<elseif $activeSlave.vaginalSkill >= 100>>$pronounCap is a @@.aquamarine;vanilla sex master@@.
+		<<elseif $activeSlave.vaginalSkill > 60>>$pronounCap is a @@.aquamarine;vanilla sex expert@@.
+		<<elseif $activeSlave.vaginalSkill > 30>>$pronounCap is @@.aquamarine;skilled at vanilla sex@@.
+		<<elseif $activeSlave.vaginalSkill > 10>>$pronounCap has @@.aquamarine;basic knowledge about vanilla sex@@.
+		<<else>>$pronounCap is unskilled at vaginal sex.
+	<</if>>
 <</if>>
+
+<</if>>
+
 <</widget>>
 
 

--- a/src/utility/descriptionWidgetsFlesh.tw
+++ b/src/utility/descriptionWidgetsFlesh.tw
@@ -4077,17 +4077,15 @@ and
 
 <<widget "accentDescription">>
 
-<<if canTalk($activeSlave)>>
-  <<if $activeSlave.accent != 0>>
+<<if $activeSlave.accent != 0>>
 	<<if $activeSlave.accent == 1>>
-	  <<set $seed = either("lovely", "distinctive", "rich", "beautiful")>>
-	  She speaks $language in a $seed $activeSlave.nationality accent<<if $activeSlave.speechRules == "accent elimination">>, which the rules encourage her to suppress<</if>>.
+		<<set $seed = either("lovely", "distinctive", "rich", "beautiful")>>
+		She speaks $language in a $seed $activeSlave.nationality accent<<if $activeSlave.speechRules == "accent elimination">>, which the rules encourage her to suppress<</if>>.
 	<<elseif $activeSlave.accent == 2>>
-	  She speaks $language in a thick $activeSlave.nationality accent that can be hard to understand<<if $activeSlave.speechRules == "accent elimination">>, and the rules encourage her to make an effort to suppress it<</if>>.
+		She speaks $language in a thick $activeSlave.nationality accent that can be hard to understand<<if $activeSlave.speechRules == "accent elimination">>, and the rules encourage her to make an effort to suppress it<</if>>.
 	<<else>>
-	  She speaks little $language, but understands enough to be given orders.
+		She speaks little $language, but understands enough to be given orders.
 	<</if>>
-  <</if>>
 <</if>>
 
 <</widget>>

--- a/src/utility/descriptionWidgetsFlesh.tw
+++ b/src/utility/descriptionWidgetsFlesh.tw
@@ -1335,7 +1335,7 @@ $pronounCap's got a
 
 <</widget>>
 
-<<widget "VaginaDescription">>
+<<widget "crotchDescription">>
 
 <<SlavePronouns $activeSlave>>
 
@@ -1874,6 +1874,14 @@ $pronounCap's got a
 <</if>>
 
 <</if>>
+<</widget>>
+
+
+<<widget "dickDescription">>
+
+<<SlavePronouns $activeSlave>>
+
+<<if ($showClothing == 1) && ($saleDescription == 0)>>
 
 <<if $activeSlave.dick > 0>>
 
@@ -2236,7 +2244,9 @@ $pronounCap's got a
 	<</if>>
 <</if>>
 
+
 <</if>> /* CLOSES DETAILED DICK DESCRIPTION */
+
 
 <<if $activeSlave.prostate == 0>>
 <<if ($activeSlave.dick > 0) || ($activeSlave.balls > 0)>>
@@ -2254,6 +2264,15 @@ $pronounCap's got a
 	<<dickTatDescription>>
 <</if>>
 <</if>>
+<</if>>
+<</widget>>
+
+
+<<widget "vaginaDescription">>
+
+<<SlavePronouns $activeSlave>>
+
+<<if ($showClothing == 1) && ($saleDescription == 0)>>
 
 <<if $activeSlave.dick > 0>>
 <<if $activeSlave.vagina > -1>>
@@ -2713,6 +2732,7 @@ $pronounCap's got a
 	<<elseif ($activeSlave.dick != 0) && ($activeSlave.balls == 0)>>
 		The aphrodisiacs combined with the lack of balls that keeps $object flaccid have $object sexually frustrated; $pronoun's touching $possessive limp dick distractedly and unconsciously rubbing $possessive ass against whatever's next to $object.
 	<</if>>
+<</if>>
 <</if>>
 <</if>>
 <</if>>
@@ -3920,20 +3940,54 @@ $pronounCap has
 <<widget "waistDescription">>
 
 $pronounCap has
+
 <<if $activeSlave.waist > 95>>
-	a badly @@.red;masculine waist@@ that ruins her figure<<if $activeSlave.weight > 30>> and greatly exaggerates how fat $pronoun is<<elseif $activeSlave.weight < -30>> despite how thin $pronoun is<</if>>.
+	a badly @@.red;masculine waist@@ that ruins her figure
+	<<if $activeSlave.weight > 30>> and greatly exaggerates how fat $pronoun is
+	<<elseif $activeSlave.weight < -30>> despite how thin $pronoun is<</if>>.
 <<elseif $activeSlave.waist > 40>>
-	a broad, @@.red;ugly waist@@ that makes her look mannish<<if $activeSlave.weight > 30>> and exaggerates how fat $pronoun is<<elseif $activeSlave.weight < -30>> despite how thin $pronoun is<</if>>.
+	a broad, @@.red;ugly waist@@ that makes her look mannish
+	<<if $activeSlave.weight > 30>> and exaggerates how fat $pronoun is
+	<<elseif $activeSlave.weight < -30>> despite how thin $pronoun is<</if>>.
 <<elseif $activeSlave.waist > 10>>
-	an @@.red;unattractive waist@@ that conceals $possessive <<if $activeSlave.age > 25>>girlish<<else>>womanly<</if>> figure<<if $activeSlave.weight > 30>> and accentuates how fat $pronoun is<<elseif $activeSlave.weight < -30>> despite how thin $pronoun is<</if>>.
+	an @@.red;unattractive waist@@ that conceals $possessive 
+	<<if $activeSlave.age > 25>>
+	girlish
+	<<else>>
+		womanly
+	<</if>> 
+		figure
+	<<if $activeSlave.weight > 30>> and accentuates how fat $pronoun is
+	<<elseif $activeSlave.weight < -30>> despite how thin $pronoun is<</if>>.
 <<elseif $activeSlave.waist >= -10>>
-	an average waist for a <<if $activeSlave.age > 25>>girl<<else>>woman<</if>><<if $activeSlave.weight > 30>>, though it looks broader since $pronoun's fat<<elseif $activeSlave.weight < -30>>, though it looks narrower since $pronoun's thin<</if>>.
+	an average waist for a 
+	<<if $activeSlave.age > 25>>
+		girl
+	<<else>>
+		woman
+	<</if>>
+	<<if $activeSlave.weight > 30>>, though it looks broader since $pronoun's fat
+	<<elseif $activeSlave.weight < -30>>, though it looks narrower since $pronoun's thin<</if>>.
 <<elseif $activeSlave.waist >= -40>>
-	a nice @@.pink;feminine waist@@ that gives $object a <<if $activeSlave.age > 25>>girlish<<else>>womanly<</if>> figure<<if $activeSlave.weight > 30>> despite $possessive extra weight<<elseif $activeSlave.weight < -30>> and accentuates how thin $pronoun is<</if>>.
+	a nice @@.pink;feminine waist@@ that gives $object a 
+	<<if $activeSlave.age > 25>>
+		girlish
+	<<else>>
+		womanly
+	<</if>>
+	figure
+	<<if $activeSlave.weight > 30>> despite $possessive extra weight
+	<<elseif $activeSlave.weight < -30>> and accentuates how thin $pronoun is
+	<</if>>.
 <<elseif $activeSlave.waist >= -95>>
-	a hot @@.pink;wasp waist@@ that gives $possessive an hourglass figure<<if $activeSlave.weight > 30>> despite $possessive extra weight<<elseif $activeSlave.weight < -30>> further accentuated by how thin $pronoun is<</if>>.
+	a hot @@.pink;wasp waist@@ that gives $possessive an hourglass figure
+	<<if $activeSlave.weight > 30>> despite $possessive extra weight
+	<<elseif $activeSlave.weight < -30>> further accentuated by how thin $pronoun is
+	<</if>>.
 <<else>>
-	an @@.pink;absurdly narrow waist@@ that gives $possessive a cartoonishly hourglass figure<<if $activeSlave.weight > 30>> made even more ludicrous by $possessive extra weight<<elseif $activeSlave.weight < -30>> made even more ludicrous by how thin $pronoun is<</if>>.
+	an @@.pink;absurdly narrow waist@@ that gives $possessive a cartoonishly hourglass figure
+	<<if $activeSlave.weight > 30>> made even more ludicrous by $possessive extra weight
+	<<elseif $activeSlave.weight < -30>> made even more ludicrous by how thin $pronoun is<</if>>.
 <</if>>
 
 <</widget>>

--- a/src/utility/descriptionWidgetsPiercings.tw
+++ b/src/utility/descriptionWidgetsPiercings.tw
@@ -102,6 +102,33 @@
 <</widget>>
 
 <<widget "nipplesPiercingDescription">>
+
+<<if ($activeSlave.skin == "tanned") || ($activeSlave.skin == "fair")>>
+	<<if ($activeSlave.preg > 10 || ($activeSlave.births > 0 && $activeSlave.lactation > 0))>>
+		<<set $seed = "dark brown">>
+	<<else>>
+		<<set $seed = "pink">>
+	<</if>>
+<<elseif ($activeSlave.skin == "pale") || ($activeSlave.race == "white")>>
+	<<if ($activeSlave.preg > 10 || ($activeSlave.births > 0 && $activeSlave.lactation > 0))>>
+		<<set $seed = "brown">>
+	<<else>>
+		<<set $seed = "pink">>
+	<</if>>
+<<elseif ($activeSlave.skin == "brown") || ($activeSlave.race == "black")>>
+	<<if ($activeSlave.preg > 10 || ($activeSlave.births > 0 && $activeSlave.lactation > 0))>>
+		<<set $seed = "black">>
+	<<else>>
+		<<set $seed = "dark brown">>
+	<</if>>
+<<else>>
+	<<if ($activeSlave.preg > 10 || ($activeSlave.births > 0 && $activeSlave.lactation > 0))>>
+		<<set $seed = "dark brown">>
+	<<else>>
+		<<set $seed = "brown">>
+	<</if>>
+<</if>>
+
 <<if $activeSlave.fuckdoll > 0>>
 	<<if $activeSlave.nipplesPiercing > 0>>
 		Its nipple piercings help secure the suit material to its breasts.


### PR DESCRIPTION
Splitting vaginaDescription into a few parts, mainly a dickDescription.  This allows each part to be placed as a header for surgeries.  

Adjust accentDescription widget so it can properly appear while it needs to, while still being hidden where it needs to be hidden.  In longSlave, we don't need to hear about accents if a slave is not allowed to talk (That's how it is set up anyway. )  However, in surgery I think we're more interested in the raw biological possibility of the slave, and this is needed info when making major voice decisions. Stronger weight to taking away a voice.

Also, unrelated bugfix that prevented plain vag slaves from having it removed unless they had a dick.