### PR TITLE
Relative events randomization

### DIFF
--- a/src/uncategorized/randomNonindividualEvent.tw
+++ b/src/uncategorized/randomNonindividualEvent.tw
@@ -582,17 +582,20 @@
 
 <<if $familyTesting == 1>>
 
-<<set $i = $slaves.findIndex(function(s) { return s.fuckdoll == 0 && s.canRecruit == 1 && s.devotion > 50 && canWalk(s); })>>
-<<if $i != -1>>
-	<<if random(1,100) > 90+(totalRelatives($slaves[$i])*2)>>
+<<set _recruiterSlaves = $slaves.filter(function(s) { return s.fuckdoll == 0 && s.canRecruit == 1 && s.devotion > 50 && canWalk(s); })>>
+<<for _recruiterSlaves.length > 0>>
+	<<set $recruiterSlave = _recruiterSlaves.pluck()>>
+	<<if random(1,100) > 90+(totalRelatives($recruiterSlave)*2)>>
 		<<set $j = $slavesOriginal.findIndex(function(o) { return o.ID == $slaves[$i].ID; })>>
 		<<if $j != -1>>
 			<<set $events.push("RE relative recruiter")>>
+			<<break>>
 		<<else>> /* no matching slave object in the slavesOriginal array */
+			<<set $i = $slaves.findIndex(function(o) { return o.ID == $recruiterSlave.ID; })>>
 			<<set $slaves[$i].canRecruit = 0>>
 		<</if>>
 	<</if>>
-<</if>>
+<</for>>
 
 <<else>> /* extended family mode == 0 */
 

--- a/src/uncategorized/randomNonindividualEvent.tw
+++ b/src/uncategorized/randomNonindividualEvent.tw
@@ -117,37 +117,47 @@
 
 <<else>> /* $familyTesting == 1 */
 
-<<set $devMother = $slaves.find(function(s) { return s.daughters > 0 && s.devotion > 50 && s.anus != 0 && canWalk(s); })>>
-<<if (def $devMother)>>
+<<set _relatedSlaves = $slaves.filter(function(s) { return s.daughters > 0 || s.sisters > 0; })>>
+
+<<set _devMothers = _relatedSlaves.filter(function(s) { return s.daughters > 0 && s.devotion > 50 && s.anus != 0 && canWalk(s); })>>
+<<for _devMothers.length > 0>>
+	<<set $devMother = _devMothers.pluck()>>
 	<<set $devDaughter = randomDaughter($devMother)>>
 	<<if (def $devDaughter) && ($devDaughter.devotion > 50) && ($devDaughter.anus != 0) && canWalk($devDaughter)>>
 		<<set $events.push("RE devoted mother daughter")>>
+		<<break>>
 	<</if>>
-<</if>>
+<</for>>
 
-<<set $mother = $slaves.find(function(s) { return s.daughters > 0 && s.devotion < 10 && s.anus != 0 && canWalk(s); })>>
-<<if (def $mother)>>
+<<set _resMothers = _relatedSlaves.filter(function(s) { return s.daughters > 0 && s.devotion < 10 && s.anus != 0 && canWalk(s); })>>
+<<for _resMothers.length > 0>>
+	<<set $mother = _resMothers.pluck()>>
 	<<set $daughter = randomDaughter($mother)>>
 	<<if (def $daughter) && ($daughter.devotion < 10) && ($daughter.anus != 0) && canWalk($daughter)>>
 		<<set $events.push("RE resistant mother daughter")>>
+		<<break>>
 	<</if>>
-<</if>>
+<</for>>
 
-<<set $youngerSister = $slaves.find(function(s) { return s.sisters > 0 && canPenetrate(s); })>>
-<<if (def $youngerSister)>>
+<<set _youngerSisters = _relatedSlaves.filter(function(s) { return s.sisters > 0 && canPenetrate(s); })>>
+<<for _youngerSisters.length > 0>>
+	<<set $youngerSister = _youngerSisters.pluck()>>
 	<<set $olderSister = randomSister($youngerSister)>>
 	<<if (def $olderSister) && ($olderSister.anus == 0) && $youngerSister.devotion > ($olderSister.devotion+20)>>
 		<<set $events.push("RE sibling revenge")>>
+		<<break>>
 	<</if>>
-<</if>>
+<</for>>
 
-<<set $alphaTwin = $slaves.find(function(s) { return s.sisters > 0 && s.anus > 0 && s.devotion > 50 && canWalk(s); })>>
-<<if (def $alphaTwin)>>
+<<set _twins = _relatedSlaves.filter(function(s) { return s.sisters > 0 && s.anus > 0 && s.devotion > 50 && canWalk(s); })>>
+<<for _twins.length > 0)>>
+	<<set $alphaTwin = _twins.pluck()>>
 	<<set $betaTwin = randomTwinSister($alphaTwin)>>
 	<<if (def $betaTwin) && ($betaTwin.anus > 0) && ($betaTwin.devotion > 50) && canWalk($betaTwin)>>
 		<<set $events.push("RE devoted twins")>>
+		<<break>>
 	<</if>>
-<</if>>
+<</for>>
 
 <</if>>  /* closes extended family mode */
 

--- a/src/uncategorized/reRelativeRecruiter.tw
+++ b/src/uncategorized/reRelativeRecruiter.tw
@@ -19,11 +19,7 @@
 	<<set $newRelativeRecruitID = 1100000>>
 <</if>>
 
-<<set $eventSlave = $slaves.find(function(s) { return s.canRecruit == 1 && s.fuckdoll == 0 && s.devotion > 50 && canWalk(s) && (random(1,100) > (totalRelatives(s)*20)); })>>
-<<if (ndef $eventSlave)>> /* due to randomization, we might have to stop here */
-	<<goto "RIE Eligibility Check">>
-<<else>>
-
+<<set $eventSlave = $recruiterSlave>>
 <<set $activeSlave = clone($slavesOriginal.find(function(o) { return o && o.ID == $eventSlave.ID; }))>>
 
 <<set _recruitedType = []>>
@@ -671,7 +667,6 @@ You look up the _relationType. She costs ¤$slaveCost, a bargain, but you won't 
 
 
 <</if>> /* _recruitedType.length */
-<</if>> /* eventSlave is valid */
 
 
 <<else>> /* vanilla */

--- a/src/uncategorized/reRelativeRecruiter.tw
+++ b/src/uncategorized/reRelativeRecruiter.tw
@@ -19,7 +19,7 @@
 	<<set $newRelativeRecruitID = 1100000>>
 <</if>>
 
-<<set $eventSlave = $recruiterSlave>>
+<<set $eventSlave = $slaves.find(function(s) { return s.ID == $recruiterSlave.ID; })>>
 <<set $activeSlave = clone($slavesOriginal.find(function(o) { return o && o.ID == $eventSlave.ID; }))>>
 
 <<set _recruitedType = []>>


### PR DESCRIPTION
Re-randomizing relative events that weren't randomized in extended family mode.

It should be noted that my changes will make RE Relative Recruiter fire more frequently. Previously it would only find/check a **single** slave for applicability, and then there would be an **at most** 10% chance (possibly even 0%) that "relative recruiter" would be pushed to the events array. Now it checks all applicable slaves until one passes the 10% or less check. Only if none pass is the event entirely ignored.

I also removed the second (similar) check in reRelativeRecruiter.tw since it seemed silly to have the event fire only to fail another random check and immediately exit the event. If you need to make it more unlikely for the event to fire, just increase the difficulty of the first check.