### PR TITLE
HG flaw fixing and BC fixes

### DIFF
--- a/src/uncategorized/BackwardsCompatibility.tw
+++ b/src/uncategorized/BackwardsCompatibility.tw
@@ -991,11 +991,11 @@ Setting missing global variables:
 	<<set $masterSuiteDecoration = "standard">>
 <</if>>
 
-<<if ndef $HGSuiteiIDs>>
-	<<set $HGSuiteiIDs = []>>
+<<if ndef $HGSuiteIDs>>
+	<<set $HGSuiteIDs = []>>
 <</if>>
-<<if $HGSuiteiIDs.length > 0 && typeof $HGSuiteiIDs[0] === 'object'>>
-	<<set $HGSuiteiIDs = $HGSuiteiIDs.map(function(a) { return a.ID; })>>
+<<if $HGSuiteIDs.length > 0 && typeof $HGSuiteIDs[0] === 'object'>>
+	<<set $HGSuiteIDs = $HGSuiteIDs.map(function(a) { return a.ID; })>>
 <</if>>
 <<if ndef $HGSuiteName>>
 	<<set $HGSuiteName = "the Head Girl Suite">>
@@ -1298,7 +1298,7 @@ Setting missing global variables:
 	<<set $justiceEvents = ["slave deal", "slave training", "majority deal", "indenture deal", "virginity deal"]>>
 <</if>>
 
-<<if ($ver.includes("0.6") == true) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true) || ($ver == "0.9")>>
+<<if (($ver.includes("0.6") == true && !$ver.includes("10.6")) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true) || ($ver == "0.9"))>>
 	<<if $seeDicks == 2>>
 		<<set $seeDicks = 100>>
 	<<elseif $seeDicks == 1>>
@@ -1517,7 +1517,7 @@ Setting missing slave variables:
 	<<set _Slave.training = 0>>
 <</if>>
 
-<<if ($ver.includes("0.6") == true) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true) && ($ver.includes("0.8.9") != true) && ($ver.includes("0.8.10") != true) && ($ver.includes("0.8.11") != true) && ($ver.includes("0.8.12") != true)>>
+<<if (($ver.includes("0.6") == true && !$ver.includes("10.6")) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true)) && ($ver.includes("0.8.9") != true) && ($ver.includes("0.8.10") != true) && ($ver.includes("0.8.11") != true) && ($ver.includes("0.8.12") != true)>>
 	<<if _Slave.attrXX == 2>>
 		<<set _Slave.attrXX = 90>>
 	<<elseif _Slave.attrXX == 1>>
@@ -1542,7 +1542,7 @@ Setting missing slave variables:
 	<</if>>
 <</if>>
 
-<<if ($ver.includes("0.6") == true) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true)>>
+<<if (($ver.includes("0.6") == true && !$ver.includes("10.6")) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true))>>
 	<<if _Slave.health <= -9>>
 		<<set _Slave.health = -90>>
 	<<elseif _Slave.health <= -7>>
@@ -1615,7 +1615,7 @@ Setting missing slave variables:
 	<</if>>
 <</if>>
 
-<<if ($ver.includes("0.6") == true) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true) || ($ver.includes("0.9") == true) && ($ver.includes("0.9.5") != true) && ($ver.includes("0.9.6") != true) && ($ver.includes("0.9.7") != true) && ($ver.includes("0.9.8") != true) && ($ver.includes("0.9.9") != true) && ($ver.includes("0.9.10") != true)>>
+<<if (($ver.includes("0.6") == true && !$ver.includes("10.6")) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true) || ($ver.includes("0.9") == true)) && ($ver.includes("0.9.5") != true) && ($ver.includes("0.9.6") != true) && ($ver.includes("0.9.7") != true) && ($ver.includes("0.9.8") != true) && ($ver.includes("0.9.9") != true) && ($ver.includes("0.9.10") != true)>>
 	<<if _Slave.oralSkill > 0>>
 	<<if _Slave.oralSkill == 3>>
 		<<set _Slave.oralSkill = 100>>
@@ -1687,7 +1687,7 @@ Setting missing slave variables:
 		<</if>>
 	<</if>>
 <</if>>
-<<if ($ver.includes("0.6") == true) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true) || ($ver.includes("0.9") != true) || ($ver == "0.9")>>
+<<if (($ver.includes("0.6") == true && !$ver.includes("10.6")) || ($ver.includes("0.7") == true) || ($ver.includes("0.8") == true) || ($ver.includes("0.9") != true) || ($ver == "0.9"))>>
 	<<if _Slave.lips != 0>>
 	<<if _Slave.lips == 3>>
 		<<set _Slave.lips = 85>>

--- a/src/uncategorized/BackwardsCompatibility.tw
+++ b/src/uncategorized/BackwardsCompatibility.tw
@@ -991,11 +991,11 @@ Setting missing global variables:
 	<<set $masterSuiteDecoration = "standard">>
 <</if>>
 
-<<if ndef $HGSuiteIDs>>
-	<<set $HGSuiteIDs = []>>
+<<if ndef $HGSuiteiIDs>>
+	<<set $HGSuiteiIDs = []>>
 <</if>>
-<<if $HGSuiteIDs.length > 0 && typeof $HGSuiteIDs[0] === 'object'>>
-	<<set $HGSuiteIDs = $HGSuiteIDs.map(function(a) { return a.ID; })>>
+<<if $HGSuiteiIDs.length > 0 && typeof $HGSuiteiIDs[0] === 'object'>>
+	<<set $HGSuiteiIDs = $HGSuiteiIDs.map(function(a) { return a.ID; })>>
 <</if>>
 <<if ndef $HGSuiteName>>
 	<<set $HGSuiteName = "the Head Girl Suite">>

--- a/src/uncategorized/slaveAssignmentsReport.tw
+++ b/src/uncategorized/slaveAssignmentsReport.tw
@@ -242,6 +242,11 @@
 		<<removeJob $slaves[$i] "learn in the schoolroom">>
 		''__@@.pink;$slaves[$i].slaveName@@__'' is no longer mentally capable and @@.yellow;has been dropped from class.@@
 	<</if>>
+<<case "be confined in the cellblock">>
+	<<if $slaves[$i].fetish == "mindbroken">>
+		<<removeJob $slaves[$i] "be confined in the cellblock">>
+		''__@@.pink;$slaves[$i].slaveName@@__'' has mentally broken and thus can not be broken further. @@.yellow;She has been released from the cellblock.@@
+	<</if>>
 <</switch>>
 
 <<if $Lurcher>>
@@ -310,12 +315,12 @@
         <<continue>>
     <</if>>
 
-    <<if ($headGirlTrainsFlaws == 1 && _Slave.behavioralFlaw != "none" || (_Slave.sexualFlaw != "none" && !_hasParaphilia))>>
+    <<if ($headGirlTrainsFlaws == 1 && ((_Slave.behavioralFlaw != "none") || (_Slave.sexualFlaw != "none" && !_hasParaphilia)))>>
         <<set _HGPossibleSlaves[2].push({ID: _Slave.ID, training: "flaw"})>>
         <<continue>>
     <</if>>
 
-    <<if ($headGirlTrainsFlaws == 2 && _Slave.devotion > 20 && _Slave.behavioralFlaw != "none" || (_Slave.sexualFlaw != "none" && !_hasParaphilia))>>
+    <<if ($headGirlTrainsFlaws == 2 && _Slave.devotion > 20 && ((_Slave.behavioralFlaw != "none") || (_Slave.sexualFlaw != "none" && !_hasParaphilia)))>>
         <<if ((_Slave.behavioralFlaw != "none" && _Slave.behavioralQuirk == "none") || (_Slave.sexualFlaw != "none" && _Slave.sexualQuirk == "none"))>>
             <<set _HGPossibleSlaves[3].push({ID: _Slave.ID, training: "soften"})>>
         <<else>>


### PR DESCRIPTION
She'll now do her job right. Also parentheses are your friends.

Also tossed in a clearer to kick mindbroken slaves out of the cellblock since they confused slave summary to the point of getting stuck in the facility.

And now more: Backwards Compatibility will now properly set the HG suite slave array and stop thinking it is running 0.6. Strongly advise moving to 0.11.0.0 to avoid trouble with 0.7 through 0.9.