### PR TITLE
RA Changes

### DIFF
--- a/devTools/tweeGo/targets/sugarcube-2/userlib.js
+++ b/devTools/tweeGo/targets/sugarcube-2/userlib.js
@@ -316,222 +316,39 @@ window.ruleApplied = function(slave, ID) {
 	return slave.currentRules.includes(ID);
 };
 
-window.ruleAssignment = function(applyAssignment, assignment) {
-	if (!applyAssignment)
-		return false;
-	return applyAssignment.includes(assignment);
-};
+window.expandFacilityAssignments = function(facilityAssignments) {
+	var assignmentPairs = {
+		"serve in the club": "be the DJ",
+		"rest in the spa": "be the Attendant",
+		"work in the brothel": "be the Madam",
+		"work in the dairy": "be the Milkmaid",
+		"work as a servant": "be the Stewardess",
+		"get treatment in the clinic": "be the Nurse",
+		"live with your Head Girl": "be your Head Girl",
+		"serve in the master suite": "be your Concubine",
+		"learn in the schoolroom": "be the Schoolteacher",
+		"be confined in the cellblock": "be the Wardeness",
+	};
 
-window.ruleFacility = function(applyFacility, facility) {
-	if (!applyFacility)
-		return false;
-	return applyFacility.includes(facility);
-};
-
-window.ruleExcludeSlaveFacility = function(rule, slave) {
-	if (!slave || !rule || !rule.excludeFacility) {
-		return null;
-	} else {
-		for(var d=0; d < rule.excludeFacility.length; ++d){
-			if(rule.excludeFacility[d] == "hgsuite"){
-				if(slave.assignment == "live with your Head Girl" ){
-					return true;
-				}
-				else if(slave.assignment == "be your Head Girl"){
-					return true;
-				}
-			}
-			else if(rule.excludeFacility[d] == "arcade"){
-				if (slave.assignment == "be confined in the arcade" ){
-					return true;
-				}
-			}
-			else if(rule.excludeFacility[d] == "mastersuite"){
-				if(slave.assignment == "serve in the master suite" ){
-					return true;
-				}
-				else if(slave.assignment == "be your Concubine"){
-					return true;
-				}
-			}
-			else if(rule.excludeFacility[d] == "clinic"){
-				if(slave.assignment == "get treatment in the clinic" ){
-					return true;
-				}
-				else if(slave.assignment == "be the Nurse"){
-					return true;
-				}
-			}
-			else if(rule.excludeFacility[d] == "spa"){
-				if(slave.assignment == "rest in the spa" ){
-					return true;
-				}
-				else if(slave.assignment == "be the Attendant"){
-					return true;
-				}
-			}
-			else if(rule.excludeFacility[d] == "brothel"){
-				if(slave.assignment == "work in the brothel" ){
-					return true;
-				}
-				else if(slave.assignment == "be the Madam"){
-					return true;
-				}
-			}
-			else if(rule.excludeFacility[d] == "club"){
-				if(slave.assignment == "serve in the club" ){
-					return true;
-				}
-				else if(slave.assignment == "be the DJ"){
-					return true;
-				}
-			}
-			else if(rule.excludeFacility[d] == "dairy"){
-				if (slave.assignment == "work in the dairy"){
-					return true;
-				}
-				else if(slave.assignment == "be the Milkmaid"){
-					return true;
-				}
-			}
-			else if(rule.excludeFacility[d] == "servantsquarters"){
-				if(slave.assignment == "work as a servant"){
-					return true;
-				}
-				else if(slave.assignment == "be the Stewardess"){
-					return true;
-				}
-			}
-			else if(rule.excludeFacility[d] == "schoolroom"){
-				if(slave.assignment == "learn in the schoolroom" ){
-					return true;
-				}
-				else if(slave.assignment == "be the Schoolteacher"){
-					return true;
-				}
-			}
-			else if(rule.excludeFacility[d] == "cellblock"){
-				if(slave.assignment == "be confined in the cellblock" ){
-					return true;
-				}
-				else if(slave.assignment == "be the Wardeness"){
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-};
-
-window.ruleAppliedToSlaveFacility = function(rule, slave) {
-	if (!slave || !rule || !rule.facility) {
-		return null;
-	} else {
-		for(var d=0; d < rule.facility.length; ++d){
-			if(rule.facility[d] == "hgsuite"){
-				if(slave.assignment == "live with your Head Girl" ){
-					return true;
-				}
-				else if((rule.excludeSpecialSlaves != true) && (slave.assignment == "be your Head Girl")){
-					return true;
-				}
-			}
-			else if(rule.facility[d] == "arcade"){
-				if(slave.assignment == "be confined in the arcade" ){
-					return true;
-				}
-			}
-			else if(rule.facility[d] == "mastersuite"){
-				if(slave.assignment == "serve in the master suite" ){
-					return true;
-				}
-				else if((rule.excludeSpecialSlaves != true) && (slave.assignment == "be your Concubine")){
-					return true;
-				}
-			}
-			else if(rule.facility[d] == "clinic"){
-				if(slave.assignment == "get treatment in the clinic" ){
-					return true;
-				}
-				else if((rule.excludeSpecialSlaves != true) && (slave.assignment == "be the Nurse")){
-					return true;
-				}
-			}
-			else if(rule.facility[d] == "spa"){
-				if(slave.assignment == "rest in the spa" ){
-					return true;
-				}
-				else if((rule.excludeSpecialSlaves != true) && (slave.assignment == "be the Attendant")){
-					return true;
-				}
-			}
-			else if(rule.facility[d] == "brothel"){
-				if(slave.assignment == "work in the brothel" ){
-					return true;
-				}
-				else if((rule.excludeSpecialSlaves != true) && (slave.assignment == "be the Madam")){
-					return true;
-				}
-			}
-			else if(rule.facility[d] == "club"){
-				if(slave.assignment == "serve in the club" ){
-					return true;
-				}
-				else if((rule.excludeSpecialSlaves != true) && (slave.assignment == "be the DJ")){
-					return true;
-				}
-			}
-			else if(rule.facility[d] == "dairy"){
-				if (slave.assignment == "work in the dairy"){
-					return true;
-				}
-				else if((rule.excludeSpecialSlaves != true) && (slave.assignment == "be the Milkmaid")){
-					return true;
-				}
-			}
-			else if(rule.facility[d] == "servantsquarters"){
-				if(slave.assignment == "work as a servant" ){
-					return true;
-				}
-				else if((rule.excludeSpecialSlaves != true) && (slave.assignment == "be the Stewardess")){
-					return true;
-				}
-			}
-			else if(rule.facility[d] == "schoolroom"){
-				if(slave.assignment == "learn in the schoolroom" ){
-					return true;
-				}
-				else if((rule.excludeSpecialSlaves != true) && (slave.assignment == "be the Schoolteacher")){
-					return true;
-				}
-			}
-			else if(rule.facility[d] == "cellblock"){
-				if(slave.assignment == "be confined in the cellblock" ){
-					return true;
-				}
-				else if((rule.excludeSpecialSlaves != true) && (slave.assignment == "be the Wardeness")){
-					return true;
-				}
-			}
-		}return false;
-	}
+	if (!facilityAssignments || !facilityAssignments.length)
+		return [];
+	var fullList = facilityAssignments.map(function(a) {
+		if (a in assignmentPairs)
+			return [a, assignmentPairs[a]];
+		return a;
+	});
+	return fullList.flatten();
 };
 
 window.ruleSlaveSelected = function(slave, rule) {
-	if (!slave || !rule) {
-		return null;
-	} else if (!rule.selectedSlaves) {
+	if (!slave || !rule || !rule.selectedSlaves)
 		return false;
-	}
 	return rule.selectedSlaves.includes(slave.ID);
 };
 
 window.ruleSlaveExcluded = function(slave, rule) {
-	if (!slave || !rule) {
-		return null;
-	} else if (!rule.excludedSlaves) {
+	if (!slave || !rule || !rule.excludedSlaves)
 		return false;
-	}
 	return rule.excludedSlaves.includes(slave.ID);
 };
 

--- a/devTools/tweeGo/targets/sugarcube-2/userlib.js
+++ b/devTools/tweeGo/targets/sugarcube-2/userlib.js
@@ -531,47 +531,26 @@ window.mergeRules = function(rules) {
     var combinedRule = {};
 
     for (var i = 0; i < rules.length; i++) {
-        for (var attr in rules[i]) {
+        for (var prop in rules[i]) {
+            // we don't manage setAssignment here, we do it in <<DefaultRules>>
+            if (prop === "setAssignment")
+                continue;
 
             // A rule overrides any preceding ones if,
             //   * there are no preceding ones,
             //   * or it sets autoBrand,
-            //   * or it sets setAssignment to something other that "none",
-            //   * or it sets assignFacility to something other that "none",
-            //   * or it sets none of the above and is not "no default setting"
+            //   * or it does not set autoBrand and is not "no default setting"
             var applies = (
-                combinedRule[attr] === undefined
-                || (attr === "autoBrand" && rules[i][attr])
-                || (attr === "setAssignment" && rules[i][attr] !== "none")
-                || (attr === "assignFacility" && rules[i][attr] !== "none")
-                || (
-                    attr !== "autoBrand"
-                    && attr !== "setAssignment"
-                    && attr !== "assignFacility"
-                    && rules[i][attr] !== "no default setting"
-                )
+                combinedRule[prop] === undefined
+                || (prop === "autoBrand" && rules[i][prop])
+                || (prop !== "autoBrand" && rules[i][prop] !== "no default setting")
             );
 
-            if (applies) {
-                if (attr == "setAssignment" && combinedRule.assignFacility !== "none") {
-                    // If the rules so far have set assignFacility, unset it,
-                    // since the assignment overrides it.  We assume that a
-                    // given rule won't set both assignFacility and
-                    // setAssignment.  If that happens, which one will prevail
-                    // is down to the enumeration order of "for ... in".
-                    combinedRule.assignFacility = "none";
-                    combinedRule.facilityRemove = false;
-                }
-                if (attr == "assignFacility" && combinedRule.setAssignment !== "none")
-                    // Similarly, if setAssignment is set, unset it.
-                    combinedRule.setAssignment = "none";
-
-                combinedRule[attr] = rules[i][attr];
-            }
+            if (applies)
+                combinedRule[prop] = rules[i][prop];
         }
     }
 
     return combinedRule;
 }
-
 

--- a/src/uncategorized/BackwardsCompatibility.tw
+++ b/src/uncategorized/BackwardsCompatibility.tw
@@ -267,6 +267,10 @@
 		<</if>>
 	<</if>>
 
+	<<if $defaultRules[_bci].setAssignment == "none">>
+		<<set $defaultRules[_bci].setAssignment = "no default setting">>
+	<</if>>
+
 	<<if $defaultRules[_bci].assignFacility>>
 		<<switch $defaultRules[_bci].assignFacility>>
 		<<case "spa">>          <<set $defaultRules[_bci].setAssignment = "rest in the spa">>

--- a/src/uncategorized/BackwardsCompatibility.tw
+++ b/src/uncategorized/BackwardsCompatibility.tw
@@ -221,52 +221,119 @@
 <</if>>
 
 <<for _bci = 0; _bci < $defaultRules.length; _bci++>>
+	<<if ndef $defaultRules[_bci].condition>>
+		<<set _activation = $defaultRules[_bci].activation>>
+		<<if _activation == "sex drive">>
+			<<set _activation = "energy">>
+		<</if>>
 
-    <<if ndef $defaultRules[_bci].condition>>
-        <<set _activation = $defaultRules[_bci].activation>>
-        <<if _activation == "sex drive">>
-            <<set _activation = "energy">>
-        <</if>>
+		<<if _activation == "none">>
+			<<set $defaultRules[_bci].condition = {id: "false"}>>
+		<<elseif _activation == "always">>
+			<<set $defaultRules[_bci].condition = {id: "true"}>>
 
-        <<if _activation == "none">>
-            <<set $defaultRules[_bci].condition = {id: "false"}>>
-        <<elseif _activation == "always">>
-            <<set $defaultRules[_bci].condition = {id: "true"}>>
+		<<elseif $defaultRules[_bci].thresholdLower != "none" && $defaultRules[_bci].thresholdUpper != "none">>
+			<<set $defaultRules[_bci].condition = {
+				id: "&&",
+				first: {
+					id: $defaultRules[_bci].eqUpper ? "<=" : "<",
+					first: {id: "(name)", name: _activation},
+					second: {id: "(number)", value: $defaultRules[_bci].thresholdUpper}
+				},
+				second: {
+					id: $defaultRules[_bci].eqLower ? ">=" : ">",
+					first: {id: "(name)", name: _activation},
+					second: {id: "(number)", value: $defaultRules[_bci].thresholdLower},
+				},
+			}>>
 
-        <<elseif $defaultRules[_bci].thresholdLower != "none" && $defaultRules[_bci].thresholdUpper != "none">>
-            <<set $defaultRules[_bci].condition = {
-                id: "&&",
-                first: {
-                    id: $defaultRules[_bci].eqUpper ? "<=" : "<",
-                    first: {id: "(name)", name: _activation},
-                    second: {id: "(number)", value: $defaultRules[_bci].thresholdUpper}
-                },
-                second: {
-                    id: $defaultRules[_bci].eqLower ? ">=" : ">",
-                    first: {id: "(name)", name: _activation},
-                    second: {id: "(number)", value: $defaultRules[_bci].thresholdLower},
-                },
-            }>>
+		<<elseif $defaultRules[_bci].thresholdLower != "none">>
+			<<set $defaultRules[_bci].condition = {
+				id: $defaultRules[_bci].eqLower ? ">=" : ">",
+				first: {id: "(name)", name: _activation},
+				second: {id: "(number)", value: $defaultRules[_bci].thresholdLower},
+			}>>
 
-        <<elseif $defaultRules[_bci].thresholdLower != "none">>
-            <<set $defaultRules[_bci].condition = {
-                id: $defaultRules[_bci].eqLower ? ">=" : ">",
-                first: {id: "(name)", name: _activation},
-                second: {id: "(number)", value: $defaultRules[_bci].thresholdLower},
-            }>>
+		<<elseif $defaultRules[_bci].thresholdUpper != "none">>
+			<<set $defaultRules[_bci].condition = {
+				id: $defaultRules[_bci].eqUpper ? "<=" : "<",
+				first: {id: "(name)", name: _activation},
+				second: {id: "(number)", value: $defaultRules[_bci].thresholdUpper},
+			}>>
 
-        <<elseif $defaultRules[_bci].thresholdUpper != "none">>
-            <<set $defaultRules[_bci].condition = {
-                id: $defaultRules[_bci].eqUpper ? "<=" : "<",
-                first: {id: "(name)", name: _activation},
-                second: {id: "(number)", value: $defaultRules[_bci].thresholdUpper},
-            }>>
+		<<else>>
+			/% both thresholds are "none", same as activation being none %/
+			<<set $defaultRules[_bci].condition = {id: "false"}>>
+		<</if>>
+	<</if>>
 
-        <<else>>
-            /% both thresholds are "none", same as activation being none
-            <<set $defaultRules[_bci].condition = {id: "false"}>>
-        <</if>>
-    <</if>>
+	<<if $defaultRules[_bci].assignFacility>>
+		<<switch $defaultRules[_bci].assignFacility>>
+		<<case "spa">>          <<set $defaultRules[_bci].setAssignment = "rest in the spa">>
+		<<case "club">>         <<set $defaultRules[_bci].setAssignment = "serve in the club">>
+		<<case "dairy">>        <<set $defaultRules[_bci].setAssignment = "work in the dairy">>
+		<<case "clinic">>       <<set $defaultRules[_bci].setAssignment = "get treatment in the clinic">>
+		<<case "arcade">>       <<set $defaultRules[_bci].setAssignment = "be confined in the arcade">>
+		<<case "hgsuite">>      <<set $defaultRules[_bci].setAssignment = "live with your Head Girl">>
+		<<case "brothel">>      <<set $defaultRules[_bci].setAssignment = "work in the brothel">>
+		<<case "cellblock">>    <<set $defaultRules[_bci].setAssignment = "be confined in the cellblock">>
+		<<case "schoolroom">>   <<set $defaultRules[_bci].setAssignment = "learn in the schoolroom">>
+		<<case "mastersuite">>  <<set $defaultRules[_bci].setAssignment = "serve in the master suite">>
+		<<case "servantsquarters">> <<set $defaultRules[_bci].setAssignment = "work as a servant">>
+		<</switch>>
+	<</if>>
+
+	<<set $defaultRules[_bci].facility.replace("spa", "rest in the spa")>>
+	<<set $defaultRules[_bci].facility.replace("club", "serve in the club")>>
+	<<set $defaultRules[_bci].facility.replace("dairy", "work in the dairy")>>
+	<<set $defaultRules[_bci].facility.replace("clinic", "get treatment in the clinic")>>
+	<<set $defaultRules[_bci].facility.replace("arcade", "be confined in the arcade")>>
+	<<set $defaultRules[_bci].facility.replace("hgsuite", "live with your Head Girl")>>
+	<<set $defaultRules[_bci].facility.replace("brothel", "work in the brothel")>>
+	<<set $defaultRules[_bci].facility.replace("cellblock", "be confined in the cellblock")>>
+	<<set $defaultRules[_bci].facility.replace("schoolroom", "learn in the schoolroom")>>
+	<<set $defaultRules[_bci].facility.replace("mastersuite", "serve in the master suite")>>
+	<<set $defaultRules[_bci].facility.replace("servantsquarters", "work as a servant")>>
+
+	<<set $defaultRules[_bci].excludeFacility.replace("spa", "rest in the spa")>>
+	<<set $defaultRules[_bci].excludeFacility.replace("club", "serve in the club")>>
+	<<set $defaultRules[_bci].excludeFacility.replace("dairy", "work in the dairy")>>
+	<<set $defaultRules[_bci].excludeFacility.replace("clinic", "get treatment in the clinic")>>
+	<<set $defaultRules[_bci].excludeFacility.replace("arcade", "be confined in the arcade")>>
+	<<set $defaultRules[_bci].excludeFacility.replace("hgsuite", "live with your Head Girl")>>
+	<<set $defaultRules[_bci].excludeFacility.replace("brothel", "work in the brothel")>>
+	<<set $defaultRules[_bci].excludeFacility.replace("cellblock", "be confined in the cellblock")>>
+	<<set $defaultRules[_bci].excludeFacility.replace("schoolroom", "learn in the schoolroom")>>
+	<<set $defaultRules[_bci].excludeFacility.replace("mastersuite", "serve in the master suite")>>
+	<<set $defaultRules[_bci].excludeFacility.replace("servantsquarters", "work as a servant")>>
+
+	<<if ndef $defaultRules[_bci].aphrodisiacs>>
+		<<set $defaultRules[_bci].aphrodisiacs = 0>>
+	<</if>>
+	<<if $defaultRules[_bci].curatives == "applied">>
+		<<set $defaultRules[_bci].curatives = 2>>
+	<</if>>
+	<<if $defaultRules[_bci].drugs == "curatives">>
+		<<set $defaultRules[_bci].curatives = 2>>
+		<<set $defaultRules[_bci].drugs = "no drugs">>
+	<<elseif $defaultRules[_bci].drugs == "preventatives">>
+		<<set $defaultRules[_bci].curatives = 1>>
+		<<set $defaultRules[_bci].drugs = "no drugs">>
+	<<elseif $defaultRules[_bci].drugs == "aphrodisiacs">>
+		<<set $defaultRules[_bci].aphrodisiacs = 1>>
+		<<set $defaultRules[_bci].drugs = "no drugs">>
+	<<elseif $defaultRules[_bci].drugs == "extreme aphrodisiacs">>
+		<<set $defaultRules[_bci].aphrodisiacs = 2>>
+		<<set $defaultRules[_bci].drugs = "no drugs">>
+	<</if>>
+
+	<<if $defaultRules[_bci].muscles >= 3 && $defaultRules[_bci].muscles <= 6>>
+		<<set $defaultRules[_bci].muscles = 100>>
+	<<elseif $defaultRules[_bci].muscles >= 2 && $defaultRules[_bci].muscles <= 6>>
+		<<set $defaultRules[_bci].muscles = 50>>
+	<<elseif $defaultRules[_bci].muscles >= 1 && $defaultRules[_bci].muscles <= 6>>
+		<<set $defaultRules[_bci].muscles = 20>>
+	<</if>>
 
 	<<if ndef $defaultRules[_bci].standardReward>>
 		<<set $defaultRules[_bci].standardReward = "no default setting">>
@@ -282,27 +349,6 @@
 	<</if>>
 	<<if ndef $defaultRules[_bci].aVirginButtplug>>
 		<<set $defaultRules[_bci].aVirginButtplug = "no default setting">>
-	<</if>>
-	<<if ndef $defaultRules[_bci].surgery>>
-		<<set $defaultRules[_bci].surgery = {lactation: "no default setting", cosmetic: 0, accent: "no default setting", shoulders: "no default setting", shouldersImplant: "no default setting", boobs: "no default setting", hips: "no default setting", hipsImplant: "no default setting", butt: "no default setting", faceShape: "no default setting", lips: "no default setting", holes: 0}>>
-	<</if>>
-	<<if $releaseID < 1018>>
-		<<if $defaultRules[_bci].growth == "none">>
-			<<set $defaultRules[_bci].growth = {boobs: 0, butt: 0, lips: 0, dick: 0, balls: 0}>>
-		<<elseif $defaultRules[_bci].growth == "girlish">>
-			<<set $defaultRules[_bci].growth = {boobs: 350, butt: 2, lips: 25, dick: 0, balls: 0}>>
-		<<elseif $defaultRules[_bci].growth == "stacked">>
-			<<set $defaultRules[_bci].growth = {boobs: 1000, butt: 4, lips: 25, dick: 4, balls: 4}>>
-		<<elseif $defaultRules[_bci].growth == "functional">>
-			<<set $defaultRules[_bci].growth = {boobs: 9000, butt: 10, lips: 45, dick: 6, balls: 6}>>
-		<<elseif $defaultRules[_bci].growth == "unlimited">>
-			<<set $defaultRules[_bci].growth = {boobs: 24000, butt: 10, lips: 100, dick: 10, balls: 6}>>
-		<<else>>
-			<<set $defaultRules[_bci].growth = {boobs: "no default setting", butt: "no default setting", lips: "no default setting", dick: "no default setting", balls: "no default setting"}>>
-		<</if>>
-	<</if>>
-	<<if ndef $defaultRules[_bci].surgery.prostate>>
-		<<set $defaultRules[_bci].surgery.prostate = "no default setting">>
 	<</if>>
 	<<if ndef $defaultRules[_bci].dietMilk>>
 		<<set $defaultRules[_bci].dietMilk = 0>>
@@ -329,6 +375,27 @@
 	<<case "women">>
 		<<set $defaultRules[_bci].clitSetting = "no default setting", $defaultRules[_bci].clitSettingXX = 100>>
 	<</switch>>
+	<<if ndef $defaultRules[_bci].surgery>>
+		<<set $defaultRules[_bci].surgery = {lactation: "no default setting", cosmetic: 0, accent: "no default setting", shoulders: "no default setting", shouldersImplant: "no default setting", boobs: "no default setting", hips: "no default setting", hipsImplant: "no default setting", butt: "no default setting", faceShape: "no default setting", lips: "no default setting", holes: 0}>>
+	<</if>>
+	<<if ndef $defaultRules[_bci].surgery.prostate>>
+		<<set $defaultRules[_bci].surgery.prostate = "no default setting">>
+	<</if>>
+	<<if $releaseID < 1018>>
+		<<if $defaultRules[_bci].growth == "none">>
+			<<set $defaultRules[_bci].growth = {boobs: 0, butt: 0, lips: 0, dick: 0, balls: 0}>>
+		<<elseif $defaultRules[_bci].growth == "girlish">>
+			<<set $defaultRules[_bci].growth = {boobs: 350, butt: 2, lips: 25, dick: 0, balls: 0}>>
+		<<elseif $defaultRules[_bci].growth == "stacked">>
+			<<set $defaultRules[_bci].growth = {boobs: 1000, butt: 4, lips: 25, dick: 4, balls: 4}>>
+		<<elseif $defaultRules[_bci].growth == "functional">>
+			<<set $defaultRules[_bci].growth = {boobs: 9000, butt: 10, lips: 45, dick: 6, balls: 6}>>
+		<<elseif $defaultRules[_bci].growth == "unlimited">>
+			<<set $defaultRules[_bci].growth = {boobs: 24000, butt: 10, lips: 100, dick: 10, balls: 6}>>
+		<<else>>
+			<<set $defaultRules[_bci].growth = {boobs: "no default setting", butt: "no default setting", lips: "no default setting", dick: "no default setting", balls: "no default setting"}>>
+		<</if>>
+	<</if>>
 <</for>>
 
 <<if ndef $month>>
@@ -1305,35 +1372,6 @@ Setting missing global variables:
 		<<set $seeDicks = 25>>
 	<</if>>
 <</if>>
-
-<<for _r = 0; _r < $defaultRules.length; _r++>>
-	<<if ndef $defaultRules[_r].aphrodisiacs>>
-		<<set $defaultRules[_r].aphrodisiacs = 0>>
-	<</if>>
-	<<if $defaultRules[_r].curatives == "applied">>
-		<<set $defaultRules[_r].curatives = 2>>
-	<</if>>
-	<<if $defaultRules[_r].drugs == "curatives">>
-		<<set $defaultRules[_r].curatives = 2>>
-		<<set $defaultRules[_r].drugs = "no drugs">>
-	<<elseif $defaultRules[_r].drugs == "preventatives">>
-		<<set $defaultRules[_r].curatives = 1>>
-		<<set $defaultRules[_r].drugs = "no drugs">>
-	<<elseif $defaultRules[_r].drugs == "aphrodisiacs">>
-		<<set $defaultRules[_r].aphrodisiacs = 1>>
-		<<set $defaultRules[_r].drugs = "no drugs">>
-	<<elseif $defaultRules[_r].drugs == "extreme aphrodisiacs">>
-		<<set $defaultRules[_r].aphrodisiacs = 2>>
-		<<set $defaultRules[_r].drugs = "no drugs">>
-	<</if>>
-	<<if $defaultRules[_r].muscles >= 3 && $defaultRules[_r].muscles <= 6>>
-		<<set $defaultRules[_r].muscles = 100>>
-	<<elseif $defaultRules[_r].muscles >= 2 && $defaultRules[_r].muscles <= 6>>
-		<<set $defaultRules[_r].muscles = 50>>
-	<<elseif $defaultRules[_r].muscles >= 1 && $defaultRules[_r].muscles <= 6>>
-		<<set $defaultRules[_r].muscles = 20>>
-	<</if>>
-<</for>>
 
 <<if !($ver.includes("0.10"))>>
 	<<if $PC.refreshment == "cigar">>

--- a/src/uncategorized/BackwardsCompatibility.tw
+++ b/src/uncategorized/BackwardsCompatibility.tw
@@ -287,29 +287,37 @@
 		<</switch>>
 	<</if>>
 
-	<<set $defaultRules[_bci].facility.replace("spa", "rest in the spa")>>
-	<<set $defaultRules[_bci].facility.replace("club", "serve in the club")>>
-	<<set $defaultRules[_bci].facility.replace("dairy", "work in the dairy")>>
-	<<set $defaultRules[_bci].facility.replace("clinic", "get treatment in the clinic")>>
-	<<set $defaultRules[_bci].facility.replace("arcade", "be confined in the arcade")>>
-	<<set $defaultRules[_bci].facility.replace("hgsuite", "live with your Head Girl")>>
-	<<set $defaultRules[_bci].facility.replace("brothel", "work in the brothel")>>
-	<<set $defaultRules[_bci].facility.replace("cellblock", "be confined in the cellblock")>>
-	<<set $defaultRules[_bci].facility.replace("schoolroom", "learn in the schoolroom")>>
-	<<set $defaultRules[_bci].facility.replace("mastersuite", "serve in the master suite")>>
-	<<set $defaultRules[_bci].facility.replace("servantsquarters", "work as a servant")>>
+	<<set $defaultRules[_bci].facility = $defaultRules[_bci].facility.map(function(x) {
+		switch (x) {
+		case "spa": return "rest in the spa";
+		case "club": return "serve in the club";
+		case "dairy": return "work in the dairy";
+		case "clinic": return "get treatment in the clinic";
+		case "arcade": return "be confined in the arcade";
+		case "hgsuite": return "live with your Head Girl";
+		case "brothel": return "work in the brothel";
+		case "cellblock": return "be confined in the cellblock";
+		case "schoolroom": return "learn in the schoolroom";
+		case "mastersuite": return "serve in the master suite";
+		case "servantsquarters": return "work as a servant";
+		}
+	})>>
 
-	<<set $defaultRules[_bci].excludeFacility.replace("spa", "rest in the spa")>>
-	<<set $defaultRules[_bci].excludeFacility.replace("club", "serve in the club")>>
-	<<set $defaultRules[_bci].excludeFacility.replace("dairy", "work in the dairy")>>
-	<<set $defaultRules[_bci].excludeFacility.replace("clinic", "get treatment in the clinic")>>
-	<<set $defaultRules[_bci].excludeFacility.replace("arcade", "be confined in the arcade")>>
-	<<set $defaultRules[_bci].excludeFacility.replace("hgsuite", "live with your Head Girl")>>
-	<<set $defaultRules[_bci].excludeFacility.replace("brothel", "work in the brothel")>>
-	<<set $defaultRules[_bci].excludeFacility.replace("cellblock", "be confined in the cellblock")>>
-	<<set $defaultRules[_bci].excludeFacility.replace("schoolroom", "learn in the schoolroom")>>
-	<<set $defaultRules[_bci].excludeFacility.replace("mastersuite", "serve in the master suite")>>
-	<<set $defaultRules[_bci].excludeFacility.replace("servantsquarters", "work as a servant")>>
+	<<set $defaultRules[_bci].excludeFacility = $defaultRules[_bci].excludeFacility.map(function(x) {
+		switch (x) {
+		case "spa": return "rest in the spa";
+		case "club": return "serve in the club";
+		case "dairy": return "work in the dairy";
+		case "clinic": return "get treatment in the clinic";
+		case "arcade": return "be confined in the arcade";
+		case "hgsuite": return "live with your Head Girl";
+		case "brothel": return "work in the brothel";
+		case "cellblock": return "be confined in the cellblock";
+		case "schoolroom": return "learn in the schoolroom";
+		case "mastersuite": return "serve in the master suite";
+		case "servantsquarters": return "work as a servant";
+		}
+	})>>
 
 	<<if ndef $defaultRules[_bci].aphrodisiacs>>
 		<<set $defaultRules[_bci].aphrodisiacs = 0>>

--- a/src/uncategorized/rulesAssistant.tw
+++ b/src/uncategorized/rulesAssistant.tw
@@ -165,64 +165,56 @@ __Rule $r Automatic Activation__
 	<<unset _customCondition>>
 	<<set $currentRule.condition = {id: "false"}>>
 	<<RAChangeActivation>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Always">>
 	<<unset _customCondition>>
 	<<set $currentRule.condition = {id: "true"}>>
 	<<RAChangeActivation>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Devotion">>
 	<<unset _customCondition>>
 	<<set $currentRule.condition = changeVariable($currentRule.condition, "devotion")>>
 	<<RAChangeActivation>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Trust">>
 	<<unset _customCondition>>
 	<<set $currentRule.condition = changeVariable($currentRule.condition, "trust")>>
 	<<RAChangeActivation>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Health">>
 	<<unset _customCondition>>
 	<<set $currentRule.condition = changeVariable($currentRule.condition, "health")>>
 	<<RAChangeActivation>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Sex drive">>
 	<<unset _customCondition>>
 	<<set $currentRule.condition = changeVariable($currentRule.condition, "energy")>>
 	<<RAChangeActivation>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Weight">>
 	<<unset _customCondition>>
 	<<set $currentRule.condition = changeVariable($currentRule.condition, "weight")>>
 	<<RAChangeActivation>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Age">>
 	<<unset _customCondition>>
 	<<set $currentRule.condition = changeVariable($currentRule.condition, "age")>>
 	<<RAChangeActivation>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Custom">>
@@ -235,12 +227,10 @@ __Rule $r Automatic Activation__
 		(custom): <br>
 		<<textinput "_customCondition" _customCondition>>
 			<<set _customConditionOld = _customCondition>>
-			<<RAChangeSave>>
-			<<RAChangeApply>>
+			<<RARuleModified>>
 		<</textinput>>
 	<</replace>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <<else>>
@@ -255,8 +245,7 @@ __Rule $r Automatic Activation__
 		//Sir, I'm afraid the condition you have given me is too complex to display in the usual interface.//
 		<<textinput "_customCondition" _customCondition>>
 			<<set _customConditionOld = _customCondition>>
-			<<RAChangeSave>>
-			<<RAChangeApply>>
+			<<RARuleModified>>
 		<</textinput>>
 	<</replace>>
 	<</timed>>
@@ -348,8 +337,7 @@ Clothes:
 <<link "Select her own outfit">>
 	<<set $currentRule.clothes = "choosing her own clothes">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
@@ -357,183 +345,157 @@ Clothes:
 <<link "No default clothes setting">>
 	<<set $currentRule.clothes = "no default setting">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Bangles">>
 	<<set $currentRule.clothes = "slutty jewelry">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Bodysuit">>
 	<<set $currentRule.clothes = "a comfortable bodysuit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Cheerleader outfit">>
 	<<set $currentRule.clothes = "a cheerleader outfit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Clubslut netting">>
 	<<set $currentRule.clothes = "clubslut netting">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Cutoffs and a t-shirt">>
 	<<set $currentRule.clothes = "cutoffs and a t-shirt">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Fallen nun">>
 	<<set $currentRule.clothes = "a fallen nuns habit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Halter top">>
 	<<set $currentRule.clothes = "a halter top dress">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Hijab and abaya">>
 	<<set $currentRule.clothes = "a hijab and abaya">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Latex catsuit">>
 	<<set $currentRule.clothes = "a latex catsuit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Leotard">>
 	<<set $currentRule.clothes = "a leotard">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Maid (nice)">>
 	<<set $currentRule.clothes = "a nice maid outfit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Maid (slutty)">>
 	<<set $currentRule.clothes = "a slutty maid outfit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Military uniform">>
 	<<set $currentRule.clothes = "a military uniform">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Mini dress">>
 	<<set $currentRule.clothes = "a mini dress">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Nice lingerie">>
 	<<set $currentRule.clothes = "attractive lingerie">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Nurse (nice)">>
 	<<set $currentRule.clothes = "a nice nurse outfit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Nurse (slutty)">>
 	<<set $currentRule.clothes = "a slutty nurse outfit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Schoolgirl">>
 	<<set $currentRule.clothes = "a schoolgirl outfit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Silken ballgown">>
 	<<set $currentRule.clothes = "a ball gown">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Skimpy battledress">>
 	<<set $currentRule.clothes = "battledress">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Slave gown">>
 	<<set $currentRule.clothes = "a slave gown">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "String bikini">>
 	<<set $currentRule.clothes = "a string bikini">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Succubus costume">>
 	<<set $currentRule.clothes = "a succubus outfit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Suit (nice)">>
 	<<set $currentRule.clothes = "nice business attire">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Suit (slutty)">>
 	<<set $currentRule.clothes = "slutty business attire">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<if ($arcologies[0].FSPhysicalIdealist != "unset") || ($cheatMode == 1) || ($clothesBoughtOil == 1)>>
@@ -541,8 +503,7 @@ Clothes:
 <<link "Body oil">>
 	<<set $currentRule.clothes = "body oil">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>> |
 <</if>>
 <<if ($arcologies[0].FSGenderFundamentalist != "unset") || ($cheatMode == 1) || ($clothesBoughtBunny == 1)>>
@@ -550,8 +511,7 @@ Clothes:
 <<link "Bunny outfit">>
 	<<set $currentRule.clothes = "a bunny outfit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>> |
 <</if>>
 <<if ($arcologies[0].FSDegradationist != "unset") || ($cheatMode == 1) || ($clothesBoughtChains == 1)>>
@@ -559,8 +519,7 @@ Clothes:
 <<link "Chains">>
 	<<set $currentRule.clothes = "chains">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>> |
 <</if>>
 <<if ($arcologies[0].FSChattelReligionist != "unset") || ($cheatMode == 1) || ($clothesBoughtHabit == 1)>>
@@ -568,8 +527,7 @@ Clothes:
 <<link "Chattel habit">>
 	<<set $currentRule.clothes = "a chattel habit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>> |
 <</if>>
 <<if ($arcologies[0].FSPaternalist != "unset") || ($cheatMode == 1) || ($clothesBoughtConservative == 1)>>
@@ -577,8 +535,7 @@ Clothes:
 <<link "Conservative clothing">>
 	<<set $currentRule.clothes = "conservative clothing">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>> |
 <</if>>
 <<if ($arcologies[0].FSArabianRevivalist != "unset") || ($cheatMode == 1) || ($clothesBoughtHarem == 1)>>
@@ -586,8 +543,7 @@ Clothes:
 <<link "Harem gauze">>
 	<<set $currentRule.clothes = "harem gauze">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>> |
 <</if>>
 <<if ($arcologies[0].FSAztecRevivalist != "unset") || ($cheatMode == 1) || ($clothesBoughtHuipil == 1)>>
@@ -595,8 +551,7 @@ Clothes:
 <<link "Huipil">>
 	<<set $currentRule.clothes = "a huipil", $currentRule.choosesOwnClothes = 0>>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>> |
 <</if>>
 <<if ($arcologies[0].FSEdoRevivalist != "unset") || ($cheatMode == 1) || ($clothesBoughtKimono == 1)>>
@@ -604,8 +559,7 @@ Clothes:
 <<link "Kimono">>
 	<<set $currentRule.clothes = "a kimono">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>> |
 <</if>>
 <<if ($arcologies[0].FSChineseRevivalist != "unset") || ($cheatMode == 1) || ($clothesBoughtQipao == 1)>>
@@ -613,8 +567,7 @@ Clothes:
 <<link "Slutty qipao">>
 	<<set $currentRule.clothes = "a slutty qipao">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>> |
 <</if>>
 <<if ($arcologies[0].FSRomanRevivalist != "unset") || ($cheatMode == 1) || ($clothesBoughtToga == 1)>>
@@ -622,8 +575,7 @@ Clothes:
 <<link "Toga">>
 	<<set $currentRule.clothes = "a toga">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>> |
 <</if>>
 <<if ($arcologies[0].FSPastoralist != "unset") || ($cheatMode == 1) || ($clothesBoughtWestern == 1)>>
@@ -631,8 +583,7 @@ Clothes:
 <<link "Western clothing">>
 	<<set $currentRule.clothes = "Western clothing">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 <</if>>
 
@@ -641,36 +592,31 @@ Clothes:
 <<link "Nude">>
 	<<set $currentRule.clothes = "no clothing">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Penitent nun">>
 	<<set $currentRule.clothes = "a penitent nuns habit">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Restrictive latex">>
 	<<set $currentRule.clothes = "restrictive latex">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Shibari ropes">>
 	<<set $currentRule.clothes = "shibari ropes">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Uncomfortable straps">>
 	<<set $currentRule.clothes = "uncomfortable straps">>
 	<<RAChangeClothes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 
@@ -681,15 +627,13 @@ Collar: ''$currentRule.collar.''
 <<link "No default collar setting">>
 	<<set $currentRule.collar = "no default setting">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "No collar">>
 	<<set $currentRule.collar = "none">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
@@ -697,15 +641,13 @@ Collar: ''$currentRule.collar.''
 <<link "Stylish leather">>
 	<<set $currentRule.collar = "stylish leather">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Satin choker">>
 	<<set $currentRule.collar = "satin choker">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Heavy Gold">>
@@ -716,32 +658,28 @@ Collar: ''$currentRule.collar.''
 <<link "Pretty jewelry">>
 	<<set $currentRule.collar = "pretty jewelry">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<if $seeAge != 0>>
 <<link "Nice retirement counter">>
 	<<set $currentRule.collar = "nice retirement counter">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <</if>>
 <<link "Cowbell">>
 	<<set $currentRule.collar = "leather with cowbell">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 <<if ($arcologies[0].FSGenderFundamentalist != "unset") || ($cheatMode == 1) || ($clothesBoughtBunny == 1)>>
    | //FS//
 <<link "Bowtie collar">>
 	<<set $currentRule.collar = "bowtie">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 <</if>>
 <<if ($arcologies[0].FSEgyptianRevivalist != "unset") || ($cheatMode == 1) || ($clothesBoughtEgypt == 1)>>
@@ -749,8 +687,7 @@ Collar: ''$currentRule.collar.''
 <<link "Ancient Egyptian">>
 	<<set $currentRule.collar = "ancient Egyptian">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 <</if>>
 
@@ -759,59 +696,51 @@ Collar: ''$currentRule.collar.''
 <<link "Tight steel">>
 	<<set $currentRule.collar = "tight steel">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<if $seeAge != 0>>
 <<link "Cruel retirement counter">>
 	<<set $currentRule.collar = "cruel retirement counter">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <</if>>
 <<link "Uncomfortable leather">>
 	<<set $currentRule.collar = "uncomfortable leather">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Shock punishment">>
 	<<set $currentRule.collar = "shock punishment">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Dildo gag">>
 	<<set $currentRule.collar = "dildo gag">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Ball gag">>
 	<<set $currentRule.collar = "ball gag">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Bit gag">>
 	<<set $currentRule.collar = "bit gag">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Neck corset">>
 	<<set $currentRule.collar = "neck corset">>
 	<<RAChangeCollar>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 
@@ -822,43 +751,37 @@ Shoes: ''$currentRule.shoes.''
 <<link "No default footwear setting">>
 	<<set $currentRule.shoes = "no default setting">>
 	<<RAChangeShoes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Barefoot">>
 	<<set $currentRule.shoes = "none">>
 	<<RAChangeShoes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Flats">>
 	<<set $currentRule.shoes = "flats">>
 	<<RAChangeShoes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Heels">>
 	<<set $currentRule.shoes = "heels">>
 	<<RAChangeShoes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Thigh boots">>
 	<<set $currentRule.shoes = "boots">>
 	<<RAChangeShoes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Painfully extreme heels">>
 	<<set $currentRule.shoes = "extreme heels">>
 	<<RAChangeShoes>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -868,29 +791,25 @@ Torso accessory: ''$currentRule.bellyAccessory.''
 <<link "No default setting">>
 	<<set $currentRule.bellyAccessory = "no default setting">>
 	<<RAChangeBelly>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.bellyAccessory = "none">>
 	<<RAChangeBelly>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Tight corset">>
 	<<set $currentRule.bellyAccessory = "a corset">>
 	<<RAChangeBelly>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Extreme corset">>
 	<<set $currentRule.bellyAccessory = "an extreme corset">>
 	<<RAChangeBelly>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -902,58 +821,50 @@ Vaginal accessories for virgins: ''$currentRule.virginAccessory.''
 <<link "No default setting">>
 	<<set $currentRule.virginAccessory = "no default setting">>
 	<<RAChangeVAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.virginAccessory = "none">>
 	<<RAChangeVAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Dildo">>
 	<<set $currentRule.virginAccessory = "dildo">>
 	<<RAChangeVAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Large dildo">>
 	<<set $currentRule.virginAccessory = "large dildo">>
 	<<RAChangeVAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Huge dildo">>
 	<<set $currentRule.virginAccessory = "huge dildo">>
 	<<RAChangeVAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 //Will permanently gape pussies//
 |
 <<link "Chastity belt">>
 	<<set $currentRule.virginAccessory = "chastity belt">>
 	<<RAChangeVAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Anal chastity belt">>
 	<<set $currentRule.virginAccessory = "anal chastity">>
 	<<RAChangeVAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Combined chastity belt">>
 	<<set $currentRule.virginAccessory = "combined chastity">>
 	<<RAChangeVAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -965,58 +876,50 @@ Vaginal accessories for anal virgins: ''$currentRule.aVirginAccessory.''
 <<link "No default setting">>
 	<<set $currentRule.aVirginAccessory = "no default setting">>
 	<<RAChangeVAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.aVirginAccessory = "none">>
 	<<RAChangeVAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Dildo">>
 	<<set $currentRule.aVirginAccessory = "dildo">>
 	<<RAChangeVAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Large dildo">>
 	<<set $currentRule.aVirginAccessory = "large dildo">>
 	<<RAChangeVAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Huge dildo">>
 	<<set $currentRule.aVirginAccessory = "huge dildo">>
 	<<RAChangeVAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 //Will permanently gape pussies//
 |
 <<link "Chastity belt">>
 	<<set $currentRule.aVirginAccessory = "chastity belt">>
 	<<RAChangeVAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Anal chastity belt">>
 	<<set $currentRule.aVirginAccessory = "anal chastity">>
 	<<RAChangeVAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Combined chastity belt">>
 	<<set $currentRule.aVirginAccessory = "combined chastity">>
 	<<RAChangeVAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1028,58 +931,50 @@ Vaginal accessories for other slaves: ''$currentRule.vaginalAccessory.''
 <<link "No default setting">>
 	<<set $currentRule.vaginalAccessory = "no default setting">>
 	<<RAChangeVAccessory 2>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.vaginalAccessory = "none">>
 	<<RAChangeVAccessory 2>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Dildo">>
 	<<set $currentRule.vaginalAccessory = "dildo">>
 	<<RAChangeVAccessory 2>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Large dildo">>
 	<<set $currentRule.vaginalAccessory = "large dildo">>
 	<<RAChangeVAccessory 2>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Huge dildo">>
 	<<set $currentRule.vaginalAccessory = "huge dildo">>
 	<<RAChangeVAccessory 2>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 //Will permanently gape pussies//
 |
 <<link "Chastity belt">>
 	<<set $currentRule.vaginalAccessory = "chastity belt">>
 	<<RAChangeVAccessory 2>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Anal chastity belt">>
 	<<set $currentRule.vaginalAccessory = "anal chastity">>
 	<<RAChangeVAccessory 2>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Combined chastity belt">>
 	<<set $currentRule.vaginalAccessory = "combined chastity">>
 	<<RAChangeVAccessory 2>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <<if $seeDicks != 0>>
@@ -1090,36 +985,31 @@ Dick accessories for anal virgins: ''$currentRule.aVirginDickAccessory.''
 <<link "No default setting">>
 	<<set $currentRule.aVirginDickAccessory = "no default setting">>
 	<<RAChangeDAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.aVirginDickAccessory = "none">>
 	<<RAChangeDAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Chastity cage">>
 	<<set $currentRule.aVirginDickAccessory = "chastity">>
 	<<RAChangeDAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Anal chastity belt">>
 	<<set $currentRule.aVirginDickAccessory = "anal chastity">>
 	<<RAChangeDAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Combined chastity belt">>
 	<<set $currentRule.aVirginDickAccessory = "combined chastity">>
 	<<RAChangeDAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1130,36 +1020,31 @@ Dick accessories for other slaves: ''$currentRule.dickAccessory.''
 <<link "No default setting">>
 	<<set $currentRule.dickAccessory = "no default setting">>
 	<<RAChangeDAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.dickAccessory = "none">>
 	<<RAChangeDAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Chastity cage">>
 	<<set $currentRule.dickAccessory = "chastity">>
 	<<RAChangeDAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Anal chastity belt">>
 	<<set $currentRule.dickAccessory = "anal chastity">>
 	<<RAChangeDAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Combined chastity belt">>
 	<<set $currentRule.dickAccessory = "combined chastity">>
 	<<RAChangeDAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 <</if>>
 
@@ -1172,58 +1057,50 @@ Buttplugs for anal virgins: ''$currentRule.aVirginButtplug.''
 <<link "No default setting">>
 	<<set $currentRule.aVirginButtplug = "no default setting">>
 	<<RAChangeBAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.aVirginButtplug = "none">>
 	<<RAChangeBAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Standard plug">>
 	<<set $currentRule.aVirginButtplug = "plug">>
 	<<RAChangeBAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Large plug">>
 	<<set $currentRule.aVirginButtplug = "large plug">>
 	<<RAChangeBAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Huge plug">>
 	<<set $currentRule.aVirginButtplug = "huge plug">>
 	<<RAChangeBAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 //Will permanently gape assholes//
 |
 <<link "Standard tailed plug">>
 	<<set $currentRule.aVirginButtplug = "tailed plug">>
 	<<RAChangeBAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Large tailed plug">>
 	<<set $currentRule.aVirginButtplug = "large tailed plug">>
 	<<RAChangeBAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Huge tailed plug">>
 	<<set $currentRule.aVirginButtplug = "huge tailed plug">>
 	<<RAChangeBAccessory 0>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 //Will permanently gape assholes//
 
@@ -1236,36 +1113,31 @@ Buttplugs for other slaves: ''$currentRule.buttplug.''
 <<link "No default setting">>
 	<<set $currentRule.buttplug = "no default setting">>
 	<<RAChangeBAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.buttplug = "none">>
 	<<RAChangeBAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Standard plug">>
 	<<set $currentRule.buttplug = "plug">>
 	<<RAChangeBAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Large plug">>
 	<<set $currentRule.buttplug = "large plug">>
 	<<RAChangeBAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Huge plug">>
 	<<set $currentRule.buttplug = "huge plug">>
 	<<RAChangeBAccessory 1>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 //Will permanently gape assholes//
 |
@@ -1355,29 +1227,25 @@ Health drugs:
 <<link "No default setting">>
 	<<set $currentRule.curatives = "no default setting">>
 	<<RAChangeCuratives>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.curatives = 0>>
 	<<RAChangeCuratives>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Preventatives">>
 	<<set $currentRule.curatives = 1>>
 	<<RAChangeCuratives>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Curatives">>
 	<<set $currentRule.curatives = 2>>
 	<<RAChangeCuratives>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1401,29 +1269,25 @@ Aphrodisiacs:
 <<link "No default setting">>
 	<<set $currentRule.aphrodisiacs = "no default setting">>
 	<<RAChangeAphrodisiacs>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.aphrodisiacs = 0>>
 	<<RAChangeAphrodisiacs>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Standard">>
 	<<set $currentRule.aphrodisiacs = 1>>
 	<<RAChangeAphrodisiacs>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Extreme">>
 	<<set $currentRule.aphrodisiacs = 2>>
 	<<RAChangeAphrodisiacs>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1447,36 +1311,31 @@ Contraceptives for fertile slaves:
 <<link "No default setting">>
 	<<set $currentRule.preg = "no default setting">>
 	<<RAChangePreg>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Fertile">>
 	<<set $currentRule.preg = 0>>
 	<<RAChangePreg>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Very fertile">>
 	<<set $currentRule.preg = 1>>
 	<<RAChangePreg>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Extremely fertile">>
 	<<set $currentRule.preg = 2>>
 	<<RAChangePreg>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Contraceptives">>
 	<<set $currentRule.preg = -1>>
 	<<RAChangePreg>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1502,43 +1361,37 @@ Hormones for female slaves:
 <<link "No default setting">>
 	<<set $currentRule.XX = "no default setting">>
 	<<RAChangeXXHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Intensive Female">>
 	<<set $currentRule.XX = 2>>
 	<<RAChangeXXHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Female">>
 	<<set $currentRule.XX = 1>>
 	<<RAChangeXXHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.XX = 0>>
 	<<RAChangeXXHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Male">>
 	<<set $currentRule.XX = -1>>
 	<<RAChangeXXHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Intensive Male">>
 	<<set $currentRule.XX = -2>>
 	<<RAChangeXXHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1564,43 +1417,37 @@ Hormones for shemales:
 <<link "No default setting">>
 	<<set $currentRule.XY = "no default setting">>
 	<<RAChangeXYHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Intensive Female">>
 	<<set $currentRule.XY = 2>>
 	<<RAChangeXYHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Female">>
 	<<set $currentRule.XY = 1>>
 	<<RAChangeXYHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.XY = 0>>
 	<<RAChangeXYHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Male">>
 	<<set $currentRule.XY = -1>>
 	<<RAChangeXYHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Intensive Male">>
 	<<set $currentRule.XY = -2>>
 	<<RAChangeXYHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1626,43 +1473,37 @@ Hormones for geldings:
 <<link "No default setting">>
 	<<set $currentRule.gelding = "no default setting">>
 	<<RAChangeGeldHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Intensive Female">>
 	<<set $currentRule.gelding = 2>>
 	<<RAChangeGeldHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Female">>
 	<<set $currentRule.gelding = 1>>
 	<<RAChangeGeldHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.gelding = 0>>
 	<<RAChangeGeldHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Male">>
 	<<set $currentRule.gelding = -1>>
 	<<RAChangeGeldHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Intensive Male">>
 	<<set $currentRule.gelding = -2>>
 	<<RAChangeGeldHormones>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1686,36 +1527,31 @@ Slave diets:
 <<link "No default diet setting">>
 	<<set $currentRule.diet = "no default setting">>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Fix fat and skinny slaves">>
 	<<set $currentRule.diet = "attractive">>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Curvy">>
 	<<set $currentRule.diet = 30>>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Average">>
 	<<set $currentRule.diet = 0>>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Thin">>
 	<<set $currentRule.diet = -30>>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <span id = "dietsupport">
@@ -1732,15 +1568,13 @@ Diet support for growth drugs:
 <<link "On">>
 	<<set $currentRule.dietGrowthSupport = 1>>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Off">>
 	<<set $currentRule.dietGrowthSupport = 0>>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 <</if>>
 </span>
@@ -1770,56 +1604,49 @@ Diet base:
 <<link "no default setting">>
 	<<set $currentRule.dietCum = "no default setting">>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Normal Diet">>
 	<<set $currentRule.dietCum = 0>>
 	<<set $currentRule.dietMilk = 0>>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Cum Added">>
 	<<set $currentRule.dietCum = 1>>
 	<<set $currentRule.dietMilk = 0>>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Milk Added">>
 	<<set $currentRule.dietCum = 0>>
 	<<set $currentRule.dietMilk = 1>>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Cum & Milk Added">>
 	<<set $currentRule.dietCum = 1>>
 	<<set $currentRule.dietMilk = 1>>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Cum-Based">>
 	<<set $currentRule.dietCum = 2>>
 	<<set $currentRule.dietMilk = 0>>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Milk Based">>
 	<<set $currentRule.dietCum = 0>>
 	<<set $currentRule.dietMilk = 2>>
 	<<RAChangeDiet>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1843,36 +1670,31 @@ Muscles:
 <<link "No default diet setting">>
 	<<set $currentRule.muscles = "no default setting">>
 	<<RAChangeMuscles>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.muscles = 0>>
 	<<RAChangeMuscles>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Toned">>
 	<<set $currentRule.muscles = 20>>
 	<<RAChangeMuscles>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Ripped">>
 	<<set $currentRule.muscles = 50>>
 	<<RAChangeMuscles>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Massive">>
 	<<set $currentRule.muscles = 100>>
 	<<RAChangeMuscles>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1894,29 +1716,25 @@ Braces:
 <<link "No default braces setting">>
 	<<set $currentRule.teeth = "no default setting">>
 	<<RAChangeBraces>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.teeth = "none">>
 	<<RAChangeBraces>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Straighten">>
 	<<set $currentRule.teeth = "straighten">>
 	<<RAChangeBraces>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Universal">>
 	<<set $currentRule.teeth = "universal">>
 	<<RAChangeBraces>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1929,16 +1747,14 @@ Assistant-applied implants:
 	<<link "Off">>
 		<<set $currentRule.autoSurgery = 0>>
 		<<RAChangeAssistantImplants>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''off.''
 	<<link "Activate">>
 		<<set $currentRule.autoSurgery = 1>>
 		<<RAChangeAssistantImplants>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 </span>
@@ -1955,29 +1771,25 @@ Living standard: ''$currentRule.livingRules.''
 <<link "No default setting">>
 	<<set $currentRule.livingRules = "no default setting">>
 	<<RAChangeLiving>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Luxurious">>
 	<<set $currentRule.livingRules = "luxurious">>
 	<<RAChangeLiving>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Normal">>
 	<<set $currentRule.livingRules = "normal">>
 	<<RAChangeLiving>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Spare">>
 	<<set $currentRule.livingRules = "spare">>
 	<<RAChangeLiving>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -1993,36 +1805,31 @@ Typical punishment: ''$currentRule.standardPunishment.''
 <<link "No default setting">>
 	<<set $currentRule.standardPunishment = "no default setting">>
 	<<RAChangePunish>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Confinement">>
 	<<set $currentRule.standardPunishment = "confinement">>
 	<<RAChangePunish>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Whipping">>
 	<<set $currentRule.standardPunishment = "whipping">>
 	<<RAChangePunish>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Chastity">>
 	<<set $currentRule.standardPunishment = "chastity">>
 	<<RAChangePunish>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Situational">>
 	<<set $currentRule.standardPunishment = "situational">>
 	<<RAChangePunish>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -2038,36 +1845,31 @@ Typical reward: ''$currentRule.standardReward.''
 <<link "No default setting">>
 	<<set $currentRule.standardReward = "no default setting">>
 	<<RAChangeReward>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Relaxation">>
 	<<set $currentRule.standardReward = "relaxation">>
 	<<RAChangeReward>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Drugs">>
 	<<set $currentRule.standardReward = "drugs">>
 	<<RAChangeReward>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Orgasm">>
 	<<set $currentRule.standardReward = "orgasm">>
 	<<RAChangeReward>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Situational">>
 	<<set $currentRule.standardReward = "situational">>
 	<<RAChangeReward>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -2079,29 +1881,25 @@ Release rules: ''$currentRule.releaseRules.''
 <<link "No default setting">>
 	<<set $currentRule.releaseRules = "no default setting">>
 	<<RAChangeMast>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Permissive">>
 	<<set $currentRule.releaseRules = "permissive">>
 	<<RAChangeMast>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Sapphic">>
 	<<set $currentRule.releaseRules = "sapphic">>
 	<<RAChangeMast>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Restrictive">>
 	<<set $currentRule.releaseRules = "restrictive">>
 	<<RAChangeMast>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -2112,78 +1910,67 @@ Smart piercing fetish target: <span id = "spf">''$currentRule.clitSetting.''</sp
 <<link "No default setting">>
 	<<set $currentRule.clitSetting = "no default setting">>
 	<<RAChangeSPF>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Vanilla">>
     <<set $currentRule.clitSetting = "vanilla">>
     <<RAChangeSPF>>
-	<<RAChangeSave>>
-    <<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Oral">>
     <<set $currentRule.clitSetting = "oral">>
     <<RAChangeSPF>>
-	<<RAChangeSave>>
-    <<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Anal">>
     <<set $currentRule.clitSetting = "anal">>
     <<RAChangeSPF>>
-	<<RAChangeSave>>
-    <<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Boobs">>
     <<set $currentRule.clitSetting = "boobs">>
     <<RAChangeSPF>>
-	<<RAChangeSave>>
-    <<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Sub">>
     <<set $currentRule.clitSetting = "submissive">>
     <<RAChangeSPF>>
-	<<RAChangeSave>>
-    <<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Dom">>
     <<set $currentRule.clitSetting = "dom">>
     <<RAChangeSPF>>
-	<<RAChangeSave>>
-    <<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Humiliation">>
     <<set $currentRule.clitSetting = "humiliation">>
     <<RAChangeSPF>>
-	<<RAChangeSave>>
-    <<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Preg">>
     <<set $currentRule.clitSetting = "pregnancy">>
     <<RAChangeSPF>>
-	<<RAChangeSave>>
-    <<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Pain">>
     <<set $currentRule.clitSetting = "masochist">>
     <<RAChangeSPF>>
-	<<RAChangeSave>>
-    <<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Sadism">>
     <<set $currentRule.clitSetting = "sadist">>
     <<RAChangeSPF>>
-	<<RAChangeSave>>
-    <<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -2194,36 +1981,31 @@ Smart piercing XY attraction target: <span id = "spxy"><<RAInitSPXY>></span>
 <<link "No default setting">>
 	<<set $currentRule.clitSettingXY = "no default setting">>
 	<<RAChangeSPXY>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Passionate">>
 	<<set $currentRule.clitSettingXY = 100>>
 	<<RAChangeSPXY>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Attracted">>
 	<<set $currentRule.clitSettingXY = 75>>
 	<<RAChangeSPXY>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Indifferent">>
 	<<set $currentRule.clitSettingXY = 45>>
 	<<RAChangeSPXY>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.clitSettingXY = 0>>
 	<<RAChangeSPXY>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -2234,36 +2016,31 @@ Smart piercing XX attraction target: <span id = "spxx"><<RAInitSPXX>></span>
 <<link "No default setting">>
 	<<set $currentRule.clitSettingXX = "no default setting">>
 	<<RAChangeSPXX>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Passionate">>
 	<<set $currentRule.clitSettingXX = 100>>
 	<<RAChangeSPXX>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Attracted">>
 	<<set $currentRule.clitSettingXX = 75>>
 	<<RAChangeSPXX>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Indifferent">>
 	<<set $currentRule.clitSettingXX = 45>>
 	<<RAChangeSPXX>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "None">>
 	<<set $currentRule.clitSettingXX = 0>>
 	<<RAChangeSPXX>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -2274,50 +2051,43 @@ Smart piercing sex drive target: <span id = "spe"><<RAInitSPE>></span>
 <<link "No default setting">>
 	<<set $currentRule.clitSettingEnergy = "no default setting">>
 	<<RAChangeSPE>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Nympho">>
 	<<set $currentRule.clitSettingEnergy = 100>>
 	<<RAChangeSPE>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Sex Addict">>
 	<<set $currentRule.clitSettingEnergy = 85>>
 	<<RAChangeSPE>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Powerful">>
 	<<set $currentRule.clitSettingEnergy = 65>>
 	<<RAChangeSPE>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Healthy">>
 	<<set $currentRule.clitSettingEnergy = 45>>
 	<<RAChangeSPE>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Weak">>
 	<<set $currentRule.clitSettingEnergy = 25>>
 	<<RAChangeSPE>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Frigid">>
 	<<set $currentRule.clitSettingEnergy = 0>>
 	<<RAChangeSPE>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -2329,29 +2099,25 @@ Speech rules: ''$currentRule.speechRules.''
 <<link "No default setting">>
 	<<set $currentRule.speechRules = "no default setting">>
 	<<RAChangeSpeech>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Permissive">>
 	<<set $currentRule.speechRules = "permissive">>
 	<<RAChangeSpeech>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Suppress accents">>
 	<<set $currentRule.speechRules = "accent elimination">>
 	<<RAChangeSpeech>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Restrictive">>
 	<<set $currentRule.speechRules = "restrictive">>
 	<<RAChangeSpeech>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <br>
@@ -2363,29 +2129,25 @@ Relationship rules: ''$currentRule.relationshipRules.''
 <<link "No default setting">>
 	<<set $currentRule.relationshipRules = "no default setting">>
 	<<RAChangeRelationship>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Permissive">>
 	<<set $currentRule.relationshipRules = "permissive">>
 	<<RAChangeRelationship>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Just friends">>
 	<<set $currentRule.relationshipRules = "just friends">>
 	<<RAChangeRelationship>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "Restrictive">>
 	<<set $currentRule.relationshipRules = "restrictive">>
 	<<RAChangeRelationship>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <<if $studio == 1>>
@@ -2396,8 +2158,7 @@ Relationship rules: ''$currentRule.relationshipRules.''
 <<link "Enable">>
 	<<set $currentRule.pornFameSpending = 0>>
 	<<RAChangeFameSpending>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 <<else>>
   Weekly porn publicity subsidy: ''¤$currentRule.pornFameSpending.''
@@ -2407,57 +2168,49 @@ Relationship rules: ''$currentRule.relationshipRules.''
 <<link "No default setting">>
 	<<set $currentRule.pornFameSpending = "no default setting">>
 	<<RAChangeFameSpending>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "No subsidy">>
 	<<set $currentRule.pornFameSpending = 0>>
 	<<RAChangeFameSpending>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "1000">>
 	<<set $currentRule.pornFameSpending = 1000>>
 	<<RAChangeFameSpending>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "2000">>
 	<<set $currentRule.pornFameSpending = 2000>>
 	<<RAChangeFameSpending>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "3000">>
 	<<set $currentRule.pornFameSpending = 3000>>
 	<<RAChangeFameSpending>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "4000">>
 	<<set $currentRule.pornFameSpending = 4000>>
 	<<RAChangeFameSpending>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "5000">>
 	<<set $currentRule.pornFameSpending = 5000>>
 	<<RAChangeFameSpending>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 |
 <<link "No broadcasting">>
 	<<set $currentRule.pornFameSpending = -1>>
 	<<RAChangeFameSpending>>
-	<<RAChangeSave>>
-	<<RAChangeApply>>
+	<<RARuleModified>>
 <</link>>
 
 <</if>>

--- a/src/utility/raWidgets.tw
+++ b/src/utility/raWidgets.tw
@@ -135,11 +135,42 @@
 <</widget>>
 
 /%
+ % Call as <<RACommonAssignmentVariables>>
+ %/
+<<widget "RACommonAssignmentVariables">>
+	<<set _assignments = [
+		"rest",
+		"whore",
+		"please you",
+		"get milked",
+		"be a servant",
+		"take classes",
+		"stay confined",
+		"serve the public",
+		"work a glory hore",
+		"be a subordinate slave",
+	]>>
+
+	<<set _facilityAssignments = [
+		"rest in the spa",
+		"serve in the club",
+		"work as a servant",
+		"work in the dairy",
+		"work in the brothel",
+		"learn in the schoolroom",
+		"live with your Head Girl",
+		"be confined in the arcade",
+		"serve in the master suite",
+		"get treatment in the clinic",
+		"be confined in the cellblock",
+	]>>
+<</widget>>
+
+/%
  % Call as <<RANormalizeAssignments>>
  %/
 <<widget "RANormalizeAssignments">>
-<<set _assignments = ["rest", "please you", "be a servant", "stay confined", "whore", "serve the public", "get milked", "be a subordinate slave", "work a glory hore", "take classes"]>>
-<<set _facilityAssignments = ["hgsuite", "brothel", "club", "arcade", "dairy", "servantsquarters", "mastersuite", "schoolroom", "spa", "clinic", "cellblock"]>>
+<<RACommonAssignmentVariables>>
 
 <<switch $args[0]>>
 <<case "assignment">>
@@ -598,165 +629,165 @@
 <</if>>
 <<if ($HGSuite > 0)>>
 |
-<<if !ruleFacility($currentRule.facility,"hgsuite")>>
+<<if !$currentRule.facility.includes("live with your Head Girl")>>
 	<<link $HGSuiteNameCaps>>
-		<<set $currentRule.facility.push("hgsuite")>>
+		<<set $currentRule.facility.push("live with your Head Girl")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$HGSuiteNameCaps''
 	<<link Stop>>
-		<<set $currentRule.facility.delete("hgsuite")>>
+		<<set $currentRule.facility.delete("live with your Head Girl")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($brothel > 0)>>
 |
-<<if !ruleFacility($currentRule.facility,"brothel")>>
+<<if !$currentRule.facility.includes("work in the brothel")>>
 	<<link $brothelNameCaps>>
-		<<set $currentRule.facility.push("brothel")>>
+		<<set $currentRule.facility.push("work in the brothel")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$brothelNameCaps''
 	<<link Stop>>
-		<<set $currentRule.facility.delete("brothel")>>
+		<<set $currentRule.facility.delete("work in the brothel")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($club > 0)>>
 |
-<<if !ruleFacility($currentRule.facility,"club")>>
+<<if !$currentRule.facility.includes("serve in the club")>>
 	<<link $clubNameCaps>>
-		<<set $currentRule.facility.push("club")>>
+		<<set $currentRule.facility.push("serve in the club")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$clubNameCaps''
 	<<link Stop>>
-		<<set $currentRule.facility.delete("club")>>
+		<<set $currentRule.facility.delete("serve in the club")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($arcade > 0)>>
 |
-<<if !ruleFacility($currentRule.facility,"arcade")>>
+<<if !$currentRule.facility.includes("be confined in the arcade")>>
 	<<link $arcadeNameCaps>>
-		<<set $currentRule.facility.push("arcade")>>
+		<<set $currentRule.facility.push("be confined in the arcade")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$arcadeNameCaps''
 	<<link Stop>>
-		<<set $currentRule.facility.delete("arcade")>>
+		<<set $currentRule.facility.delete("be confined in the arcade")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($dairy > 0)>>
 |
-<<if !ruleFacility($currentRule.facility,"dairy")>>
+<<if !$currentRule.facility.includes("work in the dairy")>>
 	<<link $dairyNameCaps>>
-		<<set $currentRule.facility.push("dairy")>>
+		<<set $currentRule.facility.push("work in the dairy")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$dairyNameCaps''
 	<<link Stop>>
-		<<set $currentRule.facility.delete("dairy")>>
+		<<set $currentRule.facility.delete("work in the dairy")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($servantsQuarters > 0)>>
 |
-<<if !ruleFacility($currentRule.facility,"servantsquarters")>>
+<<if !$currentRule.facility.includes("work as a servant")>>
 	<<link $servantsQuartersNameCaps>>
-		<<set $currentRule.facility.push("servantsquarters")>>
+		<<set $currentRule.facility.push("work as a servant")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$servantsQuartersNameCaps''
 	<<link Stop>>
-		<<set $currentRule.facility.delete("servantsquarters")>>
+		<<set $currentRule.facility.delete("work as a servant")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($masterSuite > 0)>>
 |
-<<if !ruleFacility($currentRule.facility,"mastersuite")>>
+<<if !$currentRule.facility.includes("serve in the master suite")>>
 	<<link $masterSuiteNameCaps>>
-		<<set $currentRule.facility.push("mastersuite")>>
+		<<set $currentRule.facility.push("serve in the master suite")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$masterSuiteNameCaps''
 	<<link Stop>>
-		<<set $currentRule.facility.delete("mastersuite")>>
+		<<set $currentRule.facility.delete("serve in the master suite")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($schoolroom > 0)>>
 |
-<<if !ruleFacility($currentRule.facility,"schoolroom")>>
+<<if !$currentRule.facility.includes("learn in the schoolroom")>>
 	<<link $schoolroomNameCaps>>
-		<<set $currentRule.facility.push("schoolroom")>>
+		<<set $currentRule.facility.push("learn in the schoolroom")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$schoolroomNameCaps''
 	<<link Stop>>
-		<<set $currentRule.facility.delete("schoolroom")>>
+		<<set $currentRule.facility.delete("learn in the schoolroom")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($spa > 0)>>
 |
-<<if !ruleFacility($currentRule.facility,"spa")>>
+<<if !$currentRule.facility.includes("rest in the spa")>>
 	<<link $spaNameCaps>>
-		<<set $currentRule.facility.push("spa")>>
+		<<set $currentRule.facility.push("rest in the spa")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$spaNameCaps''
 	<<link Stop>>
-		<<set $currentRule.facility.delete("spa")>>
+		<<set $currentRule.facility.delete("rest in the spa")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($clinic > 0)>>
 |
-<<if !ruleFacility($currentRule.facility,"clinic")>>
+<<if !$currentRule.facility.includes("get treatment in the clinic")>>
 	<<link $clinicNameCaps>>
-		<<set $currentRule.facility.push("clinic")>>
+		<<set $currentRule.facility.push("get treatment in the clinic")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
-''$clinicNameCaps''
+	''$clinicNameCaps''
 	<<link Stop>>
-		<<set $currentRule.facility.delete("clinic")>>
+		<<set $currentRule.facility.delete("get treatment in the clinic")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($cellblock > 0)>>
 |
-<<if !ruleFacility($currentRule.facility,"cellblock")>>
+<<if !$currentRule.facility.includes("be confined in the cellblock")>>
 	<<link $cellblockNameCaps>>
-		<<set $currentRule.facility.push("cellblock")>>
+		<<set $currentRule.facility.push("be confined in the cellblock")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$cellblockNameCaps''
 	<<link Stop>>
-		<<set $currentRule.facility.delete("cellblock")>>
+		<<set $currentRule.facility.delete("be confined in the cellblock")>>
 		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
@@ -788,165 +819,165 @@
 <</if>>
 <<if ($HGSuite > 0)>>
 |
-<<if !ruleFacility($currentRule.excludeFacility,"hgsuite")>>
+<<if !$currentRule.excludeFacility.includes("live with your Head Girl")>>
 	<<link $HGSuiteNameCaps>>
-		<<set $currentRule.excludeFacility.push("hgsuite")>>
+		<<set $currentRule.excludeFacility.push("live with your Head Girl")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$HGSuiteNameCaps''
 	<<link Stop>>
-		<<set $currentRule.excludeFacility.delete("hgsuite")>>
+		<<set $currentRule.excludeFacility.delete("live with your Head Girl")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($brothel > 0)>>
 |
-<<if !ruleFacility($currentRule.excludeFacility,"brothel")>>
+<<if !$currentRule.excludeFacility.includes("work in the brothel")>>
 	<<link $brothelNameCaps>>
-		<<set $currentRule.excludeFacility.push("brothel")>>
+		<<set $currentRule.excludeFacility.push("work in the brothel")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$brothelNameCaps''
 	<<link Stop>>
-		<<set $currentRule.excludeFacility.delete("brothel")>>
+		<<set $currentRule.excludeFacility.delete("work in the brothel")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($club > 0)>>
 |
-<<if !ruleFacility($currentRule.excludeFacility,"club")>>
+<<if !$currentRule.excludeFacility.includes("serve in the club")>>
 	<<link $clubNameCaps>>
-		<<set $currentRule.excludeFacility.push("club")>>
+		<<set $currentRule.excludeFacility.push("serve in the club")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$clubNameCaps''
 	<<link Stop>>
-		<<set $currentRule.excludeFacility.delete("club")>>
+		<<set $currentRule.excludeFacility.delete("serve in the club")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($arcade > 0)>>
 |
-<<if !ruleFacility($currentRule.excludeFacility,"arcade")>>
+<<if !$currentRule.excludeFacility.includes("be confined in the arcade")>>
 	<<link $arcadeNameCaps>>
-		<<set $currentRule.excludeFacility.push("arcade")>>
+		<<set $currentRule.excludeFacility.push("be confined in the arcade")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$arcadeNameCaps''
 	<<link Stop>>
-		<<set $currentRule.excludeFacility.delete("arcade")>>
+		<<set $currentRule.excludeFacility.delete("be confined in the arcade")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($dairy > 0)>>
 |
-<<if !ruleFacility($currentRule.excludeFacility,"dairy")>>
+<<if !$currentRule.excludeFacility.includes("work in the dairy")>>
 	<<link $dairyNameCaps>>
-		<<set $currentRule.excludeFacility.push("dairy")>>
+		<<set $currentRule.excludeFacility.push("work in the dairy")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$dairyNameCaps''
 	<<link Stop>>
-		<<set $currentRule.excludeFacility.delete("dairy")>>
+		<<set $currentRule.excludeFacility.delete("work in the dairy")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($servantsQuarters > 0)>>
 |
-<<if !ruleFacility($currentRule.excludeFacility,"servantsquarters")>>
+<<if !$currentRule.excludeFacility.includes("work as a servant")>>
 	<<link $servantsQuartersNameCaps>>
-		<<set $currentRule.excludeFacility.push("servantsquarters")>>
+		<<set $currentRule.excludeFacility.push("work as a servant")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$servantsQuartersNameCaps''
 	<<link Stop>>
-		<<set $currentRule.excludeFacility.delete("servantsquarters")>>
+		<<set $currentRule.excludeFacility.delete("work as a servant")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($masterSuite > 0)>>
 |
-<<if !ruleFacility($currentRule.excludeFacility,"mastersuite")>>
+<<if !$currentRule.excludeFacility.includes("serve in the master suite")>>
 	<<link $masterSuiteNameCaps>>
-		<<set $currentRule.excludeFacility.push("mastersuite")>>
+		<<set $currentRule.excludeFacility.push("serve in the master suite")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$masterSuiteNameCaps''
 	<<link Stop>>
-		<<set $currentRule.excludeFacility.delete("mastersuite")>>
+		<<set $currentRule.excludeFacility.delete("serve in the master suite")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($schoolroom > 0)>>
 |
-<<if !ruleFacility($currentRule.excludeFacility,"schoolroom")>>
+<<if !$currentRule.excludeFacility.includes("learn in the schoolroom")>>
 	<<link $schoolroomNameCaps>>
-		<<set $currentRule.excludeFacility.push("schoolroom")>>
+		<<set $currentRule.excludeFacility.push("learn in the schoolroom")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$schoolroomNameCaps''
 	<<link Stop>>
-		<<set $currentRule.excludeFacility.delete("schoolroom")>>
+		<<set $currentRule.excludeFacility.delete("learn in the schoolroom")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($spa > 0)>>
 |
-<<if !ruleFacility($currentRule.excludeFacility,"spa")>>
+<<if !$currentRule.excludeFacility.includes("rest in the spa")>>
 	<<link $spaNameCaps>>
-		<<set $currentRule.excludeFacility.push("spa")>>
+		<<set $currentRule.excludeFacility.push("rest in the spa")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$spaNameCaps''
 	<<link Stop>>
-		<<set $currentRule.excludeFacility.delete("spa")>>
+		<<set $currentRule.excludeFacility.delete("rest in the spa")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($clinic > 0)>>
 |
-<<if !ruleFacility($currentRule.excludeFacility,"clinic")>>
+<<if !$currentRule.excludeFacility.includes("get treatment in the clinic")>>
 	<<link $clinicNameCaps>>
-		<<set $currentRule.excludeFacility.push("clinic")>>
+		<<set $currentRule.excludeFacility.push("get treatment in the clinic")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
-''$clinicNameCaps''
+	''$clinicNameCaps''
 	<<link Stop>>
-		<<set $currentRule.excludeFacility.delete("clinic")>>
+		<<set $currentRule.excludeFacility.delete("get treatment in the clinic")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
 <<if ($cellblock > 0)>>
 |
-<<if !ruleFacility($currentRule.excludeFacility,"cellblock")>>
+<<if !$currentRule.excludeFacility.includes("be confined in the cellblock")>>
 	<<link $cellblockNameCaps>>
-		<<set $currentRule.excludeFacility.push("cellblock")>>
+		<<set $currentRule.excludeFacility.push("be confined in the cellblock")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$cellblockNameCaps''
 	<<link Stop>>
-		<<set $currentRule.excludeFacility.delete("cellblock")>>
+		<<set $currentRule.excludeFacility.delete("be confined in the cellblock")>>
 		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
@@ -959,7 +990,7 @@
  % Call as <<RAChangeSetAssignment>>
  %/
 <<widget "RAChangeSetAssignment">>
-<<set _assignments = ["rest", "please you", "be a servant", "stay confined", "whore", "serve the public", "get milked", "be a subordinate slave", "work a glory hore", "take classes"]>>
+<<RACommonAssignmentVariables>>
 
 <<if (ndef $currentRule.assignment)>><<set $currentRule.assignment = []>><</if>>
 <<if (ndef $currentRule.excludeAssignment)>><<set $currentRule.excludeAssignment = []>><</if>>
@@ -1072,7 +1103,7 @@
  % Call as <<RAChangeAssignFacility>>
  %/
 <<widget "RAChangeAssignFacility">>
-<<set _facilityAssignments = ["hgsuite", "brothel", "club", "arcade", "dairy", "servantsquarters", "mastersuite", "schoolroom", "spa", "clinic", "cellblock"]>>
+<<RACommonAssignmentVariables>>
 
 <<if (ndef $currentRule.facility)>><<set $currentRule.facility = []>><</if>>
 <<if (ndef $currentRule.excludeFacility)>><<set $currentRule.excludeFacility = []>><</if>>
@@ -1091,9 +1122,9 @@
 <</if>>
 <<if ($HGSuite > 0)>>
 |
-<<if ($currentRule.setAssignment != "hgsuite")>>
+<<if ($currentRule.setAssignment != "live with your Head Girl")>>
 	<<link $HGSuiteNameCaps>>
-		<<set $currentRule.setAssignment = "hgsuite">>
+		<<set $currentRule.setAssignment = "live with your Head Girl">>
 		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
@@ -1102,9 +1133,9 @@
 <</if>>
 <<if ($brothel > 0)>>
 |
-<<if ($currentRule.setAssignment != "brothel")>>
+<<if ($currentRule.setAssignment != "work in the brothel")>>
 	<<link $brothelNameCaps>>
-		<<set $currentRule.setAssignment = "brothel">>
+		<<set $currentRule.setAssignment = "work in the brothel">>
 		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
@@ -1113,9 +1144,9 @@
 <</if>>
 <<if ($club > 0)>>
 |
-<<if ($currentRule.setAssignment != "club")>>
+<<if ($currentRule.setAssignment != "serve in the club")>>
 	<<link $clubNameCaps>>
-		<<set $currentRule.setAssignment = "club">>
+		<<set $currentRule.setAssignment = "serve in the club">>
 		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
@@ -1124,9 +1155,9 @@
 <</if>>
 <<if ($arcade > 0)>>
 |
-<<if ($currentRule.setAssignment != "arcade")>>
+<<if ($currentRule.setAssignment != "be confined in the arcade")>>
 	<<link $arcadeNameCaps>>
-		<<set $currentRule.setAssignment = "arcade">>
+		<<set $currentRule.setAssignment = "be confined in the arcade">>
 		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
@@ -1135,9 +1166,9 @@
 <</if>>
 <<if ($dairy > 0)>>
 |
-<<if ($currentRule.setAssignment != "dairy")>>
+<<if ($currentRule.setAssignment != "work in the dairy")>>
 	<<link $dairyNameCaps>>
-		<<set $currentRule.setAssignment = "dairy">>
+		<<set $currentRule.setAssignment = "work in the dairy">>
 		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
@@ -1146,9 +1177,9 @@
 <</if>>
 <<if ($servantsQuarters > 0)>>
 |
-<<if ($currentRule.setAssignment != "servantsquarters")>>
+<<if ($currentRule.setAssignment != "work as a servant")>>
 	<<link $servantsQuartersNameCaps>>
-		<<set $currentRule.setAssignment = "servantsquarters">>
+		<<set $currentRule.setAssignment = "work as a servant">>
 		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
@@ -1157,9 +1188,9 @@
 <</if>>
 <<if ($masterSuite > 0)>>
 |
-<<if ($currentRule.setAssignment != "mastersuite")>>
+<<if ($currentRule.setAssignment != "serve in the master suite")>>
 	<<link $masterSuiteNameCaps>>
-		<<set $currentRule.setAssignment = "mastersuite">>
+		<<set $currentRule.setAssignment = "serve in the master suite">>
 		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
@@ -1168,9 +1199,9 @@
 <</if>>
 <<if ($schoolroom > 0)>>
 |
-<<if ($currentRule.setAssignment != "schoolroom")>>
+<<if ($currentRule.setAssignment != "learn in the schoolroom")>>
 	<<link $schoolroomNameCaps>>
-		<<set $currentRule.setAssignment = "schoolroom">>
+		<<set $currentRule.setAssignment = "learn in the schoolroom">>
 		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
@@ -1179,9 +1210,9 @@
 <</if>>
 <<if ($spa > 0)>>
 |
-<<if ($currentRule.setAssignment != "spa")>>
+<<if ($currentRule.setAssignment != "rest in the spa")>>
 	<<link $spaNameCaps>>
-		<<set $currentRule.setAssignment = "spa">>
+		<<set $currentRule.setAssignment = "rest in the spa">>
 		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
@@ -1190,9 +1221,9 @@
 <</if>>
 <<if ($clinic > 0)>>
 |
-<<if ($currentRule.setAssignment != "clinic")>>
+<<if ($currentRule.setAssignment != "get treatment in the clinic")>>
 	<<link $clinicNameCaps>>
-		<<set $currentRule.setAssignment = "clinic">>
+		<<set $currentRule.setAssignment = "get treatment in the clinic">>
 		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
@@ -1201,9 +1232,9 @@
 <</if>>
 <<if ($cellblock > 0)>>
 |
-<<if ($currentRule.setAssignment != "cellblock")>>
+<<if ($currentRule.setAssignment != "be confined in the cellblock")>>
 	<<link $cellblockNameCaps>>
-		<<set $currentRule.setAssignment = "cellblock">>
+		<<set $currentRule.setAssignment = "be confined in the cellblock">>
 		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
@@ -1346,7 +1377,7 @@ Shoes: ''$currentRule.shoes.''
 %/
 <<widget "RAChangeBelly">>
 <<replace #baccessory>>
-Corsetage: ''$currentRule.bellyAccessory.
+Corsetage: ''$currentRule.bellyAccessory.''
 <</replace>>
 <</widget>>
 
@@ -2656,13 +2687,13 @@ Your brand design is ''$brandDesign.''
 <<widget "RAFacilityRemove">>
 <<if $args[1].facilityRemove>>
     <<switch $args[1].setAssignment>>
-    <<case "arcade">>
+    <<case "be confined in the arcade">>
         <<if $args[0].assignment == "be confined in the arcade">>
             <br>$args[0].slaveName has been removed from $arcadeName and has been assigned to $args[1].removalAssignment.
             <<assignJob $args[0] $args[1].removalAssignment>>
         <</if>>
 
-    <<case "brothel">>
+    <<case "work in the brothel">>
         <<if $args[0].assignment == "work in the brothel">>
             <<if ($Madam == 0) || ($Madam.ID != $args[0].ID)>>
                 <br>$args[0].slaveName has been removed from $brothelName and has been assigned to $args[1].removalAssignment.
@@ -2670,7 +2701,7 @@ Your brand design is ''$brandDesign.''
             <</if>>
         <</if>>
 
-    <<case "club">>
+    <<case "serve in the club">>
         <<if $args[0].assignment == "serve in the club">>
             <<if ($DJ == 0) || ($DJ.ID != $args[0].ID)>>
                 <br>$args[0].slaveName has been removed from $clubName and has been assigned to $args[1].removalAssignment.
@@ -2678,7 +2709,7 @@ Your brand design is ''$brandDesign.''
             <</if>>
         <</if>>
 
-    <<case "dairy">>
+    <<case "work in the dairy">>
         <<if $args[0].assignment == "work in the dairy">>
             <<if ($Milkmaid == 0) || ($Milkmaid.ID != $args[0].ID)>>
                 <br>$args[0].slaveName has been removed from $dairyName and has been assigned to $args[1].removalAssignment.
@@ -2686,7 +2717,7 @@ Your brand design is ''$brandDesign.''
             <</if>>
         <</if>>
 
-    <<case "spa">>
+    <<case "rest in the spa">>
         <<if $args[0].assignment == "rest in the spa">>
             <<if ($Attendant == 0) || ($Attendant.ID != $args[0].ID)>>
                 <br>$args[0].slaveName has been removed from $spaName and has been assigned to $args[1].removalAssignment.
@@ -2694,7 +2725,7 @@ Your brand design is ''$brandDesign.''
             <</if>>
         <</if>>
 
-    <<case "clinic">>
+    <<case "get treatment in the clinic">>
         <<if $args[0].assignment == "get treatment in the clinic">>
             <<if ($Nurse == 0) || ($Nurse.ID != $args[0].ID)>>
                 <br>$args[0].slaveName has been removed from $clinicName and has been assigned to $args[1].removalAssignment.
@@ -2702,7 +2733,7 @@ Your brand design is ''$brandDesign.''
             <</if>>
         <</if>>
 
-    <<case "mastersuite">>
+    <<case "serve in the master suite">>
         <<if $args[0].assignment == "serve in the master suite">>
             <<if ($Concubine == 0) || ($Concubine.ID != $args[0].ID)>>
                 <br>$args[0].slaveName has been removed from $masterSuiteName and has been assigned to $args[1].removalAssignment.
@@ -2710,7 +2741,7 @@ Your brand design is ''$brandDesign.''
             <</if>>
         <</if>>
 
-    <<case "hgsuite">>
+    <<case "live with your Head Girl">>
         <<if $args[0].assignment == "live with your Head Girl">>
             <<if ($HeadGirl == 0) || ($HeadGirl.ID != $args[0].ID)>>
                 <br>$args[0].slaveName has been removed from $HGSuiteName and has been assigned to $args[1].removalAssignment.
@@ -2718,7 +2749,7 @@ Your brand design is ''$brandDesign.''
             <</if>>
         <</if>>
 
-    <<case "servantsquarters">>
+    <<case "work as a servant">>
         <<if $args[0].assignment == "work as a servant">>
             <<if ($Stewardess == 0) || ($Stewardess.ID != $args[0].ID)>>
                 <br>$args[0].slaveName has been removed from $servantsQuartersName and has been assigned to $args[1].removalAssignment.
@@ -2726,7 +2757,7 @@ Your brand design is ''$brandDesign.''
             <</if>>
         <</if>>
 
-    <<case "schoolroom">>
+    <<case "learn in the schoolroom">>
         <<if $args[0].assignment == "learn in the schoolroom">>
             <<if ($Schoolteacher == 0) || ($Schoolteacher.ID != $args[0].ID)>>
                 <br>$args[0].slaveName has been removed from $schoolroomName and has been assigned to $args[1].removalAssignment.
@@ -2734,7 +2765,7 @@ Your brand design is ''$brandDesign.''
             <</if>>
         <</if>>
 
-    <<case "cellblock">>
+    <<case "be confined in the cellblock">>
         <<if $args[0].assignment == "be confined in the cellblock">>
             <<if ($Wardeness == 0) || ($Wardeness.ID != $args[0].ID)>>
                 <br>$args[0].slaveName has been removed from $cellblockName and has been assigned to $args[1].removalAssignment.
@@ -2776,83 +2807,69 @@ Your brand design is ''$brandDesign.''
 
 	<<set _combinedRule = mergeRules([_combinedRule, _currentRule])>>
 
-	<<if _currentRule.setAssignment == "no default setting">>
+	<<if _currentRule.setAssignment == "no default setting" || _currentRule.setAssignment == $args[0].assignment>>
 		<<continue>>
 	<</if>>
 
 	/% apply assignment changes for each rule (_currentRule) we process; _combinedRule will be used later %/
 	<<switch _currentRule.setAssignment>>
-	<<case "hgsuite">>
+	<<case "live with your Head Girl">>
 		<<if ($HGSuiteSlaves < 1 && $args[0].indentureRestrictions <= 0)>>
-			<<if ($args[0].assignment != "live with your Head Girl")>>
-				<br>$args[0].slaveName has been automatically assigned to live in your Head Girl's private suite.
-				<<assignJob $args[0] _currentRule.setAssignment>>
-			<</if>>
+			<br>$args[0].slaveName has been automatically assigned to live in your Head Girl's private suite.
+			<<assignJob $args[0] _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
-	<<case "arcade">>
+	<<case "be confined in the arcade">>
 		<<if ($arcadeSlaves > $arcade && $args[0].indentureRestrictions <= 0)>>
-			<<if ($args[0].assignment != "be confined in the arcade")>>
-				<br>$args[0].slaveName has been automatically assigned to be confined in $arcadeName.
-				<<assignJob $args[0] _currentRule.setAssignment>>
-			<</if>>
+			<br>$args[0].slaveName has been automatically assigned to be confined in $arcadeName.
+			<<assignJob $args[0] _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
-	<<case "mastersuite">>
+	<<case "serve in the master suite">>
 		<<if ($masterSuiteSlaves > $masterSuite && ($args[0].devotion > 20 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
-			<<if ($args[0].assignment != "serve in the master suite")>>
-				<br>$args[0].slaveName has been automatically assigned to $masterSuiteName.
-				<<assignJob $args[0] _currentRule.setAssignment>>
-			<</if>>
+			<br>$args[0].slaveName has been automatically assigned to $masterSuiteName.
+			<<assignJob $args[0] _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
-	<<case "clinic">>
+	<<case "get treatment in the clinic">>
 		<<if ($clinicSlaves > $clinic && ($args[0].health < 20 || ($args[0].chem > 15 && $Nurse != 0 && $clinicUpgradeFilters == 1)))>>
-			<<if ($args[0].assignment != "get treatment in the clinic")>>
-				<br>$args[0].slaveName has been automatically assigned to get treatment in $clinicName.
-				<<assignJob $args[0] _currentRule.setAssignment>>
-			<</if>>
+			<br>$args[0].slaveName has been automatically assigned to get treatment in $clinicName.
+			<<assignJob $args[0] _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
-	<<case "spa">>
+	<<case "rest in the spa">>
 		<<if ($spa > $spaSlaves) && ($args[0].health < 20) || ($args[0].trust < 60) || ($args[0].devotion <= 60) || ($args[0].fetish == "mindbroken") && ($args[0].devotion >= -20)>>
-			<<if ($args[0].assignment != "rest in the spa")>>
-				<br>$args[0].slaveName has been automatically assigned to rest in $spaName.
-				<<assignJob $args[0] _currentRule.setAssignment>>
-			<</if>>
+			<br>$args[0].slaveName has been automatically assigned to rest in $spaName.
+			<<assignJob $args[0] _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
-	<<case "brothel">>
+	<<case "work in the brothel">>
 		<<if ($brothelSlaves < $brothel && ($args[0].devotion > 50 || $args[0].trust > 50 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
-			<<if ($args[0].assignment != "work in the brothel")>>
-				<br>$args[0].slaveName has been automatically assigned to work in $brothelName.
-				<<assignJob $args[0] _currentRule.setAssignment>>
-			<</if>>
+			<br>$args[0].slaveName has been automatically assigned to work in $brothelName.
+			<<assignJob $args[0] _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
-	<<case "club">>
+	<<case "serve in the club">>
 		<<if ($clubSlaves < $club && ($args[0].devotion > 50 || $args[0].trust > 50 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
-			<<if ($args[0].assignment != "serve in the club")>>
-				<br>$args[0].slaveName has been automatically assigned to serve in $clubName.
-				<<assignJob $args[0] _currentRule.setAssignment>>
-			<</if>>
+			<br>$args[0].slaveName has been automatically assigned to serve in $clubName.
+			<<assignJob $args[0] _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
-	<<case "dairy">>
+	<<case "work in the dairy">>
 		<<if ($dairy > $dairySlaves+$bioreactorsXY+$bioreactorsXX+$bioreactorsHerm+$bioreactorsBarren)>>
 			<<if ($args[0].indentureRestrictions > 0) && ($dairyRestraintsSetting > 1)>>
 			<<elseif (($args[0].indentureRestrictions > 1) && ($dairyRestraintsSetting > 0))>>
@@ -2861,10 +2878,8 @@ Your brand design is ''$brandDesign.''
 					<<if ($args[0].devotion > 20) || (($args[0].devotion >= -50) && ($args[0].trust < -20)) || ($args[0].trust < -50) || ($args[0].amp == 1) || ($dairyRestraintsUpgrade == 1)>>
 						<<if ($dairyStimulatorsSetting < 2) || ($args[0].anus > 2) || ($dairyPrepUpgrade == 1)>>
 							<<if ($dairyPregSetting < 2) || ($args[0].vagina > 2) || ($args[0].ovaries == 0) || ($dairyPrepUpgrade == 1)>>
-								<<if ($args[0].assignment != "work in the dairy")>>
-									<br>$args[0].slaveName has been automatically assigned to be milked in $dairyName.
-									<<assignJob $args[0] _currentRule.setAssignment>>
-								<</if>>
+								<br>$args[0].slaveName has been automatically assigned to be milked in $dairyName.
+								<<assignJob $args[0] _currentRule.setAssignment>>
 							<<else>>
 								<<RAFacilityRemove $args[0] _currentRule>>
 							<</if>>
@@ -2880,23 +2895,19 @@ Your brand design is ''$brandDesign.''
 			<</if>>
 		<</if>>
 
-	<<case "servantsquarters">>
+	<<case "work as a servant">>
 		<<if ($servantsQuartersSlaves < $servantsQuarters && canSee($args[0]) && canWalk($args[0]) && ($args[0].devotion >= -20 || $args[0].trust < -20 || ($args[0].devotion >= -50 && $args[0].trust <= 20)))>>
-			<<if ($args[0].assignment != "work as a servant")>>
-				<br>$args[0].slaveName has been automatically assigned to work in $servantsQuartersName.
-				<<assignJob $args[0] _currentRule.setAssignment>>
-			<</if>>
+			<br>$args[0].slaveName has been automatically assigned to work in $servantsQuartersName.
+			<<assignJob $args[0] _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
-	<<case "schoolroom">>
+	<<case "learn in the schoolroom">>
 		<<if ($schoolroomSlaves < $schoolroom && $args[0].fetish != "mindbroken" && ($args[0].devotion >= -20 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
 			<<if ($args[0].intelligenceImplant < 1) || ($args[0].voice != 0 && $args[0].accent+$schoolroomUpgradeLanguage > 2) || ($args[0].oralSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].whoreSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].entertainSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].analSkill < 10+$schoolroomUpgradeSkills*20) || (($args[0].vagina >= 0) && ($args[0].vaginalSkill < 10+$schoolroomUpgradeSkills*20))>>
-				<<if ($args[0].assignment != "learn in the schoolroom")>>
-					<br>$args[0].slaveName has been automatically assigned to study in $schoolroomName.
-					<<assignJob $args[0] _currentRule.setAssignment>>
-				<</if>>
+				<br>$args[0].slaveName has been automatically assigned to study in $schoolroomName.
+				<<assignJob $args[0] _currentRule.setAssignment>>
 			<<else>>
 				<<RAFacilityRemove $args[0] _currentRule>>
 			<</if>>
@@ -2904,12 +2915,10 @@ Your brand design is ''$brandDesign.''
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
-	<<case "cellblock">>
+	<<case "be confined in the cellblock">>
 		<<if ($cellblockSlaves < $cellblock && (($args[0].devotion < -20 && $args[0].trust >= -20) || ($args[0].devotion < -50 && $args[0].trust >= -50))>>
-			<<if ($args[0].assignment != "be confined in the cellblock")>>
-				<br>$args[0].slaveName has been automatically assigned to be confined in $cellblockName.
-				<<assignJob $args[0] _currentRule.setAssignment>>
-			<</if>>
+			<br>$args[0].slaveName has been automatically assigned to be confined in $cellblockName.
+			<<assignJob $args[0] _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
@@ -2922,16 +2931,13 @@ Your brand design is ''$brandDesign.''
 
 	<<case "get milked">>
 		<<if ($args[0].lactation > 0 || $args[0].balls > 0)>>
-			<<if (_currentRule.setAssignment != $args[0].assignment)>>
-				<<assignJob $args[0] _currentRule.setAssignment>>
-			<</if>>
+			/% TODO: someone write text please %/
+			<<assignJob $args[0] _currentRule.setAssignment>>
 		<</if>>
 
 	<<default>>
-		<<if (_currentRule.setAssignment != $args[0].assignment)>>
-			<br>$args[0].slaveName has been automatically assigned to _currentRule.setAssignment.
-			<<assignJob $args[0] _currentRule.setAssignment>>
-		<</if>>
+		<br>$args[0].slaveName has been automatically assigned to _currentRule.setAssignment.
+		<<assignJob $args[0] _currentRule.setAssignment>>
 	<</switch>>
 
 <</for>> /* done merging rules; from here onwards, we should only use _combinedRule */
@@ -4166,7 +4172,7 @@ is now _combinedRule.hLength cm long.
 
 		<<set _ruleAppliesToThisSlave = evalExpr(_currentRule.condition, $args[0])>>
 
-		<<if _ruleAppliesToThisSlave == true && _currentRule.excludeSpecialSlaves>> /* passed activation conditions - check inclusion/exclusion rules */
+		<<if _ruleAppliesToThisSlave && _currentRule.excludeSpecialSlaves>>
 			<<for _L = 0; _L < _leaders.length; _L++>>
 				<<if (def _leaders[_L].ID) && (_leaders[_L].ID == $args[0].ID)>>
 					<<set _ruleAppliesToThisSlave = false>>
@@ -4175,36 +4181,57 @@ is now _combinedRule.hLength cm long.
 			<</for>>
 		<</if>>
 
-		<<if _ruleAppliesToThisSlave == true>> /* check more inclusion/exclusion rules */
-			<<if   (def _currentRule.excludedSlaves && _currentRule.excludedSlaves.length > 0 && ruleSlaveExcluded($args[0], _currentRule))
-				|| (def _currentRule.selectedSlaves && _currentRule.selectedSlaves.length > 0 && !ruleSlaveSelected($args[0], _currentRule))>>
-					<<set _ruleAppliesToThisSlave = false>>
-			<<elseif $args[0].assignmentVisible == 0>> /* assignment is not visible, so check facilities assignments */
-				<<if   (def _currentRule.excludeFacility && _currentRule.excludeFacility.length > 0 && ruleExcludeSlaveFacility(_currentRule, $args[0]))
-					|| (def _currentRule.facility        && _currentRule.facility.length > 0        && !ruleAppliedToSlaveFacility(_currentRule, $args[0]))>>
-						<<set _ruleAppliesToThisSlave = false>>
-				<</if>>
-			<<else>> /* assignment is visible, so check non-facilities assignments */
-				<<if   (def _currentRule.excludeAssignment && _currentRule.excludeAssignment.length > 0 && ruleAssignment(_currentRule.excludeAssignment, $args[0].assignment))
-					|| (def _currentRule.assignment        && _currentRule.assignment.length > 0        && !ruleAssignment(_currentRule.assignment, $args[0].assignment))>>
-						<<set _ruleAppliesToThisSlave = false>>
-				<</if>>
-			<</if>>
-		<</if>> /* done with all checks for this rule */
+		/% facility and excludeFacility only include some of the
+		 % assignments we're searching for; namely, they don't include
+		 % the leader roles, so we fill these out temporarily
+		 %/
+		<<if (def _currentRule.facility)>>
+			<<set _facility = expandFacilityAssignments(_currentRule.facility)>>
+		<</if>>
+		<<if (def _currentRule.excludeFacility)>>
+			<<set _excludeFacility = expandFacilityAssignments(_currentRule.excludeFacility)>>
+		<</if>>
 
-		<<if _ruleAppliesToThisSlave == true>>
+		/% check exclusion/inclusion %/
+		<<if _ruleAppliesToThisSlave>>
+			/% first we check if a slave is in a facility she shouldn't be in %/
+			<<if (_facility.length > 0)>>
+				<<set _ruleAppliesToThisSlave = _facility.includes($args[0].assignment)>>
+			<<elseif (_excludeFacility.length > 0)>>
+				<<set _ruleAppliesToThisSlave = !_excludeFacility.includes($args[0].assignment)>>
+			<</if>>
+
+			/% and same thing with the assignments; since actual
+			 % assignments and facility assignments are different
+			 % either the previous if was executed or this one will
+			 % be but not both
+			 %/
+			<<if (def _currentRule.assignment && _currentRule.assignment.length > 0)>>
+				<<set _ruleAppliesToThisSlave = _currentRule.assignment.includes($args[0].assignment)>>
+			<<elseif (def _currentRule.excludeAssignment && _currentRule.excludeAssignment.length > 0)>>
+				<<set _ruleAppliesToThisSlave = !_currentRule.excludeAssignment.includes($args[0].assignment)>>
+			<</if>>
+
+			/% last but not least, we make sure the slave herself is not excluded %/
+			<<if (def _currentRule.selectedSlaves && _currentRule.selectedSlaves.length > 0)>>
+				<<set _ruleAppliesToThisSlave = ruleSlaveSelected($args[0], _currentRule)>>
+			<<elseif (def _currentRule.excludedSlaves && _currentRule.excludedSlaves.length > 0)>>
+				<<set _ruleAppliesToThisSlave = !ruleSlaveExcluded($args[0], _currentRule)>>
+			<</if>>
+		<</if>>
+
+		<<if _ruleAppliesToThisSlave>>
 			<<if !ruleApplied($args[0], _currentRule.ID)>> /* rule applies now, but did not apply before */
 				<<set $args[0].currentRules.push(_currentRule.ID)>>
 				<br>//@@.tan;Rule _rule (_currentRule.name) now applies to $args[0].slaveName, who is assigned to $args[0].assignment.@@//
 			<</if>>
-			/* this rule has been applied to this slave now (or was already), so we are done with this rule */
 		<<elseif ruleApplied($args[0], _currentRule.ID)>> /* rule does not apply now, but did before */
 			<<RARemoveRule $args[0]>> /* RARemoveRule prints message and includes Rules Facilities Remove check, so we are done with this rule */
 		<</if>>
-	<</for>> /* done with this rule - continue looping through all the rules defined in the rules assistant */
+	<</for>>
 
 	/* done checking/applying/removing rules - sort this slave's updated applied rules to match the current priority order in the rules assistant */
-	<<set $args[0].currentRules = $args[0].currentRules.sort(function(a, b) { return a-b; });>> /* sort this slave's applied rules to match the current priority order in the rules assistant */
+	<<set $args[0].currentRules = $args[0].currentRules.sort(function(a, b) { return a-b; });>>
 
 <</widget>>
 

--- a/src/utility/raWidgets.tw
+++ b/src/utility/raWidgets.tw
@@ -135,564 +135,479 @@
 <</widget>>
 
 /%
- Call as <<RAChangeApplyAssignment>>
-%/
-<<widget "RAChangeApplyAssignment">>
-<<replace #applyassignment>>
-<<set _rest = false>>
-<<set _fucktoy = false>>
-<<set _servant = false>>
-<<set _confined = false>>
-<<set _whore = false>>
-<<set _public = false>>
-<<set _milked = false>>
-<<set _subordinate = false>>
-<<set _gloryhole = false>>
-<<set _classes = false>>
-<<if def $currentRule.assignment>>
-	<<for _a = $currentRule.assignment.length; _a >= 0; _a-->>
-		<<if $currentRule.assignment[_a] == "rest">>
-			<<set _rest = true>>
-		<</if>>
-		<<if $currentRule.assignment[_a] == "please you">>
-			<<set _fucktoy = true>>
-		<</if>>
-		<<if $currentRule.assignment[_a] == "be a servant">>
-			<<set _servant = true>>
-		<</if>>
-		<<if $currentRule.assignment[_a] == "whore">>
-			<<set _whore = true>>
-		<</if>>
-		<<if $currentRule.assignment[_a] == "work a glory hole">>
-			<<set _gloryhole = true>>
-		<</if>>
-		<<if $currentRule.assignment[_a] == "get milked">>
-			<<set _milked = true>>
-		<</if>>
-		<<if $currentRule.assignment[_a] == "serve the public">>
-			<<set _public = true>>
-		<</if>>
-		<<if $currentRule.assignment[_a] == "be a subordinate slave">>
-			<<set _subordinate = true>>
-		<</if>>
-		<<if $currentRule.assignment[_a] == "stay confined">>
-			<<set _confined = true>>
-		<</if>>
-		<<if $currentRule.assignment[_a] == "take classes">>
-			<<set _classes = true>>
-		<</if>>
-	<</for>>
-<</if>>
+ % Call as <<RANormalizeAssignments>>
+ %/
+<<widget "RANormalizeAssignments">>
+<<set _assignments = ["rest", "please you", "be a servant", "stay confined", "whore", "serve the public", "get milked", "be a subordinate slave", "work a glory hore", "take classes"]>>
+<<set _facilityAssignments = ["hgsuite", "brothel", "club", "arcade", "dairy", "servantsquarters", "mastersuite", "schoolroom", "spa", "clinic", "cellblock"]>>
 
+<<switch $args[0]>>
+<<case "assignment">>
+	<<if $currentRule.assignment.length > 0>>
+		<<set $currentRule.excludeAssignment = []>>
+		<<set $currentRule.facilityRemove = false>>
+		<<RAChangeAssignFacility>>
+	<</if>>
+	/% RAChangeExcludeAssignment is also responsible for the case that both
+	 % assignment and excludeAssignment are empty (it sets some colors and
+	 % stuff) so we always need to call it.
+	 %/
+	<<RAChangeExcludeAssignment>>
+	<<RAChangeApplyAssignment>>
+	<<RARuleModified>>
+
+<<case "excludeAssignment">>
+	<<if $currentRule.excludeAssignment.length > 0>>
+		<<set $currentRule.assignment = []>>
+		<<RAChangeApplyAssignment>>
+	<</if>>
+	<<RAChangeExcludeAssignment>>
+	<<RARuleModified>>
+
+<<case "facility">>
+	<<if $currentRule.facility.length > 0>>
+		<<set $currentRule.excludeFacility = []>>
+		<<if !$currentRule.facility.includes($currentRule.setAssignment)>>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
+	<</if>>
+	/% same as above with RAChangeExcludeAssignment %/
+	<<RAChangeExcludeFacility>>
+	<<RAChangeApplyFacility>>
+	<<RARuleModified>>
+
+<<case "excludeFacility">>
+	<<if $currentRule.excludeFacility.length > 0>>
+		<<set $currentRule.facility = []>>
+		<<if $currentRule.excludeFacility.includes($currentRule.setAssignment)>>
+			<<set $currentRule.facilityRemove = false>>
+			<<RAChangeAssignFacility>>
+		<</if>>
+		<<RAChangeApplyFacility>>
+	<</if>>
+	<<RAChangeExcludeFacility>>
+	<<RARuleModified>>
+
+<<case "setAssignment">>
+	<<if _facilityAssignments.includes($currentRule.setAssignment) && $currentRule.facilityRemove>>
+		/% If a rule sends a slave to a facility that it does not
+		 % manage (due to exclusion or inclusion settings) and
+		 % facilityRemove is turned on, then the slave would be sent to
+		 % the facility, the rule would not apply anymore and so she
+		 % would be removed from the facility.  So we try to prevent
+		 % that.
+		 %/
+		<<if $currentRule.excludeFacility.includes($currentRule.setAssignment)>>
+			<<set $currentRule.excludeFacility.delete($currentRule.setAssignment)>>
+			<<RAChangeExcludeFacility>>
+		<</if>>
+		<<if $currentRule.facility.length > 0 && !$currentRule.facility.includes($currentRule.setAssignment)>>
+			<<set $currentRule.facility.push($currentRule.setAssignment)>>
+			<<RAChangeApplyFacility>>
+		<</if>>
+	<<else>>
+		/% facilityRemove would have no effect when the assignment is not in a
+		 % facility, but we reset anyway to prevent potential surprises to the
+		 % user later
+		 %/
+		<<set $currentRule.facilityRemove = false>>
+	<</if>>
+	<<RAChangeSetAssignment>>
+	<<RAChangeAssignFacility>>
+	<<RARuleModified>>
+
+<<case "facilityRemove">>
+	<<if $currentRule.facilityRemove>>
+		/% If facilityRemove is true that means that it was just set
+		 % which means that setAssignment is a facility (because otherwise
+		 % the UI that enables facilityRemove wouldn't be visible)
+		 %/
+		<<set $currentRule.assignment = []>>
+		<<set $currentRule.excludeFacility.delete($currentRule.setAssignment)>>
+		<<if $currentRule.facility.length > 0>>
+			<<set $currentRule.facility.push($currentRule.setAssignment)>>
+			<<RAChangeApplyFacility>>
+		<</if>>
+		/% again the thing with the RAChangeExcludeAssignment %/
+		<<RAChangeExcludeAssignment>>
+		<<RAChangeApplyAssignment>>
+		<<RAChangeExcludeFacility>>
+	<<else>>
+		/% nothing to do here really... %/
+	<</if>>
+	<<RAChangeAssignFacility>>
+	<<RARuleModified>>
+
+<</switch>>
+<</widget>>
+
+/%
+ % Call as <<RAChangeApplyAssignment>>
+ %/
+<<widget "RAChangeApplyAssignment">>
+<<if (ndef $currentRule.assignment)>><<set $currentRule.assignment = []>><</if>>
+<<if (ndef $currentRule.excludeAssignment)>><<set $currentRule.excludeAssignment = []>><</if>>
+
+<<set _rest = _whore = _fucktoy = _milked = _servant = _classes = _confined = _public = _gloryhole = _subordinate = false>>
+<<for _a = 0; _a < $currentRule.assignment.length; _a++>>
+	<<switch $currentRule.assignment[_a]>>
+	<<case "rest">>                     <<set _rest = true>>
+	<<case "whore">>                    <<set _whore = true>>
+	<<case "please you">>               <<set _fucktoy = true>>
+	<<case "get milked">>               <<set _milked = true>>
+	<<case "be a servant">>             <<set _servant = true>>
+	<<case "take classes">>             <<set _classes = true>>
+	<<case "stay confined">>            <<set _confined = true>>
+	<<case "serve the public">>         <<set _public = true>>
+	<<case "work a glory hole">>        <<set _gloryhole = true>>
+	<<case "be a subordinate slave">>   <<set _subordinate = true>>
+	<</switch>>
+<</for>>
+
+<<replace #applyassignment>>
 <<if _rest || _fucktoy || _servant || _confined || _whore || _public || _milked || _subordinate || _gloryhole || _classes>>
-  Apply to assignments:
+	Apply to assignments:
 	<<link "All">>
 		<<set $currentRule.assignment = []>>
-		<<set $currentRule.excludeAssignment = []>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
-	<</link>> |
+		<<RANormalizeAssignments "assignment">>
+	<</link>>
 <<else>>
-  @@.gray;Apply to assignments:@@
-	''All'' |
+	@@.gray;Apply to assignments:@@ ''All''
 <</if>>
-
+|
 <<if !_rest>>
 	<<link "Rest">>
 		<<set $currentRule.assignment.push("rest")>>
-		<<set $currentRule.excludeAssignment = []>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <<else>>
 	''Rest''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("rest")>>
-		<<RAChangeApplyAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <</if>>
 |
 <<if !_fucktoy>>
 	<<link "Fucktoy">>
 		<<set $currentRule.assignment.push("please you")>>
-		<<set $currentRule.excludeAssignment = []>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <<else>>
 	''Fucktoy''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("please you")>>
-		<<RAChangeApplyAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <</if>>
 |
 <<if !_subordinate>>
 	<<link "Subordinate Slave">>
 		<<set $currentRule.assignment.push("be a subordinate slave")>>
-		<<set $currentRule.excludeAssignment = []>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <<else>>
 	''Subordinate Slave''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("be a subordinate slave")>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeApplyAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <</if>>
 |
-
 <<if !_servant>>
 	<<link "House Servant">>
 		<<set $currentRule.assignment.push("be a servant")>>
-		<<set $currentRule.excludeAssignment = []>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <<else>>
 	''House Servant''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("be a servant")>>
-		<<RAChangeApplyAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <</if>>
 |
 <<if !_confined>>
 	<<link "Confined">>
 		<<set $currentRule.assignment.push("stay confined")>>
-		<<set $currentRule.excludeAssignment = []>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <<else>>
 	''Confined''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("stay confined")>>
-		<<RAChangeApplyAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <</if>>
 |
 <<if !_whore>>
 	<<link "Whore">>
 		<<set $currentRule.assignment.push("whore")>>
-		<<set $currentRule.excludeAssignment = []>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <<else>>
 	''Whore''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("whore")>>
-		<<RAChangeApplyAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <</if>>
 |
 <<if !_public>>
 	<<link "Public Servant">>
 		<<set $currentRule.assignment.push("serve the public")>>
-		<<set $currentRule.excludeAssignment = []>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <<else>>
 	''Public Servant''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("serve the public")>>
-		<<RAChangeApplyAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <</if>>
 |
 <<if !_classes>>
 	<<link "Classes">>
 		<<set $currentRule.assignment.push("take classes")>>
-		<<set $currentRule.excludeAssignment = []>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <<else>>
 	''Classes''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("take classes")>>
-		<<RAChangeApplyAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <</if>>
 |
 <<if !_milked>>
 	<<link "Milked">>
 		<<set $currentRule.assignment.push("get milked")>>
-		<<set $currentRule.excludeAssignment = []>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <<else>>
 	''Milking''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("get milked")>>
-		<<RAChangeApplyAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <</if>>
 |
 <<if !_gloryhole>>
 	<<link "Gloryhole">>
 		<<set $currentRule.assignment.push("work a glory hole")>>
-		<<set $currentRule.excludeAssignment = []>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <<else>>
 	''Gloryhole''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("work a glory hole")>>
-		<<RAChangeApplyAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "assignment">>
 	<</link>>
 <</if>>
 <</replace>>
 <</widget>>
+
 /%
- Call as <<RAChangeExcludeAssignment>>
-%/
+ % Call as <<RAChangeExcludeAssignment>>
+ %/
 <<widget "RAChangeExcludeAssignment">>
+<<if (ndef $currentRule.assignment)>><<set $currentRule.assignment = []>><</if>>
+<<if (ndef $currentRule.excludeAssignment)>><<set $currentRule.excludeAssignment = []>><</if>>
+
+<<set _rest = _whore = _fucktoy = _milked = _servant = _classes = _confined = _public = _gloryhole = _subordinate = false>>
+<<for _a = 0; _a < $currentRule.excludeAssignment.length; _a++>>
+	<<switch $currentRule.excludeAssignment[_a]>>
+	<<case "rest">>                     <<set _rest = true>>
+	<<case "whore">>                    <<set _whore = true>>
+	<<case "please you">>               <<set _fucktoy = true>>
+	<<case "get milked">>               <<set _milked = true>>
+	<<case "be a servant">>             <<set _servant = true>>
+	<<case "take classes">>             <<set _classes = true>>
+	<<case "stay confined">>            <<set _confined = true>>
+	<<case "serve the public">>         <<set _public = true>>
+	<<case "work a glory hole">>        <<set _gloryhole = true>>
+	<<case "be a subordinate slave">>   <<set _subordinate = true>>
+	<</switch>>
+<</for>>
+
 <<replace #excludeassignment>>
 <br>
-<<set _rest = false>>
-<<set _fucktoy = false>>
-<<set _servant = false>>
-<<set _confined = false>>
-<<set _whore = false>>
-<<set _public = false>>
-<<set _milked = false>>
-<<set _subordinate = false>>
-<<set _gloryhole = false>>
-<<set _classes = false>>
-<<if def $currentRule.excludeAssignment>>
-	<<for _a = $currentRule.excludeAssignment.length; _a >= 0; _a-->>
-		<<if $currentRule.excludeAssignment[_a] == "rest">>
-			<<set _rest = true>>
-		<</if>>
-		<<if $currentRule.excludeAssignment[_a] == "please you">>
-			<<set _fucktoy = true>>
-		<</if>>
-		<<if $currentRule.excludeAssignment[_a] == "be a servant">>
-			<<set _servant = true>>
-		<</if>>
-		<<if $currentRule.excludeAssignment[_a] == "whore">>
-			<<set _whore = true>>
-		<</if>>
-		<<if $currentRule.excludeAssignment[_a] == "work a glory hole">>
-			<<set _gloryhole = true>>
-		<</if>>
-		<<if $currentRule.excludeAssignment[_a] == "get milked">>
-			<<set _milked = true>>
-		<</if>>
-		<<if $currentRule.excludeAssignment[_a] == "serve the public">>
-			<<set _public = true>>
-		<</if>>
-		<<if $currentRule.excludeAssignment[_a] == "be a subordinate slave">>
-			<<set _subordinate = true>>
-		<</if>>
-		<<if $currentRule.excludeAssignment[_a] == "stay confined">>
-			<<set _confined = true>>
-		<</if>>
-		<<if $currentRule.excludeAssignment[_a] == "take classes">>
-			<<set _classes = true>>
-		<</if>>
-	<</for>>
-<</if>>
 <<if _rest || _fucktoy || _servant || _confined || _whore || _public || _milked || _subordinate || _gloryhole || _classes>>
-  Include all assignments except:
+	Include all assignments except:
 	<<link "None">>
 		<<set $currentRule.excludeAssignment = []>>
-		<<RAChangeExcludeAssignment>>
-		<<RARuleModified>>
-	<</link>> |
-<<elseif (def $currentRule.assignment) && ($currentRule.assignment.length > 0)>>
-  @@.gray;Exclude assignments:@@
-	''None'' |
+		<<RANormalizeAssignments "excludeAssignment">>
+	<</link>>
+<<elseif ($currentRule.assignment.length > 0)>>
+	@@.gray;Exclude assignments:@@ ''None''
 <<else>>
-  Excluded assignments:
-	''None'' |
+	Excluded assignments: ''None''
 <</if>>
+|
 <<if !_rest>>
 	<<link "Rest">>
-		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("rest")>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <<else>>
 	''Rest''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("rest")>>
-		<<RAChangeExcludeAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <</if>>
 |
 <<if !_fucktoy>>
 	<<link "Fucktoy">>
-		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("please you")>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <<else>>
 	''Fucktoy''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("please you")>>
-		<<RAChangeExcludeAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <</if>>
 |
 <<if !_subordinate>>
 	<<link "Subordinate Slave">>
-		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("be a subordinate slave")>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <<else>>
 	''Subordinate Slave''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("be a subordinate slave")>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <</if>>
 |
 <<if !_servant>>
 	<<link "House Servant">>
-		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("be a servant")>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <<else>>
 	''House Servant''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("be a servant")>>
-		<<RAChangeExcludeAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <</if>>
 |
 <<if !_confined>>
 	<<link "Confined">>
-		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("stay confined")>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <<else>>
 	''Confined''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("stay confined")>>
-		<<RAChangeExcludeAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <</if>>
 |
 <<if !_whore>>
 	<<link "Whore">>
-		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("whore")>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <<else>>
 	''Whore''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("whore")>>
-		<<RAChangeExcludeAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <</if>>
 |
 <<if !_public>>
 	<<link "Public Servant">>
-		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("serve the public")>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <<else>>
 	''Public Servant''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("serve the public")>>
-		<<RAChangeExcludeAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <</if>>
 |
 <<if !_classes>>
 	<<link "Classes">>
-		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("take classes")>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <<else>>
 	''Classes''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("take classes")>>
-		<<RAChangeExcludeAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <</if>>
 |
 <<if !_milked>>
 	<<link "Milked">>
-		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("get milked")>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <<else>>
 	''Milking''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("get milked")>>
-		<<RAChangeExcludeAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <</if>>
 |
 <<if !_gloryhole>>
 	<<link "Gloryhole">>
-		<<set $currentRule.assignment = []>>
 		<<set $currentRule.excludeAssignment.push("work a glory hole")>>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeExcludeAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <<else>>
 	''Gloryhole''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("work a glory hole")>>
-		<<RAChangeExcludeAssignment>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeAssignment">>
 	<</link>>
 <</if>>
 <</replace>>
 <</widget>>
 
 /%
- Call as <<RAChangeApplyFacility>>
-%/
+ % Call as <<RAChangeApplyFacility>>
+ %/
 <<widget "RAChangeApplyFacility">>
+<<if (ndef $currentRule.facility)>><<set $currentRule.facility = []>><</if>>
+<<if (ndef $currentRule.excludeFacility)>><<set $currentRule.excludeFacility = []>><</if>>
 
 <<replace #applyfacility>>
 <<if ($HGSuite > 0) || ($brothel > 0) || ($club > 0) || ($arcade > 0) || ($dairy > 0) || ($servantsQuarters > 0) || ($masterSuite > 0) || ($schoolroom > 0) || ($spa > 0) || ($clinic > 0) || ($cellblock > 0)>>
 <br><br>
-<<if (def $currentRule.facility) && ($currentRule.facility.length > 0)>>
-  Apply to facilities:
+<<if ($currentRule.facility.length > 0)>>
+	Apply to facilities:
 	<<link "All">>
 		<<set $currentRule.facility = []>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
-  @@.gray;Apply to facilities:@@
-	''All''
+	@@.gray;Apply to facilities:@@ ''All''
 <</if>>
 <<if ($HGSuite > 0)>>
 |
 <<if !ruleFacility($currentRule.facility,"hgsuite")>>
 	<<link $HGSuiteNameCaps>>
 		<<set $currentRule.facility.push("hgsuite")>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$HGSuiteNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("hgsuite")>>
-		<<RAChangeApplyFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -701,20 +616,13 @@
 <<if !ruleFacility($currentRule.facility,"brothel")>>
 	<<link $brothelNameCaps>>
 		<<set $currentRule.facility.push("brothel")>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$brothelNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("brothel")>>
-		<<RAChangeApplyFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -723,20 +631,13 @@
 <<if !ruleFacility($currentRule.facility,"club")>>
 	<<link $clubNameCaps>>
 		<<set $currentRule.facility.push("club")>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$clubNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("club")>>
-		<<RAChangeApplyFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -745,20 +646,13 @@
 <<if !ruleFacility($currentRule.facility,"arcade")>>
 	<<link $arcadeNameCaps>>
 		<<set $currentRule.facility.push("arcade")>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$arcadeNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("arcade")>>
-		<<RAChangeApplyFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -767,20 +661,13 @@
 <<if !ruleFacility($currentRule.facility,"dairy")>>
 	<<link $dairyNameCaps>>
 		<<set $currentRule.facility.push("dairy")>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$dairyNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("dairy")>>
-		<<RAChangeApplyFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -789,20 +676,13 @@
 <<if !ruleFacility($currentRule.facility,"servantsquarters")>>
 	<<link $servantsQuartersNameCaps>>
 		<<set $currentRule.facility.push("servantsquarters")>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$servantsQuartersNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("servantsquarters")>>
-		<<RAChangeApplyFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -811,20 +691,13 @@
 <<if !ruleFacility($currentRule.facility,"mastersuite")>>
 	<<link $masterSuiteNameCaps>>
 		<<set $currentRule.facility.push("mastersuite")>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$masterSuiteNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("mastersuite")>>
-		<<RAChangeApplyFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -833,20 +706,13 @@
 <<if !ruleFacility($currentRule.facility,"schoolroom")>>
 	<<link $schoolroomNameCaps>>
 		<<set $currentRule.facility.push("schoolroom")>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$schoolroomNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("schoolroom")>>
-		<<RAChangeApplyFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -855,20 +721,13 @@
 <<if !ruleFacility($currentRule.facility,"spa")>>
 	<<link $spaNameCaps>>
 		<<set $currentRule.facility.push("spa")>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$spaNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("spa")>>
-		<<RAChangeApplyFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -877,20 +736,13 @@
 <<if !ruleFacility($currentRule.facility,"clinic")>>
 	<<link $clinicNameCaps>>
 		<<set $currentRule.facility.push("clinic")>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 ''$clinicNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("clinic")>>
-		<<RAChangeApplyFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -899,75 +751,53 @@
 <<if !ruleFacility($currentRule.facility,"cellblock")>>
 	<<link $cellblockNameCaps>>
 		<<set $currentRule.facility.push("cellblock")>>
-		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <<else>>
 	''$cellblockNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("cellblock")>>
-		<<RAChangeApplyFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facility">>
 	<</link>>
 <</if>>
 <</if>>
 <</if>>
 <</replace>>
 <</widget>>
+
 /%
- Call as <<RAChangeExcludeFacility>>
-%/
+ % Call as <<RAChangeExcludeFacility>>
+ %/
 <<widget "RAChangeExcludeFacility">>
+<<if (ndef $currentRule.facility)>><<set $currentRule.facility = []>><</if>>
+<<if (ndef $currentRule.excludeFacility)>><<set $currentRule.excludeFacility = []>><</if>>
+
 <<replace #excludefacility>>
 <<if ($HGSuite > 0) || ($brothel > 0) || ($club > 0) || ($arcade > 0) || ($dairy > 0) || ($servantsQuarters > 0) || ($masterSuite > 0) || ($schoolroom > 0) || ($spa > 0) || ($clinic > 0) || ($cellblock > 0)>>
 <br>
-<<if (def $currentRule.excludeFacility) && ($currentRule.excludeFacility.length > 0)>>
-  Applying to all facilities except:
+<<if ($currentRule.excludeFacility.length > 0)>>
+	Applying to all facilities except:
 	<<link "None">>
 		<<set $currentRule.excludeFacility = []>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
-<<elseif (def $currentRule.facility) && ($currentRule.facility.length > 0)>>
-  @@.gray;Exclude facilities:@@
-	''None''
+<<elseif ($currentRule.facility.length > 0)>>
+	@@.gray;Exclude facilities:@@ ''None''
 <<else>>
-  Excluded facilities:
-	''None''
+	Excluded facilities: ''None''
 <</if>>
 <<if ($HGSuite > 0)>>
 |
 <<if !ruleFacility($currentRule.excludeFacility,"hgsuite")>>
 	<<link $HGSuiteNameCaps>>
-		<<set $currentRule.facility = []>>
 		<<set $currentRule.excludeFacility.push("hgsuite")>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$HGSuiteNameCaps''
 	<<link Stop>>
 		<<set $currentRule.excludeFacility.delete("hgsuite")>>
-		<<if $currentRule.assignFacility == "hgsuite">>
-			<<set $currentRule.assignFacility = "none">>
-			<<set $currentRule.facilityRemove = false>>
-			<<RAChangeAssignFacility>>
-		<</if>>
-		<<RAChangeExcludeFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -975,26 +805,14 @@
 |
 <<if !ruleFacility($currentRule.excludeFacility,"brothel")>>
 	<<link $brothelNameCaps>>
-		<<set $currentRule.facility = []>>
 		<<set $currentRule.excludeFacility.push("brothel")>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$brothelNameCaps''
 	<<link Stop>>
 		<<set $currentRule.excludeFacility.delete("brothel")>>
-		<<if $currentRule.assignFacility == "brothel">>
-			<<set $currentRule.assignFacility = "none">>
-			<<set $currentRule.facilityRemove = false>>
-			<<RAChangeAssignFacility>>
-		<</if>>
-		<<RAChangeExcludeFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -1002,26 +820,14 @@
 |
 <<if !ruleFacility($currentRule.excludeFacility,"club")>>
 	<<link $clubNameCaps>>
-		<<set $currentRule.facility = []>>
 		<<set $currentRule.excludeFacility.push("club")>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$clubNameCaps''
 	<<link Stop>>
 		<<set $currentRule.excludeFacility.delete("club")>>
-		<<if $currentRule.assignFacility == "club">>
-			<<set $currentRule.assignFacility = "none">>
-			<<set $currentRule.facilityRemove = false>>
-			<<RAChangeAssignFacility>>
-		<</if>>
-		<<RAChangeExcludeFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -1029,26 +835,14 @@
 |
 <<if !ruleFacility($currentRule.excludeFacility,"arcade")>>
 	<<link $arcadeNameCaps>>
-		<<set $currentRule.facility = []>>
 		<<set $currentRule.excludeFacility.push("arcade")>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$arcadeNameCaps''
 	<<link Stop>>
 		<<set $currentRule.excludeFacility.delete("arcade")>>
-		<<if $currentRule.assignFacility == "arcade">>
-			<<set $currentRule.assignFacility = "none">>
-			<<set $currentRule.facilityRemove = false>>
-			<<RAChangeAssignFacility>>
-		<</if>>
-		<<RAChangeExcludeFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -1056,26 +850,14 @@
 |
 <<if !ruleFacility($currentRule.excludeFacility,"dairy")>>
 	<<link $dairyNameCaps>>
-		<<set $currentRule.facility = []>>
 		<<set $currentRule.excludeFacility.push("dairy")>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$dairyNameCaps''
 	<<link Stop>>
 		<<set $currentRule.excludeFacility.delete("dairy")>>
-		<<if $currentRule.assignFacility == "dairy">>
-			<<set $currentRule.assignFacility = "none">>
-			<<set $currentRule.facilityRemove = false>>
-			<<RAChangeAssignFacility>>
-		<</if>>
-		<<RAChangeExcludeFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -1083,26 +865,14 @@
 |
 <<if !ruleFacility($currentRule.excludeFacility,"servantsquarters")>>
 	<<link $servantsQuartersNameCaps>>
-		<<set $currentRule.facility = []>>
 		<<set $currentRule.excludeFacility.push("servantsquarters")>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$servantsQuartersNameCaps''
 	<<link Stop>>
 		<<set $currentRule.excludeFacility.delete("servantsquarters")>>
-		<<if $currentRule.assignFacility == "servantsquarters">>
-			<<set $currentRule.assignFacility = "none">>
-			<<set $currentRule.facilityRemove = false>>
-			<<RAChangeAssignFacility>>
-		<</if>>
-		<<RAChangeExcludeFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -1110,26 +880,14 @@
 |
 <<if !ruleFacility($currentRule.excludeFacility,"mastersuite")>>
 	<<link $masterSuiteNameCaps>>
-		<<set $currentRule.facility = []>>
 		<<set $currentRule.excludeFacility.push("mastersuite")>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$masterSuiteNameCaps''
 	<<link Stop>>
 		<<set $currentRule.excludeFacility.delete("mastersuite")>>
-		<<if $currentRule.assignFacility == "mastersuite">>
-			<<set $currentRule.assignFacility = "none">>
-			<<set $currentRule.facilityRemove = false>>
-			<<RAChangeAssignFacility>>
-		<</if>>
-		<<RAChangeExcludeFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -1137,26 +895,14 @@
 |
 <<if !ruleFacility($currentRule.excludeFacility,"schoolroom")>>
 	<<link $schoolroomNameCaps>>
-		<<set $currentRule.facility = []>>
 		<<set $currentRule.excludeFacility.push("schoolroom")>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$schoolroomNameCaps''
 	<<link Stop>>
 		<<set $currentRule.excludeFacility.delete("schoolroom")>>
-		<<if $currentRule.assignFacility == "schoolroom">>
-			<<set $currentRule.assignFacility = "none">>
-			<<set $currentRule.facilityRemove = false>>
-			<<RAChangeAssignFacility>>
-		<</if>>
-		<<RAChangeExcludeFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -1164,26 +910,14 @@
 |
 <<if !ruleFacility($currentRule.excludeFacility,"spa")>>
 	<<link $spaNameCaps>>
-		<<set $currentRule.facility = []>>
 		<<set $currentRule.excludeFacility.push("spa")>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$spaNameCaps''
 	<<link Stop>>
 		<<set $currentRule.excludeFacility.delete("spa")>>
-		<<if $currentRule.assignFacility == "spa">>
-			<<set $currentRule.assignFacility = "none">>
-			<<set $currentRule.facilityRemove = false>>
-			<<RAChangeAssignFacility>>
-		<</if>>
-		<<RAChangeExcludeFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -1191,26 +925,14 @@
 |
 <<if !ruleFacility($currentRule.excludeFacility,"clinic")>>
 	<<link $clinicNameCaps>>
-		<<set $currentRule.facility = []>>
 		<<set $currentRule.excludeFacility.push("clinic")>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 ''$clinicNameCaps''
 	<<link Stop>>
 		<<set $currentRule.excludeFacility.delete("clinic")>>
-		<<if $currentRule.assignFacility == "clinic">>
-			<<set $currentRule.assignFacility = "none">>
-			<<set $currentRule.facilityRemove = false>>
-			<<RAChangeAssignFacility>>
-		<</if>>
-		<<RAChangeExcludeFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -1218,26 +940,14 @@
 |
 <<if !ruleFacility($currentRule.excludeFacility,"cellblock")>>
 	<<link $cellblockNameCaps>>
-		<<set $currentRule.facility = []>>
 		<<set $currentRule.excludeFacility.push("cellblock")>>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyFacility>>
-		<<RAChangeExcludeFacility>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <<else>>
 	''$cellblockNameCaps''
 	<<link Stop>>
 		<<set $currentRule.excludeFacility.delete("cellblock")>>
-		<<if $currentRule.assignFacility == "cellblock">>
-			<<set $currentRule.assignFacility = "none">>
-			<<set $currentRule.facilityRemove = false>>
-			<<RAChangeAssignFacility>>
-		<</if>>
-		<<RAChangeExcludeFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "excludeFacility">>
 	<</link>>
 <</if>>
 <</if>>
@@ -1246,34 +956,30 @@
 <</widget>>
 
 /%
- Call as <<RAChangeSetAssignment>>
-%/
+ % Call as <<RAChangeSetAssignment>>
+ %/
 <<widget "RAChangeSetAssignment">>
+<<set _assignments = ["rest", "please you", "be a servant", "stay confined", "whore", "serve the public", "get milked", "be a subordinate slave", "work a glory hore", "take classes"]>>
+
+<<if (ndef $currentRule.assignment)>><<set $currentRule.assignment = []>><</if>>
+<<if (ndef $currentRule.excludeAssignment)>><<set $currentRule.excludeAssignment = []>><</if>>
 
 <<replace #setassignment>>
 <br><br>
-<<if ($currentRule.setAssignment != "none")>>
-  Automatically set assignment:
+<<if _assignments.includes($currentRule.setAssignment)>>
+	Automatically set assignment:
 	<<link "None">>
-		<<set $currentRule.setAssignment = "none">>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "no default setting">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
-  @@.gray;Automatically set assignment:@@
-	''None''
+	@@.gray;Automatically set assignment:@@ ''None''
 <</if>>
 |
 <<if ($currentRule.setAssignment != "rest")>>
 	<<link "Rest">>
-		<<set $currentRule.assignment.delete("rest")>>
 		<<set $currentRule.setAssignment = "rest">>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''Rest''
@@ -1281,14 +987,8 @@
 |
 <<if ($currentRule.setAssignment != "please you")>>
 	<<link "Fucktoy">>
-		<<set $currentRule.assignment.delete("please you")>>
 		<<set $currentRule.setAssignment = "please you">>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''Fucktoy''
@@ -1296,14 +996,8 @@
 |
 <<if ($currentRule.setAssignment != "be a servant")>>
 	<<link "House Servant">>
-		<<set $currentRule.assignment.delete("be a servant")>>
 		<<set $currentRule.setAssignment = "be a servant">>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''House Servant''
@@ -1311,14 +1005,8 @@
 |
 <<if ($currentRule.setAssignment != "stay confined")>>
 	<<link "Confined">>
-		<<set $currentRule.assignment.delete("stay confined")>>
 		<<set $currentRule.setAssignment = "stay confined">>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''Confined''
@@ -1326,14 +1014,8 @@
 |
 <<if ($currentRule.setAssignment != "whore")>>
 	<<link "Whore">>
-		<<set $currentRule.assignment.delete("whore")>>
 		<<set $currentRule.setAssignment = "whore">>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''Whore''
@@ -1341,14 +1023,8 @@
 |
 <<if ($currentRule.setAssignment != "serve the public")>>
 	<<link "Public Servant">>
-		<<set $currentRule.assignment.delete("serve the public")>>
 		<<set $currentRule.setAssignment = "serve the public">>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''Public Servant''
@@ -1356,46 +1032,26 @@
 |
 <<if ($currentRule.setAssignment != "take classes")>>
 	<<link "Classes">>
-		<<set $currentRule.assignment.delete("take classes")>>
 		<<set $currentRule.setAssignment = "take classes">>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''Classes''
 <</if>>
 |
-/* disabled until we add a lactation check in DefaultRules when applying this
 <<if ($currentRule.setAssignment != "get milked")>>
 	<<link "Milking">>
-		<<set $currentRule.assignment.delete("get milked")>>
 		<<set $currentRule.setAssignment = "get milked">>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''Milking''
 <</if>>
 |
-*/
 <<if ($currentRule.setAssignment != "work a glory hole")>>
 	<<link "Gloryhole">>
-		<<set $currentRule.assignment.delete("work a glory hole")>>
 		<<set $currentRule.setAssignment = "work a glory hole">>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeApplyAssignment>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''Gloryhole''
@@ -1404,11 +1060,7 @@
 <<if ($currentRule.setAssignment != "choose her own job")>>
 	<<link "Let her choose">>
 		<<set $currentRule.setAssignment = "choose her own job">>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeSetAssignment>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''Let her choose''
@@ -1417,41 +1069,32 @@
 <</widget>>
 
 /%
- Call as <<RAChangeAssignFacility>>
-%/
+ % Call as <<RAChangeAssignFacility>>
+ %/
 <<widget "RAChangeAssignFacility">>
+<<set _facilityAssignments = ["hgsuite", "brothel", "club", "arcade", "dairy", "servantsquarters", "mastersuite", "schoolroom", "spa", "clinic", "cellblock"]>>
+
+<<if (ndef $currentRule.facility)>><<set $currentRule.facility = []>><</if>>
+<<if (ndef $currentRule.excludeFacility)>><<set $currentRule.excludeFacility = []>><</if>>
 
 <<replace #assignfacility>>
 <<if ($HGSuite > 0) || ($brothel > 0) || ($club > 0) || ($arcade > 0) || ($dairy > 0) || ($servantsQuarters > 0) || ($masterSuite > 0) || ($schoolroom > 0) || ($spa > 0) || ($clinic > 0) || ($cellblock > 0)>>
 <br>
-<<if ($currentRule.assignFacility != "none")>>
-  Automatically assigning slaves to facility (when possible):
+<<if _facilityAssignments.includes($currentRule.setAssignment)>>
+	Automatically assigning slaves to facility (when possible):
 	<<link "None">>
-		<<set $currentRule.assignFacility = "none">>
-		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "no default setting">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
-  @@.gray;Automatically assign slaves to facility:@@
-	''None''
+	@@.gray;Automatically assign slaves to facility:@@ ''None''
 <</if>>
 <<if ($HGSuite > 0)>>
 |
-<<if ($currentRule.assignFacility != "hgsuite")>>
+<<if ($currentRule.setAssignment != "hgsuite")>>
 	<<link $HGSuiteNameCaps>>
-		<<set $currentRule.assignFacility = "hgsuite">>
-		<<set $currentRule.setAssignment = "none">>
-		<<if $currentRule.excludeFacility.length > 0>>
-			<<set $currentRule.excludeFacility.delete("hgsuite")>>
-			<<RAChangeExcludeFacility>>
-		<<elseif $currentRule.facility.length > 0 && !$currentRule.facility.includes("hgsuite")>>
-			<<set $currentRule.facility.push("hgsuite")>>
-			<<RAChangeApplyFacility>>
-		<</if>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "hgsuite">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''$HGSuiteNameCaps''<<if $HGSuiteSlaves >= $HGSuite>> @@.red;(full)@@<</if>>
@@ -1459,20 +1102,10 @@
 <</if>>
 <<if ($brothel > 0)>>
 |
-<<if ($currentRule.assignFacility != "brothel")>>
+<<if ($currentRule.setAssignment != "brothel")>>
 	<<link $brothelNameCaps>>
-		<<set $currentRule.assignFacility = "brothel">>
-		<<set $currentRule.setAssignment = "none">>
-		<<if $currentRule.excludeFacility.length > 0>>
-			<<set $currentRule.excludeFacility.delete("brothel")>>
-			<<RAChangeExcludeFacility>>
-		<<elseif $currentRule.facility.length > 0 && !$currentRule.facility.includes("brothel")>>
-			<<set $currentRule.facility.push("brothel")>>
-			<<RAChangeApplyFacility>>
-		<</if>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "brothel">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''$brothelNameCaps''<<if $brothelSlaves >= $brothel>> @@.red;(full)@@<</if>>
@@ -1480,20 +1113,10 @@
 <</if>>
 <<if ($club > 0)>>
 |
-<<if ($currentRule.assignFacility != "club")>>
+<<if ($currentRule.setAssignment != "club")>>
 	<<link $clubNameCaps>>
-		<<set $currentRule.assignFacility = "club">>
-		<<set $currentRule.setAssignment = "none">>
-		<<if $currentRule.excludeFacility.length > 0>>
-			<<set $currentRule.excludeFacility.delete("club")>>
-			<<RAChangeExcludeFacility>>
-		<<elseif $currentRule.facility.length > 0 && !$currentRule.facility.includes("club")>>
-			<<set $currentRule.facility.push("club")>>
-			<<RAChangeApplyFacility>>
-		<</if>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "club">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''$clubNameCaps''<<if $clubSlaves >= $club>> @@.red;(full)@@<</if>>
@@ -1501,20 +1124,10 @@
 <</if>>
 <<if ($arcade > 0)>>
 |
-<<if ($currentRule.assignFacility != "arcade")>>
+<<if ($currentRule.setAssignment != "arcade")>>
 	<<link $arcadeNameCaps>>
-		<<set $currentRule.assignFacility = "arcade">>
-		<<set $currentRule.setAssignment = "none">>
-		<<if $currentRule.excludeFacility.length > 0>>
-			<<set $currentRule.excludeFacility.delete("arcade")>>
-			<<RAChangeExcludeFacility>>
-		<<elseif $currentRule.facility.length > 0 && !$currentRule.facility.includes("arcade")>>
-			<<set $currentRule.facility.push("arcade")>>
-			<<RAChangeApplyFacility>>
-		<</if>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "arcade">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''$arcadeNameCaps''<<if $arcadeSlaves >= $arcade>> @@.red;(full)@@<</if>>
@@ -1522,20 +1135,10 @@
 <</if>>
 <<if ($dairy > 0)>>
 |
-<<if ($currentRule.assignFacility != "dairy")>>
+<<if ($currentRule.setAssignment != "dairy")>>
 	<<link $dairyNameCaps>>
-		<<set $currentRule.assignFacility = "dairy">>
-		<<set $currentRule.setAssignment = "none">>
-		<<if $currentRule.excludeFacility.length > 0>>
-			<<set $currentRule.excludeFacility.delete("dairy")>>
-			<<RAChangeExcludeFacility>>
-		<<elseif $currentRule.facility.length > 0 && !$currentRule.facility.includes("dairy")>>
-			<<set $currentRule.facility.push("dairy")>>
-			<<RAChangeApplyFacility>>
-		<</if>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "dairy">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''$dairyNameCaps''<<if $dairySlaves >= $dairy>> @@.red;(full)@@<</if>>
@@ -1543,20 +1146,10 @@
 <</if>>
 <<if ($servantsQuarters > 0)>>
 |
-<<if ($currentRule.assignFacility != "servantsquarters")>>
+<<if ($currentRule.setAssignment != "servantsquarters")>>
 	<<link $servantsQuartersNameCaps>>
-		<<set $currentRule.assignFacility = "servantsquarters">>
-		<<set $currentRule.setAssignment = "none">>
-		<<if $currentRule.excludeFacility.length > 0>>
-			<<set $currentRule.excludeFacility.delete("servantsquarters")>>
-			<<RAChangeExcludeFacility>>
-		<<elseif $currentRule.facility.length > 0 && !$currentRule.facility.includes("servantsquarters")>>
-			<<set $currentRule.facility.push("servantsquarters")>>
-			<<RAChangeApplyFacility>>
-		<</if>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "servantsquarters">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''$servantsQuartersNameCaps''<<if $servantsQuartersSlaves >= $servantsQuarters>> @@.red;(full)@@<</if>>
@@ -1564,20 +1157,10 @@
 <</if>>
 <<if ($masterSuite > 0)>>
 |
-<<if ($currentRule.assignFacility != "mastersuite")>>
+<<if ($currentRule.setAssignment != "mastersuite")>>
 	<<link $masterSuiteNameCaps>>
-		<<set $currentRule.assignFacility = "mastersuite">>
-		<<set $currentRule.setAssignment = "none">>
-		<<if $currentRule.excludeFacility.length > 0>>
-			<<set $currentRule.excludeFacility.delete("mastersuite")>>
-			<<RAChangeExcludeFacility>>
-		<<elseif $currentRule.facility.length > 0 && !$currentRule.facility.includes("mastersuite")>>
-			<<set $currentRule.facility.push("mastersuite")>>
-			<<RAChangeApplyFacility>>
-		<</if>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "mastersuite">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''$masterSuiteNameCaps''<<if $masterSuiteSlaves >= $masterSuite>> @@.red;(full)@@<</if>>
@@ -1585,20 +1168,10 @@
 <</if>>
 <<if ($schoolroom > 0)>>
 |
-<<if ($currentRule.assignFacility != "schoolroom")>>
+<<if ($currentRule.setAssignment != "schoolroom")>>
 	<<link $schoolroomNameCaps>>
-		<<set $currentRule.assignFacility = "schoolroom">>
-		<<set $currentRule.setAssignment = "none">>
-		<<if $currentRule.excludeFacility.length > 0>>
-			<<set $currentRule.excludeFacility.delete("schoolroom")>>
-			<<RAChangeExcludeFacility>>
-		<<elseif $currentRule.facility.length > 0 && !$currentRule.facility.includes("schoolroom")>>
-			<<set $currentRule.facility.push("schoolroom")>>
-			<<RAChangeApplyFacility>>
-		<</if>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "schoolroom">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''$schoolroomNameCaps''<<if $schoolroomSlaves >= $schoolroom>> @@.red;(full)@@<</if>>
@@ -1606,20 +1179,10 @@
 <</if>>
 <<if ($spa > 0)>>
 |
-<<if ($currentRule.assignFacility != "spa")>>
+<<if ($currentRule.setAssignment != "spa")>>
 	<<link $spaNameCaps>>
-		<<set $currentRule.assignFacility = "spa">>
-		<<set $currentRule.setAssignment = "none">>
-		<<if $currentRule.excludeFacility.length > 0>>
-			<<set $currentRule.excludeFacility.delete("spa")>>
-			<<RAChangeExcludeFacility>>
-		<<elseif $currentRule.facility.length > 0 && !$currentRule.facility.includes("spa")>>
-			<<set $currentRule.facility.push("spa")>>
-			<<RAChangeApplyFacility>>
-		<</if>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "spa">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''$spaNameCaps''<<if $spaSlaves >= $spa>> @@.red;(full)@@<</if>>
@@ -1627,20 +1190,10 @@
 <</if>>
 <<if ($clinic > 0)>>
 |
-<<if ($currentRule.assignFacility != "clinic")>>
+<<if ($currentRule.setAssignment != "clinic")>>
 	<<link $clinicNameCaps>>
-		<<set $currentRule.assignFacility = "clinic">>
-		<<set $currentRule.setAssignment = "none">>
-		<<if $currentRule.excludeFacility.length > 0>>
-			<<set $currentRule.excludeFacility.delete("clinic")>>
-			<<RAChangeExcludeFacility>>
-		<<elseif $currentRule.facility.length > 0 && !$currentRule.facility.includes("clinic")>>
-			<<set $currentRule.facility.push("clinic")>>
-			<<RAChangeApplyFacility>>
-		<</if>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "clinic">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''$clinicNameCaps''<<if $clinicSlaves >= $clinic>> @@.red;(full)@@<</if>>
@@ -1648,45 +1201,35 @@
 <</if>>
 <<if ($cellblock > 0)>>
 |
-<<if ($currentRule.assignFacility != "cellblock")>>
+<<if ($currentRule.setAssignment != "cellblock")>>
 	<<link $cellblockNameCaps>>
-		<<set $currentRule.assignFacility = "cellblock">>
-		<<set $currentRule.setAssignment = "none">>
-		<<if $currentRule.excludeFacility.length > 0>>
-			<<set $currentRule.excludeFacility.delete("cellblock")>>
-			<<RAChangeExcludeFacility>>
-		<<elseif $currentRule.facility.length > 0 && !$currentRule.facility.includes("cellblock")>>
-			<<set $currentRule.facility.push("cellblock")>>
-			<<RAChangeApplyFacility>>
-		<</if>>
-		<<RAChangeAssignFacility>>
-		<<RAChangeSetAssignment>>
-		<<RARuleModified>>
+		<<set $currentRule.setAssignment = "cellblock">>
+		<<RANormalizeAssignments "setAssignment">>
 	<</link>>
 <<else>>
 	''$cellblockNameCaps''<<if $cellblockSlaves >= $cellblock>> @@.red;(full)@@<</if>>
 <</if>>
 <</if>>
-<<if $currentRule.assignFacility != "none">>
+
+<<if _facilityAssignments.includes($currentRule.setAssignment)>>
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
-Automatically remove from facility when rule no longer applies (only if it was applied before):
+Automatically remove from facility when rule stops applying:
 <<if $currentRule.facilityRemove>>
 	''True'' |
 	<<link False>>
 		<<set $currentRule.facilityRemove = false>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facilityRemove">>
 	<</link>>
 <<else>>
 	''False'' |
 	<<link True>>
 		<<set $currentRule.facilityRemove = true>>
-		<<RAChangeAssignFacility>>
-		<<RARuleModified>>
+		<<RANormalizeAssignments "facilityRemove">>
 	<</link>>
 <</if>>
+
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
-Assignment on removal: $currentRule.removalAssignment
+Assignment on removal: ''$currentRule.removalAssignment''
 <<if ($currentRule.removalAssignment != "rest")>>
 	| <<link "Rest">>
 		<<set $currentRule.removalAssignment = "rest">>
@@ -3112,7 +2655,7 @@ Your brand design is ''$brandDesign.''
  %/
 <<widget "RAFacilityRemove">>
 <<if $args[1].facilityRemove>>
-    <<switch $args[1].assignFacility>>
+    <<switch $args[1].setAssignment>>
     <<case "arcade">>
         <<if $args[0].assignment == "be confined in the arcade">>
             <br>$args[0].slaveName has been removed from $arcadeName and has been assigned to $args[1].removalAssignment.
@@ -3233,39 +2776,47 @@ Your brand design is ''$brandDesign.''
 
 	<<set _combinedRule = mergeRules([_combinedRule, _currentRule])>>
 
+	<<if _currentRule.setAssignment == "no default setting">>
+		<<continue>>
+	<</if>>
+
 	/% apply assignment changes for each rule (_currentRule) we process; _combinedRule will be used later %/
-	<<switch _currentRule.assignFacility>>
+	<<switch _currentRule.setAssignment>>
 	<<case "hgsuite">>
-		<<if ($HGSuiteSlaves == 0) && ($args[0].indentureRestrictions <= 0) && ($args[0].assignment != "live with your Head Girl")>>
-			<br>$args[0].slaveName has been automatically assigned to live in your Head Girl's private suite.
-			<<assignJob $args[0] _currentRule.assignFacility>>
+		<<if ($HGSuiteSlaves < 1 && $args[0].indentureRestrictions <= 0)>>
+			<<if ($args[0].assignment != "live with your Head Girl")>>
+				<br>$args[0].slaveName has been automatically assigned to live in your Head Girl's private suite.
+				<<assignJob $args[0] _currentRule.setAssignment>>
+			<</if>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "arcade">>
-		<<if ($arcade > $arcadeSlaves) && ($args[0].indentureRestrictions <= 0) && ($args[0].assignment != "be confined in the arcade")>>
-			<br>$args[0].slaveName has been automatically assigned to be confined in $arcadeName.
-			<<assignJob $args[0] _currentRule.assignFacility>>
+		<<if ($arcadeSlaves > $arcade && $args[0].indentureRestrictions <= 0)>>
+			<<if ($args[0].assignment != "be confined in the arcade")>>
+				<br>$args[0].slaveName has been automatically assigned to be confined in $arcadeName.
+				<<assignJob $args[0] _currentRule.setAssignment>>
+			<</if>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "mastersuite">>
-		<<if ($masterSuite > $masterSuiteSlaves) && ($args[0].devotion > 20) || (($args[0].devotion >= -50) && ($args[0].trust < -20)) || ($args[0].trust < -50)>>
+		<<if ($masterSuiteSlaves > $masterSuite && ($args[0].devotion > 20 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
 			<<if ($args[0].assignment != "serve in the master suite")>>
 				<br>$args[0].slaveName has been automatically assigned to $masterSuiteName.
-				<<assignJob $args[0] _currentRule.assignFacility>>
+				<<assignJob $args[0] _currentRule.setAssignment>>
 			<</if>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "clinic">>
-		<<if ($clinic > $clinicSlaves) && ($args[0].health < 20) || (($Nurse != 0) && ($args[0].chem > 15) && ($clinicUpgradeFilters == 1))>>
+		<<if ($clinicSlaves > $clinic && ($args[0].health < 20 || ($args[0].chem > 15 && $Nurse != 0 && $clinicUpgradeFilters == 1)))>>
 			<<if ($args[0].assignment != "get treatment in the clinic")>>
 				<br>$args[0].slaveName has been automatically assigned to get treatment in $clinicName.
-				<<assignJob $args[0] _currentRule.assignFacility>>
+				<<assignJob $args[0] _currentRule.setAssignment>>
 			<</if>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
@@ -3275,27 +2826,27 @@ Your brand design is ''$brandDesign.''
 		<<if ($spa > $spaSlaves) && ($args[0].health < 20) || ($args[0].trust < 60) || ($args[0].devotion <= 60) || ($args[0].fetish == "mindbroken") && ($args[0].devotion >= -20)>>
 			<<if ($args[0].assignment != "rest in the spa")>>
 				<br>$args[0].slaveName has been automatically assigned to rest in $spaName.
-				<<assignJob $args[0] _currentRule.assignFacility>>
+				<<assignJob $args[0] _currentRule.setAssignment>>
 			<</if>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "brothel">>
-		<<if ($brothel > $brothelSlaves) && (($args[0].devotion > 50) || ($args[0].trust > 50) || (($args[0].devotion >= -50) && ($args[0].trust < -20)) || ($args[0].trust < -50))>>
+		<<if ($brothelSlaves < $brothel && ($args[0].devotion > 50 || $args[0].trust > 50 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
 			<<if ($args[0].assignment != "work in the brothel")>>
 				<br>$args[0].slaveName has been automatically assigned to work in $brothelName.
-				<<assignJob $args[0] _currentRule.assignFacility>>
+				<<assignJob $args[0] _currentRule.setAssignment>>
 			<</if>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "club">>
-		<<if ($club > $clubSlaves) && (($args[0].devotion > 50) || ($args[0].trust > 50) || (($args[0].devotion >= -50) && ($args[0].trust < -20)) || ($args[0].trust < -50))>>
+		<<if ($clubSlaves < $club && ($args[0].devotion > 50 || $args[0].trust > 50 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
 			<<if ($args[0].assignment != "serve in the club")>>
 				<br>$args[0].slaveName has been automatically assigned to serve in $clubName.
-				<<assignJob $args[0] _currentRule.assignFacility>>
+				<<assignJob $args[0] _currentRule.setAssignment>>
 			<</if>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
@@ -3312,7 +2863,7 @@ Your brand design is ''$brandDesign.''
 							<<if ($dairyPregSetting < 2) || ($args[0].vagina > 2) || ($args[0].ovaries == 0) || ($dairyPrepUpgrade == 1)>>
 								<<if ($args[0].assignment != "work in the dairy")>>
 									<br>$args[0].slaveName has been automatically assigned to be milked in $dairyName.
-									<<assignJob $args[0] _currentRule.assignFacility>>
+									<<assignJob $args[0] _currentRule.setAssignment>>
 								<</if>>
 							<<else>>
 								<<RAFacilityRemove $args[0] _currentRule>>
@@ -3330,21 +2881,21 @@ Your brand design is ''$brandDesign.''
 		<</if>>
 
 	<<case "servantsquarters">>
-		<<if ($servantsQuarters > $servantsQuartersSlaves) && (($args[0].devotion >= -20) || (($args[0].devotion >= -50) && ($args[0].trust <= 20)) || ($args[0].trust < -20)) && canSee($args[0]) && canWalk($args[0])>>
+		<<if ($servantsQuartersSlaves < $servantsQuarters && canSee($args[0]) && canWalk($args[0]) && ($args[0].devotion >= -20 || $args[0].trust < -20 || ($args[0].devotion >= -50 && $args[0].trust <= 20)))>>
 			<<if ($args[0].assignment != "work as a servant")>>
 				<br>$args[0].slaveName has been automatically assigned to work in $servantsQuartersName.
-				<<assignJob $args[0] _currentRule.assignFacility>>
+				<<assignJob $args[0] _currentRule.setAssignment>>
 			<</if>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "schoolroom">>
-		<<if ($schoolroom > $schoolroomSlaves) && ($args[0].fetish != "mindbroken") && ($args[0].devotion >= -20 || ($args[0].devotion >= -50 && $args[0].trust < -20) || $args[0].trust < -50)>>
+		<<if ($schoolroomSlaves < $schoolroom && $args[0].fetish != "mindbroken" && ($args[0].devotion >= -20 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
 			<<if ($args[0].intelligenceImplant < 1) || ($args[0].voice != 0 && $args[0].accent+$schoolroomUpgradeLanguage > 2) || ($args[0].oralSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].whoreSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].entertainSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].analSkill < 10+$schoolroomUpgradeSkills*20) || (($args[0].vagina >= 0) && ($args[0].vaginalSkill < 10+$schoolroomUpgradeSkills*20))>>
 				<<if ($args[0].assignment != "learn in the schoolroom")>>
 					<br>$args[0].slaveName has been automatically assigned to study in $schoolroomName.
-					<<assignJob $args[0] _currentRule.assignFacility>>
+					<<assignJob $args[0] _currentRule.setAssignment>>
 				<</if>>
 			<<else>>
 				<<RAFacilityRemove $args[0] _currentRule>>
@@ -3354,27 +2905,34 @@ Your brand design is ''$brandDesign.''
 		<</if>>
 
 	<<case "cellblock">>
-		<<if ($cellblock > $cellblockSlaves) && (($args[0].devotion < -20) && ($args[0].trust >= -20)) || (($args[0].devotion < -50) && ($args[0].trust >= -50))>>
+		<<if ($cellblockSlaves < $cellblock && (($args[0].devotion < -20 && $args[0].trust >= -20) || ($args[0].devotion < -50 && $args[0].trust >= -50))>>
 			<<if ($args[0].assignment != "be confined in the cellblock")>>
 				<br>$args[0].slaveName has been automatically assigned to be confined in $cellblockName.
-				<<assignJob $args[0] _currentRule.assignFacility>>
+				<<assignJob $args[0] _currentRule.setAssignment>>
 			<</if>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
-	<</switch>>
 
-	<<if (_currentRule.setAssignment !== "none")>>
-	<<if (_currentRule.setAssignment == "choose her own job")>>
+	<<case "choose her own job">>
 		<<if ($args[0].choosesOwnAssignment == 0) && ($args[0].fetish != "mindbroken")>>
 			<br>$args[0].slaveName is now allowed to select her own assignments.
 			<<assignJob $args[0] _currentRule.setAssignment>>
 		<</if>>
-	<<elseif ($args[0].assignment !== _currentRule.setAssignment)>>
-		<br>$args[0].slaveName has been automatically assigned to _currentRule.setAssignment.
-		<<assignJob $args[0] _currentRule.setAssignment>>
-	<</if>>
-	<</if>>
+
+	<<case "get milked">>
+		<<if ($args[0].lactation > 0 || $args[0].balls > 0)>>
+			<<if (_currentRule.setAssignment != $args[0].assignment)>>
+				<<assignJob $args[0] _currentRule.setAssignment>>
+			<</if>>
+		<</if>>
+
+	<<default>>
+		<<if (_currentRule.setAssignment != $args[0].assignment)>>
+			<br>$args[0].slaveName has been automatically assigned to _currentRule.setAssignment.
+			<<assignJob $args[0] _currentRule.setAssignment>>
+		<</if>>
+	<</switch>>
 
 <</for>> /* done merging rules; from here onwards, we should only use _combinedRule */
 

--- a/src/utility/raWidgets.tw
+++ b/src/utility/raWidgets.tw
@@ -193,8 +193,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>> |
 <<else>>
   @@.gray;Apply to assignments:@@
@@ -209,16 +208,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Rest''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("rest")>>
 		<<RAChangeApplyAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -230,16 +227,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Fucktoy''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("please you")>>
 		<<RAChangeApplyAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -251,8 +246,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Subordinate Slave''
@@ -260,8 +254,7 @@
 		<<set $currentRule.assignment.delete("be a subordinate slave")>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeApplyAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -274,16 +267,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''House Servant''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("be a servant")>>
 		<<RAChangeApplyAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -295,16 +286,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Confined''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("stay confined")>>
 		<<RAChangeApplyAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -316,16 +305,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Whore''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("whore")>>
 		<<RAChangeApplyAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -337,16 +324,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Public Servant''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("serve the public")>>
 		<<RAChangeApplyAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -358,16 +343,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Classes''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("take classes")>>
 		<<RAChangeApplyAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -379,16 +362,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Milking''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("get milked")>>
 		<<RAChangeApplyAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -400,16 +381,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Gloryhole''
 	<<link Stop>>
 		<<set $currentRule.assignment.delete("work a glory hole")>>
 		<<RAChangeApplyAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</replace>>
@@ -469,8 +448,7 @@
 	<<link "None">>
 		<<set $currentRule.excludeAssignment = []>>
 		<<RAChangeExcludeAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>> |
 <<elseif (def $currentRule.assignment) && ($currentRule.assignment.length > 0)>>
   @@.gray;Exclude assignments:@@
@@ -487,16 +465,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Rest''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("rest")>>
 		<<RAChangeExcludeAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -508,16 +484,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Fucktoy''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("please you")>>
 		<<RAChangeExcludeAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -529,8 +503,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Subordinate Slave''
@@ -538,8 +511,7 @@
 		<<set $currentRule.excludeAssignment.delete("be a subordinate slave")>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeExcludeAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -551,16 +523,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''House Servant''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("be a servant")>>
 		<<RAChangeExcludeAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -572,16 +542,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Confined''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("stay confined")>>
 		<<RAChangeExcludeAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -593,16 +561,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Whore''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("whore")>>
 		<<RAChangeExcludeAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -614,16 +580,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Public Servant''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("serve the public")>>
 		<<RAChangeExcludeAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -635,16 +599,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Classes''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("take classes")>>
 		<<RAChangeExcludeAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -656,16 +618,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Milking''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("get milked")>>
 		<<RAChangeExcludeAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 |
@@ -677,16 +637,14 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeExcludeAssignment>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Gloryhole''
 	<<link Stop>>
 		<<set $currentRule.excludeAssignment.delete("work a glory hole")>>
 		<<RAChangeExcludeAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</replace>>
@@ -710,8 +668,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
   @@.gray;Apply to facilities:@@
@@ -728,16 +685,14 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$HGSuiteNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("hgsuite")>>
 		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -752,16 +707,14 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$brothelNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("brothel")>>
 		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -776,16 +729,14 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$clubNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("club")>>
 		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -800,16 +751,14 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$arcadeNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("arcade")>>
 		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -824,16 +773,14 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$dairyNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("dairy")>>
 		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -848,16 +795,14 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$servantsQuartersNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("servantsquarters")>>
 		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -872,16 +817,14 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$masterSuiteNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("mastersuite")>>
 		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -896,16 +839,14 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$schoolroomNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("schoolroom")>>
 		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -920,16 +861,14 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$spaNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("spa")>>
 		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -944,16 +883,14 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 ''$clinicNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("clinic")>>
 		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -968,16 +905,14 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$cellblockNameCaps''
 	<<link Stop>>
 		<<set $currentRule.facility.delete("cellblock")>>
 		<<RAChangeApplyFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1000,8 +935,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<elseif (def $currentRule.facility) && ($currentRule.facility.length > 0)>>
   @@.gray;Exclude facilities:@@
@@ -1021,8 +955,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$HGSuiteNameCaps''
@@ -1034,8 +967,7 @@
 			<<RAChangeAssignFacility>>
 		<</if>>
 		<<RAChangeExcludeFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1050,8 +982,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$brothelNameCaps''
@@ -1063,8 +994,7 @@
 			<<RAChangeAssignFacility>>
 		<</if>>
 		<<RAChangeExcludeFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1079,8 +1009,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$clubNameCaps''
@@ -1092,8 +1021,7 @@
 			<<RAChangeAssignFacility>>
 		<</if>>
 		<<RAChangeExcludeFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1108,8 +1036,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$arcadeNameCaps''
@@ -1121,8 +1048,7 @@
 			<<RAChangeAssignFacility>>
 		<</if>>
 		<<RAChangeExcludeFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1137,8 +1063,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$dairyNameCaps''
@@ -1150,8 +1075,7 @@
 			<<RAChangeAssignFacility>>
 		<</if>>
 		<<RAChangeExcludeFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1166,8 +1090,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$servantsQuartersNameCaps''
@@ -1179,8 +1102,7 @@
 			<<RAChangeAssignFacility>>
 		<</if>>
 		<<RAChangeExcludeFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1195,8 +1117,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$masterSuiteNameCaps''
@@ -1208,8 +1129,7 @@
 			<<RAChangeAssignFacility>>
 		<</if>>
 		<<RAChangeExcludeFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1224,8 +1144,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$schoolroomNameCaps''
@@ -1237,8 +1156,7 @@
 			<<RAChangeAssignFacility>>
 		<</if>>
 		<<RAChangeExcludeFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1253,8 +1171,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$spaNameCaps''
@@ -1266,8 +1183,7 @@
 			<<RAChangeAssignFacility>>
 		<</if>>
 		<<RAChangeExcludeFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1282,8 +1198,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 ''$clinicNameCaps''
@@ -1295,8 +1210,7 @@
 			<<RAChangeAssignFacility>>
 		<</if>>
 		<<RAChangeExcludeFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1311,8 +1225,7 @@
 		<<RAChangeApplyFacility>>
 		<<RAChangeExcludeFacility>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$cellblockNameCaps''
@@ -1324,8 +1237,7 @@
 			<<RAChangeAssignFacility>>
 		<</if>>
 		<<RAChangeExcludeFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1345,8 +1257,7 @@
 	<<link "None">>
 		<<set $currentRule.setAssignment = "none">>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
   @@.gray;Automatically set assignment:@@
@@ -1362,8 +1273,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Rest''
@@ -1378,8 +1288,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Fucktoy''
@@ -1394,8 +1303,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''House Servant''
@@ -1410,8 +1318,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Confined''
@@ -1426,8 +1333,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Whore''
@@ -1442,8 +1348,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Public Servant''
@@ -1458,8 +1363,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Classes''
@@ -1475,8 +1379,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Milking''
@@ -1492,8 +1395,7 @@
 		<<RAChangeApplyAssignment>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Gloryhole''
@@ -1506,8 +1408,7 @@
 		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeSetAssignment>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''Let her choose''
@@ -1529,8 +1430,7 @@
 		<<set $currentRule.assignFacility = "none">>
 		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
   @@.gray;Automatically assign slaves to facility:@@
@@ -1551,8 +1451,7 @@
 		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$HGSuiteNameCaps''<<if $HGSuiteSlaves >= $HGSuite>> @@.red;(full)@@<</if>>
@@ -1573,8 +1472,7 @@
 		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$brothelNameCaps''<<if $brothelSlaves >= $brothel>> @@.red;(full)@@<</if>>
@@ -1595,8 +1493,7 @@
 		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$clubNameCaps''<<if $clubSlaves >= $club>> @@.red;(full)@@<</if>>
@@ -1617,8 +1514,7 @@
 		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$arcadeNameCaps''<<if $arcadeSlaves >= $arcade>> @@.red;(full)@@<</if>>
@@ -1639,8 +1535,7 @@
 		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$dairyNameCaps''<<if $dairySlaves >= $dairy>> @@.red;(full)@@<</if>>
@@ -1661,8 +1556,7 @@
 		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$servantsQuartersNameCaps''<<if $servantsQuartersSlaves >= $servantsQuarters>> @@.red;(full)@@<</if>>
@@ -1683,8 +1577,7 @@
 		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$masterSuiteNameCaps''<<if $masterSuiteSlaves >= $masterSuite>> @@.red;(full)@@<</if>>
@@ -1705,8 +1598,7 @@
 		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$schoolroomNameCaps''<<if $schoolroomSlaves >= $schoolroom>> @@.red;(full)@@<</if>>
@@ -1727,8 +1619,7 @@
 		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$spaNameCaps''<<if $spaSlaves >= $spa>> @@.red;(full)@@<</if>>
@@ -1749,8 +1640,7 @@
 		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$clinicNameCaps''<<if $clinicSlaves >= $clinic>> @@.red;(full)@@<</if>>
@@ -1771,8 +1661,7 @@
 		<</if>>
 		<<RAChangeAssignFacility>>
 		<<RAChangeSetAssignment>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''$cellblockNameCaps''<<if $cellblockSlaves >= $cellblock>> @@.red;(full)@@<</if>>
@@ -1786,16 +1675,14 @@ Automatically remove from facility when rule no longer applies (only if it was a
 	<<link False>>
 		<<set $currentRule.facilityRemove = false>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	''False'' |
 	<<link True>>
 		<<set $currentRule.facilityRemove = true>>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <br>&nbsp;&nbsp;&nbsp;&nbsp;
@@ -1804,56 +1691,49 @@ Assignment on removal: $currentRule.removalAssignment
 	| <<link "Rest">>
 		<<set $currentRule.removalAssignment = "rest">>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <<if ($currentRule.removalAssignment != "please you")>>
 	| <<link "Fucktoy">>
 		<<set $currentRule.removalAssignment = "please you">>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <<if ($currentRule.removalAssignment != "be a servant")>>
 	| <<link "House Servant">>
 		<<set $currentRule.removalAssignment = "be a servant">>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <<if ($currentRule.removalAssignment != "stay confined")>>
 	| <<link "Confined">>
 		<<set $currentRule.removalAssignment = "stay confined">>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <<if ($currentRule.removalAssignment != "whore")>>
 	| <<link "Whore">>
 		<<set $currentRule.removalAssignment = "whore">>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <<if ($currentRule.removalAssignment != "serve the public")>>
 	| <<link "Public Servant">>
 		<<set $currentRule.removalAssignment = "serve the public">>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <<if ($currentRule.removalAssignment != "work a glory hole")>>
 	| <<link "Gloryhole">>
 		<<set $currentRule.removalAssignment = "work a glory hole">>
 		<<RAChangeAssignFacility>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</if>>
@@ -1873,8 +1753,7 @@ Assignment on removal: $currentRule.removalAssignment
 	<<link False>>
 		<<set $currentRule.excludeSpecialSlaves = false>>
 		<<RASpecialSlaves>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <<else>>
 	@@.gray;Exclude special slaves:@@
@@ -1882,8 +1761,7 @@ Assignment on removal: $currentRule.removalAssignment
 	<<link True>>
 		<<set $currentRule.excludeSpecialSlaves = true>>
 		<<RASpecialSlaves>>
-		<<RAChangeSave>>
-		<<RAChangeApply>>
+		<<RARuleModified>>
 	<</link>>
 <</if>>
 <</replace>>
@@ -2481,6 +2359,14 @@ Relationship rules: ''$currentRule.relationshipRules.''
     </span>
     <span id="applied"></span>
 <</replace>>
+<</widget>>
+
+/%
+ % <<RARuleModified>>
+ %/
+<<widget "RARuleModified">>
+    <<RAChangeSave>>
+    <<RAChangeApply>>
 <</widget>>
 
 /%

--- a/src/utility/raWidgets.tw
+++ b/src/utility/raWidgets.tw
@@ -2807,64 +2807,57 @@ Your brand design is ''$brandDesign.''
 
 	<<set _combinedRule = mergeRules([_combinedRule, _currentRule])>>
 
-	<<if _currentRule.setAssignment == "no default setting" || _currentRule.setAssignment == $args[0].assignment>>
+	/% We merge assignments here %/
+	<<if _currentRule.setAssignment == "no default setting">>
 		<<continue>>
 	<</if>>
 
-	/% apply assignment changes for each rule (_currentRule) we process; _combinedRule will be used later %/
 	<<switch _currentRule.setAssignment>>
 	<<case "live with your Head Girl">>
 		<<if ($HGSuiteSlaves < 1 && $args[0].indentureRestrictions <= 0)>>
-			<br>$args[0].slaveName has been automatically assigned to live in your Head Girl's private suite.
-			<<assignJob $args[0] _currentRule.setAssignment>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "be confined in the arcade">>
-		<<if ($arcadeSlaves > $arcade && $args[0].indentureRestrictions <= 0)>>
-			<br>$args[0].slaveName has been automatically assigned to be confined in $arcadeName.
-			<<assignJob $args[0] _currentRule.setAssignment>>
+		<<if ($arcadeSlaves < $arcade && $args[0].indentureRestrictions <= 0)>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "serve in the master suite">>
-		<<if ($masterSuiteSlaves > $masterSuite && ($args[0].devotion > 20 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
-			<br>$args[0].slaveName has been automatically assigned to $masterSuiteName.
-			<<assignJob $args[0] _currentRule.setAssignment>>
+		<<if ($masterSuiteSlaves < $masterSuite && ($args[0].devotion > 20 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "get treatment in the clinic">>
-		<<if ($clinicSlaves > $clinic && ($args[0].health < 20 || ($args[0].chem > 15 && $Nurse != 0 && $clinicUpgradeFilters == 1)))>>
-			<br>$args[0].slaveName has been automatically assigned to get treatment in $clinicName.
-			<<assignJob $args[0] _currentRule.setAssignment>>
+		<<if ($clinicSlaves < $clinic && ($args[0].health < 20 || ($args[0].chem > 15 && $Nurse != 0 && $clinicUpgradeFilters == 1)))>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "rest in the spa">>
-		<<if ($spa > $spaSlaves) && ($args[0].health < 20) || ($args[0].trust < 60) || ($args[0].devotion <= 60) || ($args[0].fetish == "mindbroken") && ($args[0].devotion >= -20)>>
-			<br>$args[0].slaveName has been automatically assigned to rest in $spaName.
-			<<assignJob $args[0] _currentRule.setAssignment>>
+		<<if ($spaSlaves < $spa) && ($args[0].health < 20) || ($args[0].trust < 60) || ($args[0].devotion <= 60) || ($args[0].fetish == "mindbroken") && ($args[0].devotion >= -20)>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "work in the brothel">>
 		<<if ($brothelSlaves < $brothel && ($args[0].devotion > 50 || $args[0].trust > 50 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
-			<br>$args[0].slaveName has been automatically assigned to work in $brothelName.
-			<<assignJob $args[0] _currentRule.setAssignment>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
 	<<case "serve in the club">>
 		<<if ($clubSlaves < $club && ($args[0].devotion > 50 || $args[0].trust > 50 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
-			<br>$args[0].slaveName has been automatically assigned to serve in $clubName.
-			<<assignJob $args[0] _currentRule.setAssignment>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
@@ -2878,8 +2871,7 @@ Your brand design is ''$brandDesign.''
 					<<if ($args[0].devotion > 20) || (($args[0].devotion >= -50) && ($args[0].trust < -20)) || ($args[0].trust < -50) || ($args[0].amp == 1) || ($dairyRestraintsUpgrade == 1)>>
 						<<if ($dairyStimulatorsSetting < 2) || ($args[0].anus > 2) || ($dairyPrepUpgrade == 1)>>
 							<<if ($dairyPregSetting < 2) || ($args[0].vagina > 2) || ($args[0].ovaries == 0) || ($dairyPrepUpgrade == 1)>>
-								<br>$args[0].slaveName has been automatically assigned to be milked in $dairyName.
-								<<assignJob $args[0] _currentRule.setAssignment>>
+								<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 							<<else>>
 								<<RAFacilityRemove $args[0] _currentRule>>
 							<</if>>
@@ -2897,8 +2889,7 @@ Your brand design is ''$brandDesign.''
 
 	<<case "work as a servant">>
 		<<if ($servantsQuartersSlaves < $servantsQuarters && canSee($args[0]) && canWalk($args[0]) && ($args[0].devotion >= -20 || $args[0].trust < -20 || ($args[0].devotion >= -50 && $args[0].trust <= 20)))>>
-			<br>$args[0].slaveName has been automatically assigned to work in $servantsQuartersName.
-			<<assignJob $args[0] _currentRule.setAssignment>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
@@ -2906,8 +2897,7 @@ Your brand design is ''$brandDesign.''
 	<<case "learn in the schoolroom">>
 		<<if ($schoolroomSlaves < $schoolroom && $args[0].fetish != "mindbroken" && ($args[0].devotion >= -20 || $args[0].trust < -50 || ($args[0].devotion >= -50 && $args[0].trust < -20)))>>
 			<<if ($args[0].intelligenceImplant < 1) || ($args[0].voice != 0 && $args[0].accent+$schoolroomUpgradeLanguage > 2) || ($args[0].oralSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].whoreSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].entertainSkill <= 10+$schoolroomUpgradeSkills*20) || ($args[0].analSkill < 10+$schoolroomUpgradeSkills*20) || (($args[0].vagina >= 0) && ($args[0].vaginalSkill < 10+$schoolroomUpgradeSkills*20))>>
-				<br>$args[0].slaveName has been automatically assigned to study in $schoolroomName.
-				<<assignJob $args[0] _currentRule.setAssignment>>
+				<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 			<<else>>
 				<<RAFacilityRemove $args[0] _currentRule>>
 			<</if>>
@@ -2917,37 +2907,88 @@ Your brand design is ''$brandDesign.''
 
 	<<case "be confined in the cellblock">>
 		<<if ($cellblockSlaves < $cellblock && (($args[0].devotion < -20 && $args[0].trust >= -20) || ($args[0].devotion < -50 && $args[0].trust >= -50))>>
-			<br>$args[0].slaveName has been automatically assigned to be confined in $cellblockName.
-			<<assignJob $args[0] _currentRule.setAssignment>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 		<<else>>
 			<<RAFacilityRemove $args[0] _currentRule>>
 		<</if>>
 
+	<<case "take classes">>
+		<<if (!$args[0].intelligenceImplant && $args[0].fetish != "mindbroken" && ($args[0].devotion >= -20 || $args[0].trust < -50 || ($args[0].trust < -20 && $args[0].devotion >= -50)))>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
+		<</if>>
+
 	<<case "choose her own job">>
-		<<if ($args[0].choosesOwnAssignment == 0) && ($args[0].fetish != "mindbroken")>>
-			<br>$args[0].slaveName is now allowed to select her own assignments.
-			<<assignJob $args[0] _currentRule.setAssignment>>
+		<<if ($args[0].fetish != "mindbroken")>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 		<</if>>
 
 	<<case "get milked">>
 		<<if ($args[0].lactation > 0 || $args[0].balls > 0)>>
-			/% TODO: someone write text please %/
-			<<assignJob $args[0] _currentRule.setAssignment>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
+		<</if>>
+
+	<<case "be a servant">>
+		<<if (canWalk($args[0]) && canSee($args[0]) && ($args[0].devotion >= -20 || $args[0].trust < -50 || ($args[0].trust < -20 && $args[0].devotion >= -50)))>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
+		<</if>>
+
+	<<case "work a glory hole">>
+		<<if $args[0].indentureRestrictions <= 0>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
+		<</if>>
+
+	<<case "whore" "serve the public" "stay confined">>
+		<<if ($args[0].fuckdoll == 0)>>
+			<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 		<</if>>
 
 	<<default>>
-		<br>$args[0].slaveName has been automatically assigned to _currentRule.setAssignment.
-		<<assignJob $args[0] _currentRule.setAssignment>>
+		<<set _combinedRule.setAssignment = _currentRule.setAssignment>>
 	<</switch>>
 
 <</for>> /* done merging rules; from here onwards, we should only use _combinedRule */
 
-/% In case a slave has no rules applying to them, _combinedRule would (should)
-be an empty object, and that would wreck havoc to the rest of the code. So, we
-check if a rule attribute, any one, is defined and otherwise skip everything.
-%/
+/% If a slave has no rules applying to them, _combinedRule would (should) be an
+ % empty object, and that would wreak havoc on the rest of the code. So we
+ % check if a rule property, any one, is defined and otherwise skip everything.
+ %/
+<<if (def _combinedRule.clothes)>>
 
-<<if (def _combinedRule.clothes)>> /* we have at least one non-default rule setting */
+<<if (def _combinedRule.setAssignment && _combinedRule.setAssignment != "no default setting")>>
+<<if ((_combinedRule.setAssignment == "choose her own job" && !$args[0].choosesOwnAssignment) || _combinedRule.setAssignment != $args[0].assignment)>>
+	<<switch _combinedRule.setAssignment>>
+	<<case "live with your Head Girl">>
+		<br>$args[0].slaveName has been automatically assigned to live in your Head Girl's private suite.
+	<<case "be confined in the arcade">>
+		<br>$args[0].slaveName has been automatically assigned to be confined in $arcadeName.
+	<<case "serve in the master suite">>
+		<br>$args[0].slaveName has been automatically assigned to $masterSuiteName.
+	<<case "get treatment in the clinic">>
+		<br>$args[0].slaveName has been automatically assigned to get treatment in $clinicName.
+	<<case "rest in the spa">>
+		<br>$args[0].slaveName has been automatically assigned to rest in $spaName.
+	<<case "work in the brothel">>
+		<br>$args[0].slaveName has been automatically assigned to work in $brothelName.
+	<<case "serve in the club">>
+		<br>$args[0].slaveName has been automatically assigned to serve in $clubName.
+	<<case "work in the dairy">>
+		<br>$args[0].slaveName has been automatically assigned to be milked in $dairyName.
+	<<case "work as a servant">>
+		<br>$args[0].slaveName has been automatically assigned to work in $servantsQuartersName.
+	<<case "work as a servant">>
+		<br>$args[0].slaveName has been automatically assigned to work in $servantsQuartersName.
+	<<case "learn in the schoolroom">>
+		<br>$args[0].slaveName has been automatically assigned to study in $schoolroomName.
+	<<case "be confined in the cellblock">>
+		<br>$args[0].slaveName has been automatically assigned to be confined in $cellblockName.
+	<<case "choose her own job">>
+		<br>$args[0].slaveName is now allowed to select her own assignments.
+	<<default>>
+		<br>$args[0].slaveName has been automatically assigned to _combinedRule.setAssignment.
+	<</switch>>
+	<<assignJob $args[0] _combinedRule.setAssignment>>
+<</if>>
+<</if>>
 
 <<if $args[0].fuckdoll == 0>>
 


### PR DESCRIPTION
I set out to "finish" what I started in #420, that is to also merge `setAssignment` and `assignFacility` before applying them so that you wouldn't get stuff like

> Foobar has been automatically assigned to work in the Brothel.
> Foobar has been automatically assigned to relax in the Spa.
> Foobar is now allowed to select her own assignments.

over and over again.

To make the above easier, I eliminated `assignFacility` and just use `setAssignment`.  This means that you don't have to write `<<set $currentRule.assignFacility = "foobar", $currentRule.setAssignment = "none">>` all the time.  It does mean that in places where you need to know if a slave would be set to an assignment or sent to a facility you now need to check against a list of those but that's literally just three places right now.

Also, I changed how inclusion and exclusion works for the rules.  It used to be that if a rule was setting applying or excluded facilities, only the slaves that were in facilities in general would be the ones excluded.  Like, if a rule said "I only want to deal with slaves in the Brothel", it would also apply for all the slaves in the Penthouse (because of `assignmentVisible`).  I found that weird and so I changed it.  In the example, only slaves in the Brothel would be considered at all.

The less impactful changes are as follows.

First of all, instead of having to write `<<RAChangeSave>>` and `<<RAChangeApply>>` given that these two (almost) always come together, there's now a macro that combines them, `<<RARuleModified>>`.

Secondly, where before the widgets that deal with assignments in the RA UI had a ton of code in the links, I now moved all of that in `<<RANormalizeAssignments>>`.  You just have to change the variable that the user actually tells you to change and let it handle all the collateral including updating any UI that needs updating.

This ended up being bigger than I originally thought.  The UI changes I have tested and seem to work ok.  The rest, **please test yourself**.