### PR TITLE
 Fix "pregnant virgins" in MS, hopefully

### DIFF
--- a/src/uncategorized/cosmeticRulesAssistantSettings.tw
+++ b/src/uncategorized/cosmeticRulesAssistantSettings.tw
@@ -99,8 +99,6 @@ Cosmetic contact lenses: ''$currentRule.eyeColor.''
 	<<set $artificialEyeShape = "">>
 	<</link>>
 	rule to $artificialEyeShape $artificialEyeColor eyes? //This will be applied in addition to eyewear choices.//
-<<else>>
-	error $artificialEyeShape $artificialEyeColor eyes
 <</if>>
 
 <br><br>

--- a/src/uncategorized/saLongTermEffects.tw
+++ b/src/uncategorized/saLongTermEffects.tw
@@ -3360,7 +3360,7 @@
 			You frequently avail yourself to her fertile pussy. It's no surprise when @@.lime;she ends up pregnant with your child@@.
 			<<set $slaves[$i].preg = 1, $slaves[$i].pregSource = -1>>
 
-		<<else>> /% look for a random father among master suite slaves %/
+		<<elseif $slaves[$i].vagina > 0>> /% look for a random father among master suite slaves %/
 			<<for _m = 0; _m < $MastSiIDs.length; _m++>>
 				<<if canImpreg($slaves[$i], $MastSiIDs[_m])>>
 					/* catch for self-impregnation */
@@ -3375,6 +3375,7 @@
 					<<break>>
 				<</if>>
 			<</for>>
+			<<set $activeSlave = $slaves[$i]>><<VaginalVCheck 10>><<set $slaves[$i] = $activeSlave>>
 		<</if>>
 		
 	<<case "please you">>


### PR DESCRIPTION
TL;DR Randy slaves in MS no longer impregnate MS virgins.  Also, increments sex counter when they do impregnate someone else.

When "universal pregnancy" is disabled, this commit adds a checks for virginity before random slaves cause pregnancy within MS.  Virginity check was already happening for MC a few lines earlier, so I believe it should happen for randy slaves too.

Also register that a sexy time happened.  Hopefully I used VaginalVCheck correctly.

Fixes: https://www.reddit.com/r/freecitiesgame/comments/7ahm03/virgin_pregnancy/