### PR TITLE
fixed balls comparison in raWidgets.tw

### DIFF
--- a/src/utility/raWidgets.tw
+++ b/src/utility/raWidgets.tw
@@ -3499,7 +3499,7 @@ Your brand design is ''$brandDesign.''
 		<<if ($args[0].assignment != "be confined in the arcade")>>
 		<<if ($args[0].assignment != "get milked") || (($args[0].fetish != "boobs") || ($args[0].energy <= 95))>>
 		<<if ($args[0].assignment != "work in the dairy") || (($args[0].fetish != "boobs") || ($args[0].energy <= 95))>>
-		<<if ($args[0].assignment != "get milked") || $args[0].balls = 0>>
+		<<if ($args[0].assignment != "get milked") || $args[0].balls == 0>>
 		<<if ($args[0].assignment != "work in the dairy") || $args[0].balls == 0>>
 		<<if ($args[0].assignment != "be your Head Girl")>>
 			<<set _release = 1>>


### PR DESCRIPTION
Fixes #1034.

`balls` was being assigned to 0, not being compared.