### PR TITLE
Fix evaluation of string literals in custom rules.

### DIFF
--- a/src/js/rulesAssistant.tw
+++ b/src/js/rulesAssistant.tw
@@ -247,8 +247,13 @@ window.evalExpr = function(expr, env) {
         return true;
     case "false":
         return false;
-    case "(number)": case "(string)":
+    case "(number)":
         return expr.value;
+    // Literal strings are stored as "value" with the literal quotes inside
+    // the string. This is useful for printing, but we need to strip them
+    // when we are evaluating them.
+    case "(string)":
+	return expr.value.replace(/^["']/, "").replace(/['"]$/, "");
 
     case "(name)":
         return env[expr.name];


### PR DESCRIPTION
Literal strings are stored as "value" with the literal quotes inside the string. When they are later evaluated, the existing code compares the evaluated value with a value in quotes, thus meaning that it can never successfully match. Unfortunately, we can't just strip the quotes before saving them because it would then appear to be a variable (rather than a literal) when it is round-tripped through the "custom" box. 