### PR TITLE
Encyclopedia future societies

### DIFF
--- a/src/gui/Encyclopedia/encyclopedia.tw
+++ b/src/gui/Encyclopedia/encyclopedia.tw
@@ -1691,6 +1691,16 @@ FUTURE SOCIETIES
 
 
 <<case "Future Societies">>
+//The evolution of society has never been linear. Times of unrest and upheaval produce rapid change, followed by long periods of stasis in the absence of the necessary ingredients for further change. The world is undoubtedly in the midst of a time of great change: society is certainly evolving. But into what?
+<br><br>
+Not since antiquity have single persons held as much practical power over the direction of society as Free Cities arcology owners now have. Naturally, different Free Cities notables are going different ways with their great power. Many are building new societies as different from each other as they are from the old world.
+<br><br>
+One arcology might hold a society that is moving towards a fundamentalist interpretation of an old slave-holding religious tradition. Another might pay homage to historical racially segregated societies. A third might see intentional manipulation of gender roles that have held since the start of recorded history. And these three arcologies might well be each other's neighbors.
+<br><br>
+-- Lawrence, W. G., //Guide to Modern Slavery, Online Edition. Accessed April 2, 2032.////
+
+<br><br>
+
 ''Future Society Models'' are societal goals the player can select and pursue for the arcology. It is possible to maintain four future society goals at once. The first is unlocked after week 20 for players with minimal reputation, or at game start with the Social Engineering character option; the rest unlock as the player achieves higher reputation levels.
 <br><br>
 All societies approve of specific things, usually slaves with specific characteristics; some societies also have dislikes. All societies are advanced by the things they approve of and slowed by the things they disapprove of, and all societies give and take reputation when approving and disapproving. All societies unlock unique events, arcology upgrades, and slave behaviors; some even unlock special clothing.
@@ -2023,16 +2033,6 @@ Some markets attempt to stamp out the practice, but most do not. It is generally
 LORE: FREE CITIES CULTURE TOMORROW
 
 **********/
-
-
-<<case "The Future of Society">>
-//The evolution of society has never been linear. Times of unrest and upheaval produce rapid change, followed by long periods of stasis in the absence of the necessary ingredients for further change. The world is undoubtedly in the midst of a time of great change: society is certainly evolving. But into what?
-<br><br>
-Not since antiquity have single persons held as much practical power over the direction of society as Free Cities arcology owners now have. Naturally, different Free Cities notables are going different ways with their great power. Many are building new societies as different from each other as they are from the old world.
-<br><br>
-One arcology might hold a society that is moving towards a fundamentalist interpretation of an old slave-holding religious tradition. Another might pay homage to historical racially segregated societies. A third might see intentional manipulation of gender roles that have held since the start of recorded history. And these three arcologies might well be each other's neighbors.
-<br><br>
--- Lawrence, W. G., //Guide to Modern Slavery, Online Edition. Accessed April 2, 2032.////
 
 
 <<case "The New Rome">>
@@ -2910,7 +2910,7 @@ Behind the Arcology:
 <</if>>
 
 
-<<if ["Lore","Money","Disease in the Free Cities","Free Cities Justice","Modern Anal","Slave Couture","Slave Marriage","The Ejaculate Market","Gingering","The Future of Society","The New Rome","Naked, Barefoot, and Pregnant","The Top","The Bottom","The Purity of the Human Form","A World Built on Implants","Slaves as Stock","Slavery and the Physical Ideal","Faith in the Free Cities","Slave Whore, Arcology K-2","Slave Acolyte, Arcology V-7","Public Slave, Arcology A-3","Mercenary, Arcology B-2","Slave Trainer, Arcology D-10","Security Drones","Water Filtration","Slave Nutrition",].includes($encyclopedia)>>
+<<if ["Lore","Money","Disease in the Free Cities","Free Cities Justice","Modern Anal","Slave Couture","Slave Marriage","The Ejaculate Market","Gingering","The New Rome","Naked, Barefoot, and Pregnant","The Top","The Bottom","The Purity of the Human Form","A World Built on Implants","Slaves as Stock","Slavery and the Physical Ideal","Faith in the Free Cities","Slave Whore, Arcology K-2","Slave Acolyte, Arcology V-7","Public Slave, Arcology A-3","Mercenary, Arcology B-2","Slave Trainer, Arcology D-10","Security Drones","Water Filtration","Slave Nutrition",].includes($encyclopedia)>>
 <br><br>
 //Lore://
 <br>
@@ -2926,8 +2926,7 @@ The Free Cities today:
  
 <br>
 Free Cities culture tomorrow: 
-[[The Future of Society|Encyclopedia][$encyclopedia = "The Future of Society"]]
- | [[The New Rome|Encyclopedia][$encyclopedia = "The New Rome"]]
+[[The New Rome|Encyclopedia][$encyclopedia = "The New Rome"]]
  | [[Naked, Barefoot, and Pregnant|Encyclopedia][$encyclopedia = "Naked, Barefoot, and Pregnant"]]
  | [[The Top|Encyclopedia][$encyclopedia = "The Top"]]
  | [[The Bottom|Encyclopedia][$encyclopedia = "The Bottom"]]

--- a/src/uncategorized/cosmeticRulesAssistantSettings.tw
+++ b/src/uncategorized/cosmeticRulesAssistantSettings.tw
@@ -99,8 +99,6 @@ Cosmetic contact lenses: ''$currentRule.eyeColor.''
 	<<set $artificialEyeShape = "">>
 	<</link>>
 	rule to $artificialEyeShape $artificialEyeColor eyes? //This will be applied in addition to eyewear choices.//
-<<else>>
-	error $artificialEyeShape $artificialEyeColor eyes
 <</if>>
 
 <br><br>

--- a/src/uncategorized/futureSocities.tw
+++ b/src/uncategorized/futureSocities.tw
@@ -1,7 +1,7 @@
 :: Future Society [nobr]
 
 
-<<set $nextButton = "Back", $nextLink = "Main", $showEncyclopedia = 1, $encyclopedia = "The Future of Society">>
+<<set $nextButton = "Back", $nextLink = "Main", $showEncyclopedia = 1, $encyclopedia = "Future Societies">>
 
 <<if ndef $arcologies[0].FSSubjugationist>>
 	<<set $arcologies[0].FSSubjugationist = "unset">>

--- a/src/uncategorized/policies.tw
+++ b/src/uncategorized/policies.tw
@@ -2,7 +2,7 @@
 
 <<set $nextButton = "Back">>
 <<set $nextLink = "Main">>
-<<set $showEncyclopedia = 1>><<set $encyclopedia = "The Future of Society">>
+<<set $showEncyclopedia = 1>><<set $encyclopedia = "Future Societies">>
 <<if $rep < 0>><<set $rep = 0>><</if>>
 <<set $customRetirementAge = Math.clamp($customRetirementAge, 20, 45)>>
 <<if $CustomRetirementAgePolicy == 1>><<set $retirementAge = $customRetirementAge>><</if>>

--- a/src/utility/descriptionRoomsFS.tw
+++ b/src/utility/descriptionRoomsFS.tw
@@ -1,0 +1,686 @@
+:: description rooms FS [nobr widget]
+
+/* This file contains flavor text for major rooms in the arcology, which changes with various future societies. */
+
+
+<<widget "brothelDescriptionFS">>
+
+$brothelNameCaps
+<<switch $brothelDecoration>>
+<<case "Roman Revivalist">>
+	is decorated as a Roman whorehouse. Refreshments are served at a bar, and someone is playing pipes in the back.
+<<case "Aztec Revivalist">>
+	is decorated as an Aztec ode to fertility and nature. Clients may sacrifice a bit of blood to honor the goddess of Filth or to partake in a fertility ritual before joining the girl of their choosing.
+<<case "Egyptian Revivalist">>
+	is decorated as an ancient Egyptian fertility temple. Customers are bade relax on couches next to running water so that slaves may dance to entice them.
+<<case "Edo Revivalist">>
+	is furnished as an Edo period pleasure house, seedy by the standards of the time. Still, girls usually keep their clothes on until they lead patrons back behind the sliding paper screens, though this does not stop silhouettes of the activities within from being visible on them.
+<<case "Arabian Revivalist">>
+	is furnished as an Arabian fleshmarket, with the merchandise standing on little platforms, prices visible. Customers are permitted to fondle before making a decision and dragging a girl back behind a curtain.
+<<case "Chinese Revivalist">>
+	is furnished as an old Chinese pleasure house, with each girl set up in her own low room. They stand outside the doors, luring customers back one by one.
+<<case "Chattel Religionist">>
+	is decorated as a place of carnal worship. The air is scented by censers, and the slaves here maintain an air of holiness even when being sodomized in public.
+<<case "Degradationist">>
+	is decorated to look like a dungeon. The decor involves a lot of black leather and burnished steel, and the slaves on offer are mostly chained to beds and walls.
+<<case "Asset Expansionist">>
+	is decorated to look like a club. Loud music is playing, and the whores that aren't with customers are stripping and poledancing on a stage.
+<<case "Transformation Fetishist">>
+	is sterile and clean. Interactive screens on the walls list the whores and their modifications in clinical detail.
+<<case "Gender Radicalist">>
+	is decorated to look like an old world bordello. The rich decor includes erotic photography and pornographic statuary, depicting every possible combination of human sexual congress.
+<<case "Gender Fundamentalist">>
+	is decorated to look like an old world whorehouse. Screens on the walls are showing pornography starring the whores, with prices flashing after each sex act.
+<<case "Physical Idealist">>
+	is decorated to look like a club. Loud music is playing, and the whores that aren't with customers are stripping on a stage. There is a distinct smell of sweat, and there is as much emphasis on the strippers' muscles as their breasts.
+<<case "Supremacist">>
+	is decorated like an old world gentleman's club. The pictures on the wall depict degradation of every race on earth, except $arcologies[0].FSSupremacistRace people.
+<<case "Subjugationist">>
+	is decorated to celebrate the degradation of $arcologies[0].FSSubjugationistRace whores. The whores greet customers in stereotypical $arcologies[0].FSSubjugationistRace accents.
+<<case "Paternalist">>
+	is decorated to look like a trendy bar. Whores are encouraged to meet customers for a drink and get to know them a little before heading back into a private room.
+<<case "Pastoralist">>
+	is decorated to look like a dairy. Though it isn't one, there is an intense sexual focus on boobs and lactation, and all the whores have their sizes and productivity proudly posted.
+<<case "Maturity Preferentialist">>
+	is decorated to look like a refined bar. It has a row of sturdy backless barstools, perfect for a delectable selection of succulent MILFs to perch on.
+<<case "Youth Preferentialist">>
+	is decorated to look like a the sort of bar old world students visit on spring break. Vapid music is playing, and when whores aren't with customers, they dance and make out with each other to attract some.
+<<case "Body Purist">>
+	is decorated to look like an old world bordello. The rich decor includes erotic photography and pornographic statuary, depicting idealized human forms in the act of love.
+<<case "Slimness Enthusiast">>
+	is decorated to look like an old world bordello. The rich decor includes erotic photography and pornographic statuary, depicting slim, girlish figures playing, dancing, and loving.
+<<default>>
+	is utilitarian. There's a businesslike foyer with an area for the merchandise to stand. Customers make their selection (or selections) and then lead the whores back into little rooms.
+<</switch>>
+
+<</widget>>
+
+
+<<widget "clubDescriptionFS">>
+
+$clubNameCaps
+<<switch $clubDecoration>>
+<<case "Roman Revivalist">>
+	is decorated like a Roman villa's entertainment rooms. There is a lot of white stone, plaster, and terracotta.
+<<case "Aztec Revivalist">>
+	is decorated with obsidian figures inserted in the lime walls and giant oak pillars that give a homey feeling to the otherwise cold building.
+<<case "Egyptian Revivalist">>
+	is decorated like a room in an ancient Egyptian palace. There are columns of warm stone and pools of clear water full of aquatic plants.
+<<case "Edo Revivalist">>
+	is furnished as an Edo period theatre. Performances of the traditional Japanese arts can be seen here, though more modern dancing happens in the evenings. In either case, geisha girls are present and willing.
+<<case "Arabian Revivalist">>
+	is designed like an open plaza in an Arabian palace, with a raised stage in the center for erotic dancing. Diaphanous, flowing curtains billow across the space, dispersing the narcotic smoke billowing from a score of hookahs.
+<<case "Chinese Revivalist">>
+	is furnished as an old Chinese disorderly house. It's intentionally packed in so that closeness and good cheer is obligatory here; prominent citizens share tables while their hangers-on jostle for room.
+<<case "Chattel Religionist">>
+	isn't a religious establishment, but it almost looks like one. It's clean and proper, with beams of natural light that come down to highlight holy sex slaves' bodies.
+<<case "Degradationist">>
+	has a perverted, debauched appearance. The decor is utilitarian so it can be cleaned easily, and the reason is obvious. Many patrons have brought their own slaves to publicly rape here.
+<<case "Asset Expansionist">>
+	has a gaudy appearance. There are a lot of neon lights and there are screens everywhere, showing off big tits and plush asses.
+<<case "Transformation Fetishist">>
+	has a gaudy appearance. There are a lot of neon lights and there are screens everywhere, showing off huge fake tits and plastic dick sucking lips.
+<<case "Gender Radicalist">>
+	has a gaudy appearance. There are a lot of neon lights and there are screens everywhere, showing closeups of cocks fucking every imaginable orifice.
+<<case "Gender Fundamentalist">>
+	has an old world appearance, a decidedly throwback atmosphere harking back to the glory days of cultures past.
+<<case "Physical Idealist">>
+	isn't a gym, but it smells like one. The dancing is rough and competitive, and the drinks are rich with protein.
+<<case "Supremacist">>
+	is decorated like an upper-class gentleman's club in the old countries of $arcologies[0].FSSupremacistRace people.
+<<case "Subjugationist">>
+	is decorated like an upper-class gentleman's club in the old countries which favored $arcologies[0].FSSubjugationistRace slaves.
+<<case "Paternalist">>
+	is handsome and well-kept, even romantic. Though the slaves here are sex slaves, every provision is made to encourage them to enjoy themselves.
+<<case "Pastoralist">>
+	is decorated to resemble a frontier disorderly house. The drinks are pounded straight, and there's a set of swinging doors for bad men to part dramatically as they enter.
+<<case "Maturity Preferentialist">>
+	is surprisingly elegant. The music consists of refined remixes of traditional dance music, offering slaves and citizens the chance to dance beautifully together.
+<<case "Youth Preferentialist">>
+	is deafeningly loud. There's a bright light show running, offering staccato glimpses of the scene out on the dance floor.
+<<case "Body Purist">>
+	is gorgeous, decorated and kept in the height of fashionable night establishment style. The music is cutting edge and everything and everyone is elegant.
+<<case "Slimness Enthusiast">>
+	is distinctly gaudy, with lots of sugary drinks on offer. The music and decor are of a decidedly bubblegum quality.
+<<default>>
+	is set up in an uncomplicated way. There's a bar for drinks, a dance floor for slave girls, and private rooms for slave sex.
+<</switch>>
+
+<</widget>>
+
+
+<<widget "dairyDescriptionFS">>
+
+<<if ($dairyRestraintsSetting > 1)>>
+
+$dairyNameCaps is an industrial facility, but there's a viewing gallery for visitors.
+<<switch $dairyDecoration>>
+<<case "Roman Revivalist">>
+	The screens there review each slave's liquid contributions to the state in minute detail.
+<<case "Aztec Revivalist">>
+	The strange sight of the milking machines, designed to look like fertility statues gives the space an imposing feeling.
+<<case "Egyptian Revivalist">>
+	The screens there list a tally of each slave's contributions to the harvest this season. They also identify related slaves who occupy multi-slave milking machines so that they may feed each other directly.
+<<case "Edo Revivalist">>
+	It looks out on a strangely contradictory sight: a beautiful and terrible combination of modern slavery and technology, placed amongst tatami mats and rice paper partitions.
+<<case "Arabian Revivalist">>
+	It looks out on a strangely contradictory sight: a beautiful and terrible combination of modern slavery and technology, placed inside brightly tiled walls.
+<<case "Chinese Revivalist">>
+	The milking machines are fascinating: they're encased in decorative carvings, making it look like the slaves are in the embrace of traditional Chinese depictions of lions, bears, and dragons.
+<<case "Chattel Religionist">>
+	It presents the inmates as lessons, here to expiate their sins in a purgatory created by technology.
+<<case "Degradationist">>
+	The screens there feature, among a sea of facts and figures about each slave, her most recent brain scan.
+<<case "Asset Expansionist">>
+	It's designed for VIP visits, since this place is arguably the present apogee of expansionism. Nowhere else can breasts become so large. This is a place for pride.
+<<case "Transformation Fetishist">>
+	It's designed for VIP visits, since this place is arguably the present apogee of transformationism. Nowhere else can slaves be so radically changed, from humans into something less - and something more.
+<<case "Gender Radicalist">>
+	The gallery is placed for a good view of each slave's front, from her head to what's between her spread legs.
+<<case "Gender Fundamentalist">>
+	The gallery is placed for a good view of each slave's breasts, belly, and cunt. Visitors can critically compare each feminine advantage.
+<<case "Physical Idealist">>
+	The gallery is placed for a good view of each slave's body. Though muscles are at a lower premium here, there is intense interest in such radical changes to human biology.
+<<case "Supremacist">>
+	The screens there give information about each cow, but the data they present is also predictive. They imply a vision for a world in which more subhumans serve in this way. Many more.
+<<case "Subjugationist">>
+	The screens there give information about each cow, but the data they present is also predictive. They imply a vision for a world in which more milking machines have $arcologies[0].FSSubjugationistRace components. Many more.
+<<case "Paternalist">>
+	The screens there include feeds that show what media is being pumped into the slaves through their machines. It's designed to provide as much mental stimulation as possible.
+<<case "Pastoralist">>
+	The screens there let the production figures speak for themselves. There may be more personable cows out there, but they don't produce milk like these do.
+<<case "Maturity Preferentialist">>
+	The screens there give each slave's productivity and forecast it into the future. The facility is unmatched at extracting value from mature bodies.
+<<case "Youth Preferentialist">>
+	The screens there give each slave's productivity and forecast it into the future. The best bodies here have many, many years of productivity ahead of them.
+<<case "Body Purist">>
+	The screens there offer reams of data on each slave's product purity. Drugs are necessary here, and each body's balance results in a different grade of product.
+<<case "Slimness Enthusiast">>
+	The screens there alternate live views of the fashionably slim cows in their stalls with brief infomercials on the specialized techniques and equipment $dairyName uses to extract milk from such modest udders.
+<<default>>
+	Fascinated visitors may peruse each slave's productivity statistics on a corresponding touchscreen.
+<</switch>>
+
+<<else>>
+
+$dairyNameCaps
+<<switch $dairyDecoration>>
+<<case "Roman Revivalist">>
+	is functional and clean, using traditional methods wherever possible. At one end of the long row of stalls there is an alcove with a shrine to the Roman goddess of bountiful harvests.
+<<case "Aztec Revivalist">>
+	is sterile and organized, using traditional methods wherever possible. At one end of the long row of stalls there is an alcove with a shrine to the Aztec god of the Earth.
+<<case "Egyptian Revivalist">>
+	is functional and clean, using traditional methods wherever possible. At one end of the long row of stalls there is an alcove with a shrine to the Egyptian god of bountiful harvests.
+<<case "Edo Revivalist">>
+	is clean and traditional. The stalls are constructed of bamboo and carefully shaped wood, and muscle power is used wherever possible. Cows exercise and help out by walking on a wooden wheel that raises fresh water to $dairyName.
+<<case "Arabian Revivalist">>
+	is clean and traditional. Its dusky stone walls keep it so warm that the cows go nude, basking in the hot sun between milkings.
+<<case "Chinese Revivalist">>
+	is clean and traditional. The stalls are constructed of bamboo and carefully shaped wood, and muscle power is used wherever possible. Cows exercise and help out by fetching and carrying as best they can.
+<<case "Chattel Religionist">>
+	is functional and clean. There are nice quotations from the holy book on the walls, and there is a little shrine designed to allow a cow who has difficulty standing to make her devotions comfortably.
+<<case "Degradationist">>
+	is harsh and utilitarian. There are stands to restrain cows who aren't being milked for dosing, punishment, or sexual use. There are cattle prods here and there to use on resistant cows, unproductive cows, or cows one wishes to hear scream.
+<<case "Asset Expansionist">>
+	looks misleadingly industrial at first glance. Though the cows here are free-range, the facility mounts a system of slings and cranes to allow slaves with massive udders to walk around with their tits suspended from the ceiling.
+<<case "Transformation Fetishist">>
+	looks like a medical facility at first glance. Transformation is just as much a priority as production: there are surgical and drug injection machines right here.
+<<case "Gender Radicalist">>
+	is comfortable and well-kept. The milking machines include perianal vibrators to massage slaves from butthole to cock while they give cum.
+<<case "Gender Fundamentalist">>
+	is comfortable and well-kept. The milking machines include vibrators so that cows can get off while they're milked.
+<<case "Physical Idealist">>
+	could be mistaken for a gym with milking machines. Cows here are expected to keep fit between milkings, since the best milk comes from cattle who are healthy, muscular, and strong.
+<<case "Supremacist">>
+	is spartan, since that's all subhuman cows need. There are cattle prods here and there to use on resistant cows, unproductive cows, or subhuman cows one wishes to hear scream.
+<<case "Subjugationist">>
+	is spartan, since that's all $arcologies[0].FSSubjugationistRace cows need. There are cattle prods here and there to use on resistant cows, unproductive cows, or $arcologies[0].FSSubjugationistRace cows one wishes to hear scream.
+<<case "Paternalist">>
+	is comfortable and well-kept. Rather than stalls, $dairyName has an open arrangement of machines cows can use freely, and a lovely common area they can relax in afterward.
+<<case "Pastoralist">>
+	is state of the art, but is also brilliantly designed to look like a barn. All the advanced machinery retracts when not in use, leaving the cows in a clean, airy pastoral paradise. It smells of summer.
+<<case "Maturity Preferentialist">>
+	is inviting and homelike. After a milking, cows have a wide selection of soft furniture to choose from, so comfortable that most fall fast asleep.
+<<case "Youth Preferentialist">>
+	is functional, but fun. There are all sorts of fun activities to keep the cows amused between milkings, cleverly adapted for girls with massive mammaries.
+<<case "Body Purist">>
+	is state of the art, and spotlessly clean. All attention here is on the cows, to keep them happy, productive, and pure.
+<<case "Slimness Enthusiast">>
+	is quite unusual. Since the cows it milks may not necessarily have gigantic boobs, the milking machines here can adapt to drain cream from any body.
+<<default>>
+	is comfortable and well-kept. It features nice rest areas for cows to lounge in after a milking, and exercise equipment to keep them healthy.
+<</switch>>
+
+<</if>>
+
+<</widget>>
+
+
+<<widget "spaDescriptionFS">>
+
+$spaNameCaps
+<<switch $spaDecoration>>
+<<case "Roman Revivalist">>
+	is built as a Roman bath. The flooring is pleasantly warm due to a modernized version of hypocaust heating, and is covered in mosaic depicting slaves enjoying sex.
+<<case "Aztec Revivalist">>
+	is built as an Aztec bathhouse. Water steams from the middle of the room and the air is heavy with the scent of herbs and essences. The idols by the door glisten with moisture.
+<<case "Egyptian Revivalist">>
+	is decorated like an Egyptian water garden. All but the hottest pools include aquatic plants around their edges, and the atmosphere is heavy with perfume.
+<<case "Edo Revivalist">>
+	is decorated like a traditional onsen. The stone-lined pools are surrounded by meticulously kept gardens, and there are proper provisions for bathing in the old Japanese style.
+<<case "Arabian Revivalist">>
+	looks like a dream of an Arabian palace garden. Every surface is richly tiled in vibrant colors, and the beguiling scents of perfumes from the Levant hang in the air.
+<<case "Chinese Revivalist">>
+	is gloomy and hot, filled with an oppressive steam that immediately dulls the senses. Though relaxation is possible and indeed easy here, it is a stultifying relaxation whose humid warmth seems to suppress independence.
+<<case "Chattel Religionist">>
+	is dedicated to the purification of the body and the spirit. The pools are arranged for the completion of self-purification procedures which include ritual masturbation.
+<<case "Degradationist">>
+	is utilitarian. There are waterproof cameras positioned throughout the spa so that anyone who wants to can watch the nude slaves. One wall has a screen showing the current viewer count to keep the slaves aware of this.
+<<case "Asset Expansionist">>
+	is utilitarian. It is equipped with all sorts of devices to help slaves care for huge assets, including lifts to help them in and out of the water, and all around showers to help clean and moisturize difficult to reach spots.
+<<case "Transformation Fetishist">>
+	is utilitarian. It is equipped with special devices to help speed surgical recovery, including a series of baths designed to prevent scarring.
+<<case "Gender Radicalist">>
+	is comfortable, with waterproof cushions lining the pools. There are screens on the walls showing slave girls with all different varieties of genitalia orgasming from penetration, to keep the idea at the forefront of the slaves' minds.
+<<case "Gender Fundamentalist">>
+	is comfortable, with waterproof cushions lining the pools. There are screens on the walls showing light entertainment featuring a lot of beautiful women and handsome men for the slaves' edification.
+<<case "Physical Idealist">>
+	is not the gym, but it does have some workout equipment, mostly low-impact machines designed to speed recovery. There are special hot baths to ease sore muscles.
+<<case "Supremacist">>
+	is comfortable, with waterproof cushions lining the pools. There are screens on the walls showing light entertainment featuring $arcologies[0].FSSupremacistRace main characters.
+<<case "Subjugationist">>
+	is comfortable, with waterproof cushions lining the pools. There are screens on the walls showing light entertainment featuring $arcologies[0].FSSubjugationistRace characters in comic relief roles.
+<<case "Paternalist">>
+	is comfortable, with waterproof cushions lining the pools. There are screens on the walls showing light entertainment written by and intended for smart, loyal slaves.
+<<case "Pastoralist">>
+	is utilitarian. It is equipped with all sorts of devices to help slaves care for huge assets, including lifts to help them in and out of the water, and all around showers to help clean and moisturize difficult to reach spots.
+<<case "Maturity Preferentialist">>
+	is comfortable, but surprisingly businesslike. It's all about beautification here; there's a bewildering array of mud baths, resting pools, and massage setups, all designed to keep mature slaves looking their very best.
+<<case "Youth Preferentialist">>
+	is comfortable and fun. There are hot tubs and massage tables for slaves who feel like relaxing, but there's also a colder pool with pool toys for girls who want to play. It even has a small waterslide.
+<<case "Body Purist">>
+	is comfortable, with waterproof cushions lining the pools. Everything is designed for the slaves' comfort; there are even special mud baths to perfect skin clarity.
+<<case "Slimness Enthusiast">>
+	is comfortable, with waterproof cushions lining the pools. Everything is designed for the slaves' comfort; there are even special mud baths to perfect skin clarity.
+<<default>>
+	is well-appointed, with massage tables, hot tubs, and a cold pool.
+<</switch>>
+
+<</widget>>
+
+
+<<widget "clinicDescriptionFS">>
+
+$clinicNameCaps
+<<switch $clinicDecoration>>
+<<case "Roman Revivalist">>
+	is open and airy; a breeze wafts through the space, and Roman theories on natural cleanliness are very much on display.
+<<case "Aztec Revivalist">>
+	is open and airy; a light hint of herbs and natural oil permeates the air. Everything is incredibly sterile, especially the blood management equipment.
+<<case "Egyptian Revivalist">>
+	is open and airy; clean rushes are strewn across the floor, making a gentle susurration when anyone crosses the space.
+<<case "Edo Revivalist">>
+	is clean and spartan to the point of featurelessness. Spotless tatami mats cover the floor, and partitions divide the space into cubicles.
+<<case "Arabian Revivalist">>
+	is open and airy; a thin trail of smoke wafts through the space on a gentle breeze, coming from a brazier burning incense.
+<<case "Chinese Revivalist">>
+	is open and airy; a thin trail of smoke wafts through the space on a gentle breeze, coming from a brazier burning medicinal herbs.
+<<case "Chattel Religionist">>
+	is open and airy; shaded beams of sunlight shine through skylights to bathe each bed in a pool of healing warmth.
+<<case "Degradationist">>
+	is clean and cold, all scrubbed tile and cool steel. The beds have prominent restraint attachment points to force patients into any position desired.
+<<case "Asset Expansionist">>
+	is utilitarian, without any concession to style. Every available centimeter of space is used for equipment specialized to support growth.
+<<case "Transformation Fetishist">>
+	is utilitarian, without any concession to style. Every available centimeter of space is used for equipment specialized to support radical surgery.
+<<case "Gender Radicalist">>
+	is comfortable and feminine. Its curving walls and soft colors are designed to present slaves coming out of anaesthesia with an impression of girlishness.
+<<case "Gender Fundamentalist">>
+	is comfortable and feminine. Its curving walls and soft colors are designed to keep slaves here for their female health nice and comfortable.
+<<case "Physical Idealist">>
+	is utilitarian, without any concession to style. Every available centimeter of space is used for some piece of equipment useful in making the human body faster or stronger.
+<<case "Supremacist">>
+	is clean and cold, all scrubbed tile and cool steel. The only hint of its radical uses are the pseudoscientific racialist charts on the walls.
+<<case "Subjugationist">>
+	is clean and cold, all scrubbed tile and cool steel. The only hint of its radical uses are the pseudoscientific racialist charts on the walls.
+<<case "Paternalist">>
+	is warm and inviting, with curved walls and warm colors designed to put patients at their ease. Each bed is well provided with entertainment options.
+<<case "Pastoralist">>
+	is utilitarian, without any concession to style. Every available centimeter of space is used for equipment specialized for human veterinary medicine.
+<<case "Maturity Preferentialist">>
+	is comfortable and soothing, with curved walls and cool colors designed to keep patients relaxed. Each bed is provided with refined yet invariably pornographic entertainment options.
+<<case "Youth Preferentialist">>
+	is bright and cheerful, with curved walls and pastel colors designed to keep patients in good spirits. Each bed is provided with light entertainment options.
+<<case "Body Purist">>
+	is utilitarian, without any concession to style. Every available centimeter of space is filled with equipment designed to make medicine as low-impact as possible.
+<<case "Slimness Enthusiast">>
+	is warm and inviting, with curved walls and warm colors designed to put patients at their ease. Each bed is well provided with entertainment options.
+<<default>>
+	is a well-equipped modern medical facility. Each patient has her own area, with heavy automation to provide her treatment without any human intervention at all.
+<</switch>>
+
+<</widget>>
+
+
+<<widget "schoolroomDescriptionFS">>
+
+$schoolroomNameCaps is well-equipped, with wall screens to display lessons. These are currently
+<<switch $schoolroomDecoration>>
+<<case "Roman Revivalist">>
+	showing the story of a famous Roman slave who sacrificed her life for the life of <<if def $PC.customTitle>>her $PC.customTitle<<elseif $PC.title != 0>>her master<<else>>her mistress<</if>>.
+<<case "Aztec Revivalist">>
+	showing the reenactment of a legendary story of a slave who ascended by offering her blood to the gods, and was granted eternal life.
+<<case "Egyptian Revivalist">>
+	showing an interpretation of Egyptian history that attributes many great monuments to the enlightened use slave labor.
+<<case "Edo Revivalist">>
+	showing an interpretation of Japanese cultural history that emphasizes a serf's duty to her social superiors.
+<<case "Arabian Revivalist">>
+	showing an interpretation of Arabian cultural history that focuses on thriving slave markets and vibrant harems.
+<<case "Chinese Revivalist">>
+	showing an interpretation of Chinese cultural history that focuses on concubinage, palace etiquette, and social order.
+<<case "Chattel Religionist">>
+	displaying a passage from the holy book that supports slavery.
+<<case "Degradationist">>
+	displaying a rote recitation of a slave's proper acceptance of her subhuman status.
+<<case "Asset Expansionist">>
+	reviewing techniques that allow two slaves with huge breasts to inspect and moisturize each others' hard to reach areas.
+<<case "Transformation Fetishist">>
+	offering a brief primer on surgical recovery, with practical techniques to make it quicker.
+<<case "Gender Radicalist">>
+	going over how to keep one's asspussy ready for intercourse at any time, including how to schedule regular enemata and pre-lubrication.
+<<case "Gender Fundamentalist">>
+	going over the trifecta that is the standard approach of sex slaves: a blowjob, followed by vaginal, finished with anal.
+<<case "Physical Idealist">>
+	offering a brief primer on the arcology's nutritional system which will allow slaves to double check their own protein intake.
+<<case "Supremacist">>
+	reviewing the scientific evidence for $arcologies[0].FSSupremacistRace superiority.
+<<case "Subjugationist">>
+	reviewing the scientific evidence for $arcologies[0].FSSubjugationistRace inferiority.
+<<case "Paternalist">>
+	reviewing a lesson on time-management skills, and the students are taking notes on their own tablets.
+<<case "Pastoralist">>
+	reviewing how to help fellow slaves with huge, lactating breasts.
+<<case "Maturity Preferentialist">>
+	going over daily sets of exercises designed to keep mature slaves' holes as tight as possible.
+<<case "Youth Preferentialist">>
+	reviewing social cues that young slaves who have been enslaved through their entire adulthood might not understand.
+<<case "Body Purist">>
+	offering a brief primer on the arcology's nutritional system which will allow slaves to double check their own caloric intake.
+<<case "Slimness Enthusiast">>
+	offering a brief primer on the arcology's nutritional system which will allow slaves to double check their own caloric intake.
+<<default>>
+	reviewing the often complex subject of how to address citizens other that one's owner.
+<</switch>>
+
+<</widget>>
+
+
+<<widget "cellblockDescriptionFS">>
+
+$cellblockNameCaps
+<<switch $cellblockDecoration>>
+<<case "Roman Revivalist">>
+	is designed to resemble the holding pens beneath the old Coliseum. Whenever there's a fight in the arcology, screens in each cell helpfully keep inmates informed of what awaits (otherwise) useless slaves.
+<<case "Aztec Revivalist">>
+	is designed to frighten the prisoners to submission. All the cells look to the center of the facility, where a sacrificial altar stands, adorned with ceremonial knives, ropes and blunt instruments.
+<<case "Egyptian Revivalist">>
+	uses the climate of Egypt as an additional source of discomfort. The air here is hot and dry, and inmates can easily imagine themselves confined in mud brick cells in a baking desert.
+<<case "Edo Revivalist">>
+	is furnished in a severely medieval Japanese style. There is one refinement, but it's of exquisite cruelty. At the end of the hall, there's a fountain with a traditional bamboo boar scarer. As it fills with water, it tips against a stone with a thunk... thunk... thunk... thunk...
+<<case "Arabian Revivalist">>
+	is furnished as imagined Arabian slave pens, all set around a central pillar. This pillar is capped by shackles, so that slaves can be bound by their hands and whipped on the backs, buttocks, and thighs in clear view of all their fellow chattel.
+<<case "Chinese Revivalist">>
+	is furnished in a severely medieval Chinese style. There is one refinement, but it's of exquisite cruelty. Somewhere out of sight, water is dripping into an urn, drop by drop... drop... drop... drop...
+<<case "Chattel Religionist">>
+	is built of cold stone. Most of the cells are unfurnished little cubes inside which the only bed is the bare floor. A few are smaller still, so that the inmates can neither stand nor lie flat.
+<<case "Degradationist">>
+	is a nightmare. Everything is made of metal, and almost everything menaces with spikes of steel. Inmates must carefully avoid the walls of their own cells if they wish to avoid being stabbed.
+<<case "Asset Expansionist">>
+	is a straightforward prison, with one exception. Each cell features a screen displaying plans for its inmate's expansion. Day and night, inmates are confronted with the sight of themselves transformed.
+<<case "Transformation Fetishist">>
+	is a straightforward prison, with one exception. Each cell features a screen displaying plans for its inmate's expansion. Day and night, inmates are confronted with the sight of themselves transformed.
+<<case "Gender Radicalist">>
+	is a straightforward prison, with one exception. Each cell features a screen displaying plans for its inmate's bimbofication. Day and night, inmates are confronted with the sight of themselves dyed, pierced, tattooed, gaped, filled with implants, or all of these.
+<<case "Gender Fundamentalist">>
+	is a block of barred cells whose sides, offering a clear view of the whole prison, provide much menace. Anyone who abuses an inmate does so in full view of every other slave here, keeping the jailbirds in a state of constant fear that they're next.
+<<case "Physical Idealist">>
+	is a block of barred cells whose sides, offering a clear view of the whole prison, provide much menace. Anyone who assrapes an inmate does so in full view of every other slave here, keeping the bitches in a state of constant fear that their asses are next.
+<<case "Supremacist">>
+	is a straightforward prison whose menace is provided by context that, although subtle, adds up to a nightmare. Everyone outside the cells is $arcologies[0].FSSupremacistRace, and everyone inside them is not. The darkness of history is palpable here.
+<<case "Subjugationist">>
+	is a straightforward prison whose menace is provided by context that, although subtle, adds up to a nightmare. The inmates inside the cells are $arcologies[0].FSSubjugationistRace, and everyone outside them is not. The darkness of history is palpable here.
+<<case "Paternalist">>
+	is a prison, but a modern and scientific one. The cells, the common areas, and even the color of the walls are all carefully designed to communicate the feeling that inmates can better themselves.
+<<case "Pastoralist">>
+	requires its inmates to drink as much breast milk as they can hold. This sounds like a small thing, but for an unbroken slave, conquering the revulsion of drinking another girl's milk is an important step.
+<<case "Maturity Preferentialist">>
+	is subtly designed to make very clear to its inmates that they are sex objects. Many screens showing pornography make it clear to the maturest girl here that she's still an object of lust, and will be used to slake others' pleasure.
+<<case "Youth Preferentialist">>
+	is subtly designed to make the breadth of sex acts performed in the arcology clear to its inmates. A cacophony of pornography makes clear to the most innocent inmate that her pussy is a fuck hole, her mouth is a fuck hole, her anus is a fuck hole, and, in fact, all three can be fuck holes at once.
+<<case "Body Purist">>
+	requires its inmates to drink as much filtered water as they can, all the time. This sounds like a petty thing, but most inmates are very aware that they're being flushed out. Cleaned. It is an oddly menacing thought.
+<<case "Slimness Enthusiast">>
+	is torture for chubby slaves. Fat bitches that pass through here soon learn that they're going to be slim and pretty one day, but that it isn't going to be much fun getting there.
+<<default>>
+	could be mistaken for a modern prison. A close inspection, however, reveals restraints in each cell that will hold inmates in sexually compromising positions, and compliance systems to force them to place their wrists and ankles in them.
+<</switch>>
+
+<</widget>>
+
+
+<<widget "servantsQuartersDescriptionFS">>
+
+$servantsQuartersNameCaps
+<<switch $servantsQuartersDecoration>>
+<<case "Roman Revivalist">>
+	are spartan, yet functional. At one end of the long dormitory there is an alcove with a shrine to the Roman goddess of domesticity.
+<<case "Aztec Revivalist">>
+	are simple, yet grandiose. In every corner stands a monument to a god, and as the sun peeks through, all the obsidian ornaments glisten with light.
+<<case "Egyptian Revivalist">>
+	are utilitarian, yet warm and well-kept. At one end of the long dormitory there is an alcove with a shrine to the Egyptian goddess of servility.
+<<case "Edo Revivalist">>
+	are spartan and functional. Fresh mats are laid across the floor every day, and the simple beds of blankets and wooden blocks are neatly stowed against the walls before sunrise.
+<<case "Arabian Revivalist">>
+	are utilitarian, yet warm and well-kept. They are floored with beautifully patterned tile; there are channels for clean running water that make it easy to keep clean and fresh, so long as one is willing to bathe in the open.
+<<case "Chinese Revivalist">>
+	are spartan, yet functional. At one end of the long dormitory there is an alcove with a shrine hosting a bronze statue of a watchful dragon.
+<<case "Chattel Religionist">>
+	are spartan, yet functional. Servants here are expected to be clean and hardworking, and there is a penitents cell ready for them if they are not.
+<<case "Degradationist">>
+	are severe and utilitarian. Servants sleep uncomfortably here, knowing that even on their meager bedrolls, they are fair game for abuse.
+<<case "Asset Expansionist">>
+	are comfortable and well-kept. There are pornographic pictures on the walls, depicting slaves with gigantic breasts earnestly enjoying huge cocks.
+<<case "Transformation Fetishist">>
+	are comfortable and well-kept. There are pornographic pictures on the walls, depicting slaves with huge implants earnestly enjoying sex.
+<<case "Gender Radicalist">>
+	are comfortable and well-kept. There are pornographic pictures on the walls, depicting all sorts of slaves earnestly enjoying taking cocks up their anuses.
+<<case "Gender Fundamentalist">>
+	are comfortable and well-kept. There are pornographic pictures on the walls, depicting pretty female slaves being fucked by muscular men.
+<<case "Physical Idealist">>
+	are comfortable and well-kept. There are softcore pictures on the walls, depicting gorgeously muscled, oiled-up men and women, flexing and posing for the camera.
+<<case "Supremacist">>
+	are spartan, since that's all domestics from the inferior races need or deserve. There's a whipping post in the corner of the room so that whenever a slave is beaten, the rest must watch.
+<<case "Subjugationist">>
+	are spartan, since that's all $arcologies[0].FSSubjugationistRace domestics need or deserve. There's a whipping post in the corner of the room so that whenever a slave is beaten, the rest must watch.
+<<case "Paternalist">>
+	are comfortable and well-kept. Though there is little privacy here, the servants are provided for. There's even a small rest area for them to take their regular breaks in.
+<<case "Pastoralist">>
+	are comfortable and well-kept. There are pornographic pictures on the walls, depicting lactating slaves earnestly enjoying sex. The servants are provided with milk to drink.
+<<case "Maturity Preferentialist">>
+	are comfortable, but functional. There are motivational posters on the walls featuring cheerful MILF servants, exhorting mature slaves to smile, serve, and get fucked like good girls.
+<<case "Youth Preferentialist">>
+	are comfortable, but well equipped to corral wayward slaves. There are instructional screens in the common areas reviewing basic slave tasks like scrubbing a floor and giving head.
+<<case "Body Purist">>
+	are comfortable and well-kept. There are pornographic pictures on the walls, depicting gorgeous slaves earnestly enjoying sex.
+<<case "Slimness Enthusiast">>
+	are comfortable and well-kept. There are pornographic pictures on the walls, depicting slender slaves earnestly enjoying sex.
+<<default>>
+	are comfortable. Servants sleep together in a dormitory, eat together in a little kitchen, bathe together in a communal shower, and then head out into the penthouse to serve.
+<</switch>>
+
+<</widget>>
+
+
+<<widget "arcadeDescriptionFS">>
+
+$arcadeNameCaps
+<<switch $arcadeDecoration>>
+<<case "Roman Revivalist">>
+	is built out as a Roman street restaurant, with the bar containing the inmates. Citizens can amuse themselves at either side of the bar while enjoying some wine and olives and talking over the day's events.
+<<case "Aztec Revivalist">>
+	is built out as an Aztec stone temple, with a short stone staircase to lead the people straight to the slaves waiting in front of the establishment. A small canal leads the shed blood to the back and out of the building.
+<<case "Egyptian Revivalist">>
+	is built to look like an ancient Egyptian temple, with a long altar of sacrifice serving as the wall in which the inmates are held. Incongruously, it's piled with fresh flowers.
+<<case "Edo Revivalist">>
+	is built to look like an Edo onsen, with discreet partitions allowing citizens a modicum of privacy as they use the services here. There are baths available so they can wash themselves afterward.
+<<case "Arabian Revivalist">>
+	is built to look like a fantastical Arabian dungeon, with the inmates kept in iron cages that hold their holes in place for use.
+<<case "Chinese Revivalist">>
+	is set up to look like a rough bar in an ancient Chinese city, with the inmates immured in the bar itself. Rowdy citizens can drink and fuck the holes here while shouting and boasting over the slaves' heads.
+<<case "Chattel Religionist">>
+	is well decorated with severe religious iconography, since this place is an acceptable if not respectable place for a citizen to find relief, so long as they keep the service of the slave they use here in mind.
+<<case "Degradationist">>
+	is nothing but a system of harnesses to hold slaves in the usual posture they would hold within a normal Free Cities sex arcade. This way, no iota of their degradation here is missed.
+<<case "Asset Expansionist">>
+	is constructed so that the slaves lie within the arcade facing up. The wall itself ends at waist height, so their breasts stick up to be groped while they are used from either end.
+<<case "Transformation Fetishist">>
+	reveals more of its inmates' bodies than the typical Free Cities sex arcade. There's no attempt to hide the feeding arrangements or injection lines, since transformation into a human sex toy is considered arousing here.
+<<case "Gender Radicalist">>
+	is built to reveal most of its inmate's bellies, butts, groins, and thighs. Whatever a slave here has between her legs, it's available to be fucked, played with, or abused.
+<<case "Gender Fundamentalist">>
+	is built to block the lower part of its inmates' butts from view and use. The slaves within are thus limited to their anuses for service here, so any slave can be disposed of in $arcadeName without offending fundamentalist sensibilities.
+<<case "Physical Idealist">>
+	logs customers' performance for their own athletic information. It keeps track of personal bests and all-time high scores, and pays out cash prizes to customers who fuck the holes faster, harder, or for longer than the previous record holder.
+<<case "Supremacist">>
+	is constructed so that the inmates' entire heads stick out of the mouth wall, though they're still masked and their jaws are held apart by ring gags. After all, seeing the anguish of the subhumans here is one of the main attractions.
+<<case "Subjugationist">>
+	is constructed so that the inmates' entire heads stick out of the mouth wall, though they're still masked and their jaws are held apart by ring gags. After all, seeing the anguish of the $arcologies[0].FSSubjugationistRace slaves here is one of the main attractions.
+<<case "Paternalist">>
+	is constructed so that nothing at all of the slaves is visible. The arcade is just a row of holes. In this way, good, paternalistic citizens can partake of a Free Cities sex arcade without being confronted with what they're doing.
+<<case "Pastoralist">>
+	is constructed so that the slaves lie within the arcade facing up. If a slave is lactating, her breasts are kept bare and under the maximum sustainable dose of lactation drugs, so that any penetration of her holes produces amusing squirts of milk.
+<<case "Maturity Preferentialist">>
+	is constructed so that nothing but the slaves' holes can be seen. This makes it possible to maintain the appearance of offering MILFs while using $arcadeName to get value out of useless young bitches' holes.
+<<case "Youth Preferentialist">>
+	is constructed so that nothing but the slaves' holes can be seen. This makes it possible to maintain the appearance of offering nothing but young slaves while using $arcadeName to get value out of old bitches' holes.
+<<case "Body Purist">>
+	is built out in such a way that much more of the slaves' rears and faces are visible than in a standard Free Cities sex arcade. This makes it much easier to check them for purity before using their holes.
+<<case "Slimness Enthusiast">>
+	is barely distinguishable from a standard Free Cities sex arcade. The difference is a fun one, though: since the butts sticking out of the wall are much skinnier than usual, there's no padding to get in the way of hilting oneself in the holes.
+<<default>>
+	is a standard Free Cities sex arcade: a pair of hallways extend away from the entrance, lined with doorless stalls like those in a public restroom. One hallway offers mouths, the other <<if $seeDicks != 100>>vaginas and <</if>>anuses.
+<</switch>>
+
+<</widget>>
+
+
+<<widget "masterSuiteDescriptionFS">>
+
+<<if $masterSuiteUpgradeLuxury == 1>>
+
+$masterSuiteNameCaps is furnished
+<<switch $masterSuiteDecoration>>
+<<case "Roman Revivalist">>
+	as a Roman emperor's apartment. There is a small shrine to the old gods the <<if $PC.title == 1>>master<<else>>mistress<</if>> favors in a side room, and the flooring is erotic mosaic. Pride of place is given to a set of low couches placed together, capable of accommodating many nude bodies.
+<<case "Aztec Revivalist">>
+	as an Aztec cultural, spiritual and military leader of the city you're allowed great leniency. The <<if $PC.title == 1>>Master<<else>>Mistress<</if>>'s room is created to gratify you as a true god of the people.
+<<case "Egyptian Revivalist">>
+	after the royal room of an ancient Egyptian palace. There is a small shrine to the old gods the <<if $PC.title == 1>>master<<else>>mistress<</if>> favors in a side room, and linen hangings decorate the walls and ceiling. An imposing bed of sandalwood occupies the center of the room.
+<<case "Edo Revivalist">>
+	in the Spartan style of an Edo period castle's innermost rooms. Rice paper screens partition off many small cubicles around its large central space. There, around a low bed, there are many mats for servants to kneel around their <<if $PC.title == 1>>master<<else>>mistress<</if>>.
+<<case "Arabian Revivalist">>
+	as a beguiling haze of Arabian decadence. There is a great gilded bed in the center of the space, piled with silk pillows for naked bodies to recline on. Gauzy curtains flutter in the warm, heady breeze.
+<<case "Chinese Revivalist">>
+	as though it were the innermost sanctum of the Forbidden City. A massive bed fills the central space. The walls are gorgeous gilded hand-carved screens, and heavy jade statues of favored gods crouch in the corners.
+<<case "Chattel Religionist">>
+	as a severe place of cold stone and hard wood. A single shaft of sunlight illuminates an enormous stone platform that serves as a bed where penitents give their bodies to their <<if $PC.title == 1>>master<<else>>mistress<</if>>.
+<<case "Degradationist">>
+	with a gothic grandeur. Blood-red upholstery and hardwood menace crouch in the center of the space in the form of a massive poster bed with curtains of chain mail.
+<<case "Asset Expansionist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make sex with stacked slaves as fun as possible. There's a huge bed in the middle of the suite, heavily reinforced.
+<<case "Transformation Fetishist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make sex with bimbo slaves as fun as possible. There's a huge bed in the middle of the suite, heavily reinforced.
+<<case "Gender Radicalist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make fucking slave girls in the butt lots of fun.  There's a huge bed in the middle of the suite, with straps to restrain slave girls who don't want to be fucked in the butt, but they're concealed for now.
+<<case "Gender Fundamentalist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make fucking slave girls nice and enjoyable. There's a huge bed in the middle of the suite, with straps to restrain slave girls who don't want to be fucked, but they're concealed for now.
+<<case "Physical Idealist">>
+	as a shrine to the owner's body. Athletic trophies and photographs of past victories line the walls. There's a huge bed in the middle of the space, and there are mirrors almost everywhere, including on the ceiling over the bed.
+<<case "Supremacist">>
+	like the royal bedroom in a palace in the old countries of $arcologies[0].FSSupremacistRace people. A massive four-poster bed dominates the space.
+<<case "Subjugationist">>
+	like the royal bedroom in a palace in the old countries which favored $arcologies[0].FSSubjugationistRace slaves. A massive four-poster bed dominates the space.
+<<case "Paternalist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make sex with slaves mutually enjoyable.
+<<case "Pastoralist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants. The space is dominated by a massive, reinforced bed, built in sections so that part of it can be cleaned while cream-squirting cows cavort on the rest.
+<<case "Maturity Preferentialist">>
+	comfortably, with elegant sex toys and perfumed lubricants designed to appeal to mature sex slaves. The space is dominated by a broad, soft bed, well supplied with pillows. It's the perfect place to relax with a harem of MILFs.
+<<case "Youth Preferentialist">>
+	comfortably, with pastel-colored sex toys and flavored lubricants designed to appeal to eager young sex slaves. The space is dominated by a broad, reinforced bed, without cushions or sheets, which would just get in the way of energetic sex.
+<<case "Body Purist" "Slimness Enthusiast">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make sex with slaves mutually enjoyable. The space is dominated by a huge bed with soft sheets.
+<<default>>
+	in a refined, yet practical style. It's dominated by a huge bed in which many slaves could serve their <<if $PC.title == 1>>master<<else>>mistress<</if>> and then cuddle afterward.
+<</switch>>
+
+<<elseif $masterSuiteUpgradeLuxury == 2>>
+
+$masterSuiteNameCaps is furnished
+<<switch $masterSuiteDecoration>>
+<<case "Roman Revivalist">>
+	as a Roman emperor's apartment. There is a small shrine to the old gods the <<if $PC.title == 1>>master<<else>>mistress<</if>> favors in a side room, and the flooring is erotic mosaic.
+<<case "Aztec Revivalist">>
+	as an Aztec cultural, spiritual and military leader of the city you're allowed great leniency. The <<if $PC.title == 1>>Master<<else>>Mistress<</if>>'s room is created to gratify you as a true god of the people.
+<<case "Egyptian Revivalist">>
+	after the royal room of an ancient Egyptian palace. There is a small shrine to the old gods the <<if $PC.title == 1>>master<<else>>mistress<</if>> favors in a side room, and linen hangings decorate the walls and ceiling.
+<<case "Edo Revivalist">>
+	in the Spartan style of an Edo period castle's innermost rooms. Rice paper screens partition off many small cubicles around its large central space.
+<<case "Arabian Revivalist">>
+	as a beguiling haze of Arabian decadence. Gauzy curtains flutter in the warm, heady breeze.
+<<case "Chinese Revivalist">>
+	as though it were the innermost sanctum of the Forbidden City. The walls are gorgeous gilded hand-carved screens, and heavy jade statues of favored gods crouch in the corners.
+<<case "Chattel Religionist">>
+	as a severe place of cold stone and hard wood. A single shaft of sunlight illuminates the central space.
+<<case "Degradationist">>
+	with a gothic grandeur. Blood-red upholstery and hardwood menace decorate the walls.
+<<case "Asset Expansionist">>
+	comfortably, with the convenience of massive-breasted slaves in mind. There are lots of handrails, cushions, and low tables, covered with creams, lubricants, and sex toys.
+<<case "Transformation Fetishist">>
+	comfortably, with the convenience of bimbos in mind. There are lots of makeup dressers with mirrors, stripper poles, and low tables, covered with creams, lubricants, and sex toys.
+<<case "Gender Radicalist">>
+	comfortably, with the convenience of dickgirls in mind. There are lots of makeup dressers with mirrors, stripper poles, and low tables, covered with creams, lubricants, and vibrating butt plugs.
+<<case "Gender Fundamentalist">>
+	comfortably, with the convenience and pleasure of slavegirls in mind. There are lots of makeup dressers with mirrors, soft divans, and low tables, covered with creams, lubricants, and vibrators.
+<<case "Physical Idealist">>
+	as a shrine to the owner's body. Athletic trophies and photographs of past victories line the walls. The entire area is filled with the heady odors of sweat, metabolites, and sex.
+<<case "Supremacist">>
+	like the royal bedroom in a palace in the old countries of $arcologies[0].FSSupremacistRace people.
+<<case "Subjugationist">>
+	like the royal bedroom in a palace in the old countries which favored $arcologies[0].FSSubjugationistRace slaves.
+<<case "Paternalist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make sex with slaves mutually enjoyable.
+<<case "Pastoralist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants, with a distinct focus on mammary intercourse.
+<<case "Maturity Preferentialist">>
+	comfortably, with elegant sex toys and perfumed lubricants designed to appeal to mature sex slaves.
+<<case "Youth Preferentialist">>
+	comfortably, with pastel-colored sex toys and flavored lubricants designed to appeal to eager young sex slaves.
+<<case "Body Purist" "Slimness Enthusiast">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make sex with slaves mutually enjoyable.
+<<default>>
+	in a refined, yet practical style.
+<</switch>>
+
+<<else>>
+
+$masterSuiteNameCaps is furnished
+<<switch $masterSuiteDecoration>>
+<<case "Roman Revivalist">>
+	as a Roman patrician's apartment. There is a small shrine to the old gods the <<if $PC.title == 1>>master<<else>>mistress<</if>> favors in a side room, and the flooring is erotic mosaic.
+<<case "Aztec Revivalist">>
+	as an Aztec cultural, spiritual and military leader of the city you're allowed great leniency. The <<if $PC.title == 1>>Master<<else>>Mistress<</if>>'s room is created to gratify you as a true god of the people.
+<<case "Egyptian Revivalist">>
+	after the best room of an ancient Egyptian mansion. There is a small shrine to the old gods the <<if $PC.title == 1>>master<<else>>mistress<</if>> favors in a side room, and linen hangings decorate the walls and ceiling.
+<<case "Edo Revivalist">>
+	in the Spartan style of an Edo period mansion's innermost rooms. Rice paper screens divide it into subsections, each of which contains little more than a low bed.
+<<case "Arabian Revivalist">>
+	as a beguiling haze of Arabian decadence. Soft cushions are scattered across the floor and piled against the walls to provide something for dusky, naked bodies to recline on. Gauzy curtains partition the room into a number of cozy dens.
+<<case "Chinese Revivalist">>
+	like the mansion of a senior mandarin of ancient China. The walls are gorgeous hand-carved wooden screens, and heavy jade statues of favored gods crouch in the corners.
+<<case "Chattel Religionist">>
+	as a severe place of cold stone and hard wood. A single shaft of sunlight illuminates the bed where penitents give their bodies to their <<if $PC.title == 1>>master<<else>>mistress<</if>>.
+<<case "Degradationist">>
+	with a gothic grandeur. Blood-red upholstery and hardwood menace. There are numerous places where resistant slaves can be restrained.
+<<case "Asset Expansionist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make sex with stacked slaves as fun as possible.
+<<case "Transformation Fetishist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make sex with bimbo slaves as fun as possible.
+<<case "Gender Radicalist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make fucking slave girls in the butt lots of fun. The straps to restrain slave girls who don't want to be fucked in the butt are concealed for now.
+<<case "Gender Fundamentalist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make fucking slave girls nice and enjoyable. The straps to restrain slave girls who don't want to be fucked are concealed for now.
+<<case "Physical Idealist">>
+	as a shrine to the owner's body. Athletic trophies and photographs of past victories line the walls. There are mirrors almost everywhere, including on the ceiling over the bed.
+<<case "Supremacist">>
+	like the master bedroom in a mansion in the old countries of $arcologies[0].FSSupremacistRace people.
+<<case "Subjugationist">>
+	like the master bedroom in a mansion in the old countries which favored $arcologies[0].FSSubjugationistRace slaves.
+<<case "Paternalist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make sex with slaves mutually enjoyable.
+<<case "Pastoralist">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants. Everything that isn't waterproof is covered in plastic, to catch errant milk.
+<<case "Maturity Preferentialist">>
+	comfortably, with elegant sex toys and perfumed lubricants designed to appeal to mature sex slaves.
+<<case "Youth Preferentialist">>
+	comfortably, with pastel-colored sex toys and flavored lubricants designed to appeal to eager young sex slaves.
+<<case "Body Purist" "Slimness Enthusiast">>
+	comfortably, with lots of easy-to-clean leather and plentiful tools, toys, and lubricants to make sex with slaves mutually enjoyable.
+<<default>>
+	comfortably, as a fairly normal luxury suite. It is unusually large, to accommodate as large a stable of sex slaves as strikes your fancy.
+<</switch>>
+
+<</if>>
+
+<</widget>>
+


### PR DESCRIPTION
Missed this when I worked on encyclopedia.

This commit merges the "lore" style entry for FS (which sadly the in game FS page linked to) with the actual FS game mechanics encyc page.