### PR TITLE
Cleaner branch of the "Main" tabs

### DIFF
--- a/src/uncategorized/main.tw
+++ b/src/uncategorized/main.tw
@@ -172,7 +172,178 @@ __''MAIN MENU''__&nbsp;&nbsp;&nbsp;&nbsp;//[[Summary Options]]//
 <<if $positionMainLinks >= 0>>
 	<<MainLinks>>
 <</if>>
-<<include "Slave Summary">>
+
+<<if $useTabs == 0>>
+	<<include "Slave Summary">>
+<<else>>
+	<head>
+	<style>
+
+	div.tab {
+		overflow: hidden;
+		border: 1px solid #ccc;
+		background-color: transparent;
+	}
+
+	div.tab button {
+		background-color: inherit;
+		float: left;
+		border: none;
+		outline: none;
+		cursor: pointer;
+		padding: 14px 16px;
+		transition: 0.3s;
+		font-size: 19px;
+	}
+
+	div.tab button:hover {
+		background-color: #444;
+	}
+
+	div.tab button.active {
+		background-color: #777;
+	}
+
+	.tabcontent {
+		display: none;
+		padding: 6px 12px;
+		-webkit-animation: fadeEffect 1s;
+		animation: fadeEffect 1s;
+	}
+
+	@-webkit-keyframes fadeEffect {
+		from {opacity: 0;}
+		to {opacity: 1;}
+	}
+
+	@keyframes fadeEffect {
+		from {opacity: 0;}
+		to {opacity: 1;}
+	}
+	</style>
+	</head>
+	<body>
+
+	<div class="tab">
+		<button class="tablinks" onclick="opentab(event, 'Special')" id="specialButton">Special</button>
+		<button class="tablinks" onclick="opentab(event, 'Resting')">Resting</button>
+		<button class="tablinks" onclick="opentab(event, 'stay confined')">Confined</button>
+		<button class="tablinks" onclick="opentab(event, 'take classes')">Students</button>
+		<button class="tablinks" onclick="opentab(event, 'please you')">Fucktoys</button>
+		<button class="tablinks" onclick="opentab(event, 'whore')">Whores</button>
+		<button class="tablinks" onclick="opentab(event, 'serve the public')">Public Servants</button>
+		<button class="tablinks" onclick="opentab(event, 'be a servant')">Servants</button>
+		<button class="tablinks" onclick="opentab(event, 'get milked')">Cows</button>
+		<button class="tablinks" onclick="opentab(event, 'work a glory hole')">Gloryhole</button>
+		<button class="tablinks" onclick="opentab(event, 'be a subordinate slave')">Subordinate slaves</button>
+		<button class="tablinks" onclick="opentab(event, 'All')">All</button>	  
+	</div>
+
+	<div id="Special" class="tabcontent">
+	  <div class="content">
+		  <<set $slaveAssignmentTab = "special">>
+		  <<include "Slave Summary">>
+	</div>
+	</div>
+
+	<div id="Resting" class="tabcontent">
+		<div class="content">
+			<<set $slaveAssignmentTab = "resting">>
+			<<include "Slave Summary">>
+		</div>
+	</div>
+	
+	<div id="stay confined" class="tabcontent">
+		<div class="content">
+			<<set $slaveAssignmentTab = "stay confined">>
+			<<include "Slave Summary">>
+		</div>
+	</div>
+
+	<div id="take classes" class="tabcontent">
+		<div class="content">
+			<<set $slaveAssignmentTab = "take classes">>
+			<<include "Slave Summary">>
+		</div>
+	</div>
+	
+	<div id="please you" class="tabcontent">
+		<div class="content">
+			<<set $slaveAssignmentTab = "please you">>
+			<<include "Slave Summary">>
+		</div>
+	</div>
+	
+	<div id="whore" class="tabcontent">
+		<div class="content">
+			<<set $slaveAssignmentTab = "whore">>
+			<<include "Slave Summary">>
+		</div>
+	</div>
+	
+	<div id="serve the public" class="tabcontent">
+		<div class="content">
+			<<set $slaveAssignmentTab = "serve the public">>
+			<<include "Slave Summary">>
+		</div>
+	</div>
+	
+	<div id="be a servant" class="tabcontent">
+		<div class="content">
+			<<set $slaveAssignmentTab = "be a servant">>
+			<<include "Slave Summary">>
+		</div>
+	</div>
+	
+	<div id="get milked" class="tabcontent">
+		<div class="content">
+			<<set $slaveAssignmentTab = "get milked">>
+			<<include "Slave Summary">>
+		</div>
+	</div>
+	
+	<div id="work a glory hole" class="tabcontent">
+		<div class="content">
+			<<set $slaveAssignmentTab = "work a glory hole">>
+			<<include "Slave Summary">>
+		</div>
+	</div>
+	
+	<div id="be a subordinate slave" class="tabcontent">
+		<div class="content">
+			<<set $slaveAssignmentTab = "be a subordinate slave">>
+			<<include "Slave Summary">>
+		</div>
+	</div>
+	
+	<div id="All" class="tabcontent">
+		<div class="content">
+			<<set $slaveAssignmentTab = "all">>
+			<<include "Slave Summary">>
+		</div>
+	</div>
+
+	<script>
+	function opentab(evt, tabName) {
+		var i, tabcontent, tablinks;
+		tabcontent = document.getElementsByClassName("tabcontent");
+		for (i = 0; i < tabcontent.length; i++) {
+			tabcontent[i].style.display = "none";
+		}
+		tablinks = document.getElementsByClassName("tablinks");
+		for (i = 0; i < tablinks.length; i++) {
+			tablinks[i].className = tablinks[i].className.replace(" active", "");
+		}
+		document.getElementById(tabName).style.display = "block";
+		evt.currentTarget.className += " active";
+	}
+
+	document.getElementById("specialButton").click();
+	</script>
+
+	</body>
+<</if>>
+	
 <<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>>
 <<if $positionMainLinks <= 0>>
 	<br><<MainLinks>>

--- a/src/uncategorized/main.tw
+++ b/src/uncategorized/main.tw
@@ -225,8 +225,8 @@ __''MAIN MENU''__&nbsp;&nbsp;&nbsp;&nbsp;//[[Summary Options]]//
 	<body>
 
 	<div class="tab">
-		<button class="tablinks" onclick="opentab(event, 'Special')" id="specialButton">Special</button>
-		<button class="tablinks" onclick="opentab(event, 'Resting')">Resting</button>
+		<button class="tablinks" onclick="opentab(event, 'Special')">Special</button>
+		<button class="tablinks" onclick="opentab(event, 'Resting')" id="defaultButton">Resting</button>
 		<button class="tablinks" onclick="opentab(event, 'stay confined')">Confined</button>
 		<button class="tablinks" onclick="opentab(event, 'take classes')">Students</button>
 		<button class="tablinks" onclick="opentab(event, 'please you')">Fucktoys</button>
@@ -338,7 +338,7 @@ __''MAIN MENU''__&nbsp;&nbsp;&nbsp;&nbsp;//[[Summary Options]]//
 		evt.currentTarget.className += " active";
 	}
 
-	document.getElementById("specialButton").click();
+	document.getElementById("defaultButton").click();
 	</script>
 
 	</body>

--- a/src/uncategorized/main.tw
+++ b/src/uncategorized/main.tw
@@ -176,6 +176,9 @@ __''MAIN MENU''__&nbsp;&nbsp;&nbsp;&nbsp;//[[Summary Options]]//
 <<if $useTabs == 0>>
 	<<include "Slave Summary">>
 <<else>>
+	<<set $Flag = 0>>
+		<<include "Slave Summary">>
+	<<set $Flag = 1>>
 	<head>
 	<style>
 
@@ -225,7 +228,6 @@ __''MAIN MENU''__&nbsp;&nbsp;&nbsp;&nbsp;//[[Summary Options]]//
 	<body>
 
 	<div class="tab">
-		<button class="tablinks" onclick="opentab(event, 'Special')">Special</button>
 		<button class="tablinks" onclick="opentab(event, 'Resting')" id="defaultButton">Resting</button>
 		<button class="tablinks" onclick="opentab(event, 'stay confined')">Confined</button>
 		<button class="tablinks" onclick="opentab(event, 'take classes')">Students</button>
@@ -237,13 +239,6 @@ __''MAIN MENU''__&nbsp;&nbsp;&nbsp;&nbsp;//[[Summary Options]]//
 		<button class="tablinks" onclick="opentab(event, 'work a glory hole')">Gloryhole</button>
 		<button class="tablinks" onclick="opentab(event, 'be a subordinate slave')">Subordinate slaves</button>
 		<button class="tablinks" onclick="opentab(event, 'All')">All</button>	  
-	</div>
-
-	<div id="Special" class="tabcontent">
-	  <div class="content">
-		  <<set $slaveAssignmentTab = "special">>
-		  <<include "Slave Summary">>
-	</div>
 	</div>
 
 	<div id="Resting" class="tabcontent">

--- a/src/uncategorized/slaveSummary.tw
+++ b/src/uncategorized/slaveSummary.tw
@@ -38,6 +38,9 @@
 	<<elseif $slaveAssignmentTab == "be a subordinate slave">>
 		<<if (_Slave.assignment != "be a subordinate slave")>><<continue>><</if>>
 	<<elseif $slaveAssignmentTab == "all">>
+		<<if (_Slave.assignment == "be your Head Girl")
+		|| (_Slave.assignment == "recruit girls")
+		|| (_Slave.assignment == "guard you")>><<continue>><</if>>
 	<</if>>
 	<<if _Slave.assignmentVisible != 1>><<continue>><</if>>
 	<<if (_Slave.choosesOwnClothes == 1) && (_Slave.clothes == "choosing her own clothes")>>

--- a/src/uncategorized/slaveSummary.tw
+++ b/src/uncategorized/slaveSummary.tw
@@ -13,6 +13,32 @@
 
 <<switch _Pass>>
 <<case "Main">>
+	<<if $slaveAssignmentTab == "special">>
+		<<if (_Slave.assignment != "be your Head Girl")
+		&& (_Slave.assignment != "recruit girls")
+		&& (_Slave.assignment != "guard you")>><<continue>><</if>>
+	<<elseif $slaveAssignmentTab == "resting">>
+		<<if _Slave.assignment != "rest">><<continue>><</if>>
+	<<elseif $slaveAssignmentTab == "stay confined">>
+		<<if (_Slave.assignment != "stay confined")>><<continue>><</if>>
+	<<elseif $slaveAssignmentTab == "take classes">>
+		<<if (_Slave.assignment != "take classes")>><<continue>><</if>>
+	<<elseif $slaveAssignmentTab == "please you">>
+		<<if (_Slave.assignment != "please you")>><<continue>><</if>>
+	<<elseif $slaveAssignmentTab == "whore">>
+		<<if (_Slave.assignment != "whore")>><<continue>><</if>>
+	<<elseif $slaveAssignmentTab == "serve the public">>
+		<<if (_Slave.assignment != "serve the public")>><<continue>><</if>>
+	<<elseif $slaveAssignmentTab == "be a servant">>
+		<<if (_Slave.assignment != "be a servant")>><<continue>><</if>>
+	<<elseif $slaveAssignmentTab == "get milked">>
+		<<if (_Slave.assignment != "get milked")>><<continue>><</if>>
+	<<elseif $slaveAssignmentTab == "work a glory hole">>
+		<<if (_Slave.assignment != "work a glory hole")>><<continue>><</if>>
+	<<elseif $slaveAssignmentTab == "be a subordinate slave">>
+		<<if (_Slave.assignment != "be a subordinate slave")>><<continue>><</if>>
+	<<elseif $slaveAssignmentTab == "all">>
+	<</if>>
 	<<if _Slave.assignmentVisible != 1>><<continue>><</if>>
 	<<if (_Slave.choosesOwnClothes == 1) && (_Slave.clothes == "choosing her own clothes")>>
 		<<set $i = _ssi, _oldDevotion = _Slave.devotion>>
@@ -25,7 +51,8 @@
 	<<elseif "guard you" == _Slave.assignment>>''@@.lightcoral;BG@@''
 	<</if>>
 	<<if $personalAttention == _Slave.ID>>''@@.lightcoral;PA@@''<</if>>
-	<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">>
+	<<print "[[_slaveName|Slave Interact][$activeSlave = $slaves["+_ssi+"]]]">> /* lists their names */
+	
 <<case "Personal Attention Select">>
 	<<if (_Slave.assignmentVisible != 1) || (_Slave.fuckdoll > 0)>><<continue>><</if>>
 	<br style="clear:both" /><<if $lineSeparations == 0>><br><<else>><hr style="margin:0"><</if>><<if ($seeImages == 1) && ($seeSummaryImages == 1)>><div class="imageRef smlImg"><<SlaveArt _Slave 1>></div><</if>>
@@ -539,161 +566,161 @@
 <<case "Main">>
 	<<continue>>
 <<case "HG Select">>
-<<if setup.HGCareers.includes(_Slave.career)>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
-<</if>>
-<<case "Head Girl Suite">>
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $Flag == 0>>
-	<<print "[[Send her to live with your Head Girl|Assign][$i = "+_ssi+"]]">>
-<<else>>
-	<<print "[[Bring her out of the Head Girl's suite|Retrieve][$i = "+_ssi+"]]">>
-	<<break>>
-<</if>>
-<<case "BG Select">>
-<<if setup.bodyguardCareers.includes(_Slave.career)>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
-<</if>>
-<<case "Spa">>
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $Flag == 0>>
-	<<print "[[Send her to the Spa|Assign][$i = "+_ssi+"]]">>
-<<elseif $Flag == 1>>
-	<<print "[[Remove her from the Spa|Retrieve][$i = "+_ssi+"]]">>
-<<else>>
-	[[Change or remove Attendant|Attendant Select]]
-	<<break>>
-<</if>>
-<<case "Attendant Select">>
-<<if setup.attendantCareers.includes(_Slave.career)>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
-<</if>>
-<<case "Brothel">>
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $Flag == 0>>
-	<<print "[[Send her to the Brothel|Assign][$i = "+_ssi+"]]">>
-<<elseif $Flag == 1>>
-	<<print "[[Release her from the Brothel|Retrieve][$i = "+_ssi+"]]">>
-<<else>>
-	[[Change or remove Madam|Madam Select]]
-	<<break>>
-<</if>>
-<<case "Madam Select">>
-<<if setup.madamCareers.includes(_Slave.career)>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
-<</if>>
-<<case "Club">>
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $Flag == 0>>
-	<<print "[[Send her to the Club|Assign][$i = "+_ssi+"]]">>
-<<elseif $Flag == 1>>
-	<<print "[[Remove her from the Club|Retrieve][$i = "+_ssi+"]]">>
-<<else>>
-	[[Change or remove DJ|DJ Select]]
-	<<break>>
-<</if>>
-<<case "Arcade">>
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $Flag == 0>>
-	<<print "[[Confine her in the Arcade|Assign][$i = "+_ssi+"]]">>
-<<else>>
-	<<print "[[Release her from the Arcade|Retrieve][$i = "+_ssi+"]]">>
-<</if>>
-<<case "DJ Select">>
-<<if setup.DJCareers.includes(_Slave.career)>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
-<</if>>
-<<case "Clinic">>
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-	<<if $clinicUpgradeScanner == 1>>
-		@@.cyan;Estimated DNA error value: <<print Math.ceil(_Slave.chem/10)>>@@
+	<<if setup.HGCareers.includes(_Slave.career)>>
+		<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
 	<</if>>
-<<if $Flag == 0>>
-	<<print "[[Send her to the Clinic|Assign][$i = "+_ssi+"]]">>
-<<elseif $Flag == 1>>
-	<<print "[[Take her out of the Clinic|Retrieve][$i = "+_ssi+"]]">>
-<<else>>
-	[[Change or remove Nurse|Nurse Select]]
-	<<break>>
-<</if>>
+<<case "Head Girl Suite">>
+	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Send her to live with your Head Girl|Assign][$i = "+_ssi+"]]">>
+	<<else>>
+		<<print "[[Bring her out of the Head Girl's suite|Retrieve][$i = "+_ssi+"]]">>
+		<<break>>
+	<</if>>
+<<case "BG Select">>
+	<<if setup.bodyguardCareers.includes(_Slave.career)>>
+		<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
+	<</if>>
+<<case "Spa">>
+	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Send her to the Spa|Assign][$i = "+_ssi+"]]">>
+	<<elseif $Flag == 1>>
+		<<print "[[Remove her from the Spa|Retrieve][$i = "+_ssi+"]]">>
+	<<else>>
+		[[Change or remove Attendant|Attendant Select]]
+		<<break>>
+	<</if>>
+<<case "Attendant Select">>
+	<<if setup.attendantCareers.includes(_Slave.career)>>
+		<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
+	<</if>>
+<<case "Brothel">>
+	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Send her to the Brothel|Assign][$i = "+_ssi+"]]">>
+	<<elseif $Flag == 1>>
+		<<print "[[Release her from the Brothel|Retrieve][$i = "+_ssi+"]]">>
+	<<else>>
+		[[Change or remove Madam|Madam Select]]
+		<<break>>
+	<</if>>
+<<case "Madam Select">>
+	<<if setup.madamCareers.includes(_Slave.career)>>
+		<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
+	<</if>>
+<<case "Club">>
+	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Send her to the Club|Assign][$i = "+_ssi+"]]">>
+	<<elseif $Flag == 1>>
+		<<print "[[Remove her from the Club|Retrieve][$i = "+_ssi+"]]">>
+	<<else>>
+		[[Change or remove DJ|DJ Select]]
+		<<break>>
+	<</if>>
+<<case "Arcade">>
+	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Confine her in the Arcade|Assign][$i = "+_ssi+"]]">>
+	<<else>>
+		<<print "[[Release her from the Arcade|Retrieve][$i = "+_ssi+"]]">>
+	<</if>>
+<<case "DJ Select">>
+	<<if setup.DJCareers.includes(_Slave.career)>>
+		<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
+	<</if>>
+<<case "Clinic">>
+	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
+		<<if $clinicUpgradeScanner == 1>>
+			@@.cyan;Estimated DNA error value: <<print Math.ceil(_Slave.chem/10)>>@@
+		<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Send her to the Clinic|Assign][$i = "+_ssi+"]]">>
+	<<elseif $Flag == 1>>
+		<<print "[[Take her out of the Clinic|Retrieve][$i = "+_ssi+"]]">>
+	<<else>>
+		[[Change or remove Nurse|Nurse Select]]
+		<<break>>
+	<</if>>
 <<case "Nurse Select">>
-<<if setup.nurseCareers.includes(_Slave.career)>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
-<</if>>
+	<<if setup.nurseCareers.includes(_Slave.career)>>
+		<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
+	<</if>>
 <<case "Schoolroom">>
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $Flag == 0>>
-	<<print "[[Assign her to the Schoolroom|Assign][$i = "+_ssi+"]]">>
-<<elseif $Flag == 1>>
-	<<print "[[Release her from the Schoolroom|Retrieve][$i = "+_ssi+"]]">>
-<<else>>
-	[[Change or remove Schoolteacher|Schoolteacher Select]]
-	<<break>>
-<</if>>
+	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Assign her to the Schoolroom|Assign][$i = "+_ssi+"]]">>
+	<<elseif $Flag == 1>>
+		<<print "[[Release her from the Schoolroom|Retrieve][$i = "+_ssi+"]]">>
+	<<else>>
+		[[Change or remove Schoolteacher|Schoolteacher Select]]
+		<<break>>
+	<</if>>
 <<case "Schoolteacher Select">>
-<<if setup.schoolteacherCareers.includes(_Slave.career)>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
-<</if>>
+	<<if setup.schoolteacherCareers.includes(_Slave.career)>>
+		<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
+	<</if>>
 <<case "Dairy">>
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $Flag == 0>>
-	<<print "[[Send her to the Dairy|Assign][$i = "+_ssi+"]]">>
-<<elseif $Flag == 1>>
-	<<print "[[Release her from the Dairy|Retrieve][$i = "+_ssi+"]]">>
-<<else>>
-	[[Change or remove Milkmaid|Milkmaid Select]]
-	<<break>>
-<</if>>
+	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Send her to the Dairy|Assign][$i = "+_ssi+"]]">>
+	<<elseif $Flag == 1>>
+		<<print "[[Release her from the Dairy|Retrieve][$i = "+_ssi+"]]">>
+	<<else>>
+		[[Change or remove Milkmaid|Milkmaid Select]]
+		<<break>>
+	<</if>>
 <<case "Milkmaid Select">>
-<<if setup.milkmaidCareers.includes(_Slave.career)>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
-<</if>>
+	<<if setup.milkmaidCareers.includes(_Slave.career)>>
+		<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
+	<</if>>
 <<case "Servants' Quarters">>
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $Flag == 0>>
-	<<print "[[Assign her to the Servants' Quarters|Assign][$i = "+_ssi+"]]">>
-<<elseif $Flag == 1>>
-	<<print "[[Release her from the Servants' Quarters|Retrieve][$i = "+_ssi+"]]">>
-<<else>>
-	[[Change or remove Stewardess|Stewardess Select]]
-	<<break>>
-<</if>>
+	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Assign her to the Servants' Quarters|Assign][$i = "+_ssi+"]]">>
+	<<elseif $Flag == 1>>
+		<<print "[[Release her from the Servants' Quarters|Retrieve][$i = "+_ssi+"]]">>
+	<<else>>
+		[[Change or remove Stewardess|Stewardess Select]]
+		<<break>>
+	<</if>>
 <<case "Stewardess Select">>
-<<if setup.stewardessCareers.includes(_Slave.career)>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
-<</if>>
+	<<if setup.stewardessCareers.includes(_Slave.career)>>
+		<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
+	<</if>>
 <<case "Master Suite">>
 <br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $Flag == 0>>
-	<<print "[[Add her to the Suite|Assign][$i = "+_ssi+"]]">>
-<<elseif $Flag == 1>>
-	<<print "[[Send her out of the Suite|Retrieve][$i = "+_ssi+"]]">>
-<<else>>
-	[[Change or remove Concubine|Concubine Select]]
-	<<break>>
-<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Add her to the Suite|Assign][$i = "+_ssi+"]]">>
+	<<elseif $Flag == 1>>
+		<<print "[[Send her out of the Suite|Retrieve][$i = "+_ssi+"]]">>
+	<<else>>
+		[[Change or remove Concubine|Concubine Select]]
+		<<break>>
+	<</if>>
 <<case "Cellblock">>
-<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $Flag == 0>>
-	<<print "[[Confine her in the cellblock|Assign][$i = "+_ssi+"]]">>
-<<elseif $Flag == 1>>
-	<<print "[[Release her from the cellblock|Retrieve][$i = "+_ssi+"]]">>
-<<else>>
-	[[Change or remove Wardeness|Wardeness Select]]
-	<<break>>
-<</if>>
+	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Confine her in the cellblock|Assign][$i = "+_ssi+"]]">>
+	<<elseif $Flag == 1>>
+		<<print "[[Release her from the cellblock|Retrieve][$i = "+_ssi+"]]">>
+	<<else>>
+		[[Change or remove Wardeness|Wardeness Select]]
+		<<break>>
+	<</if>>
 <<case "Wardeness Select">>
-<<if setup.wardenessCareers.includes(_Slave.career)>>
-	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
-<</if>>
+	<<if setup.wardenessCareers.includes(_Slave.career)>>
+		<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>@@.lime;Has applicable career experience.@@
+	<</if>>
 <<case "New Game Plus">>
 	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
-<<if $Flag == 0>>
-	<<print "[[Add to import list|NGP Workaround][$slavesToImport = 1, $i = "+_ssi+"]]">>
-<<else>>
-	<<print "[[Remove from import list|NGP Workaround][$slavesToImport = 0, $i = "+_ssi+"]]">>
-	<<set $slavesToImport += 1>>
-<</if>>
+	<<if $Flag == 0>>
+		<<print "[[Add to import list|NGP Workaround][$slavesToImport = 1, $i = "+_ssi+"]]">>
+	<<else>>
+		<<print "[[Remove from import list|NGP Workaround][$slavesToImport = 0, $i = "+_ssi+"]]">>
+		<<set $slavesToImport += 1>>
+	<</if>>
 <<case "Matchmaking">>
 	<br><<if $seeImages != 1 || $seeSummaryImages != 1 || $imageChoice == 1>>&nbsp;&nbsp;&nbsp;&nbsp;<</if>>
 	<<print "[[Match them|Matchmaking][$subSlave = $slaves[" + _ssi + "]]]">>

--- a/src/uncategorized/slaveSummary.tw
+++ b/src/uncategorized/slaveSummary.tw
@@ -13,7 +13,7 @@
 
 <<switch _Pass>>
 <<case "Main">>
-	<<if $slaveAssignmentTab == "special">>
+	<<if $Flag == 0>>
 		<<if (_Slave.assignment != "be your Head Girl")
 		&& (_Slave.assignment != "recruit girls")
 		&& (_Slave.assignment != "guard you")>><<continue>><</if>>


### PR DESCRIPTION
Contains what I was trying to do in #937, now with less messy commit problems.  As before:

Uses the 'weekly reports' style tabs on the `main` screen.  Currently, in an attempt to reflect the style of the Club and other buildings, "special" slaves are listed more statically, then the tabs appear below, with a tab for each common assignment (whoring, servant, etc.)  The default tab is "resting" slaves, encouraging players to check on their health, and consider reassigning them if their task just completed.  

Hopefully this helps performance as well, especially with art enabled.

All the old sorting works as well, allowing players to display only whores, but sorted by devotion.  (It may be possible to depreciate sorting by occupation after this.)